### PR TITLE
feat: expandable line item detail view in eval results

### DIFF
--- a/frontend/src/components/extraction-eval/DocumentResultsTable.tsx
+++ b/frontend/src/components/extraction-eval/DocumentResultsTable.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import type { ExtractionEvalResult } from '@/types/extractionEval'
+import { ScorePill } from '@/components/evaluation/ScorePill'
+import { FieldBreakdownView } from './FieldBreakdownView'
+import { LineItemsBreakdownView } from './LineItemsBreakdownView'
+import { Badge } from '@/components/ui/badge'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+
+interface DocumentResultsTableProps {
+  results: ExtractionEvalResult[]
+}
+
+export function DocumentResultsTable({ results }: DocumentResultsTableProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  if (results.length === 0) {
+    return (
+      <div className="text-center py-8 text-sm text-muted-foreground">
+        No results yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border">
+      {/* Header */}
+      <div className="grid grid-cols-[1fr_80px_80px_80px_60px] gap-2 px-4 py-2 border-b text-xs font-medium text-muted-foreground">
+        <span>Document</span>
+        <span>Score</span>
+        <span>Fields</span>
+        <span>Line F1</span>
+        <span>Status</span>
+      </div>
+
+      {/* Rows */}
+      {results.map((result) => {
+        const isExpanded = expandedId === result.id
+        const fieldCount = Object.keys(result.fieldScores).length
+        const exactCount = Object.values(result.fieldScores).filter((s) => s.exact).length
+
+        return (
+          <div key={result.id}>
+            <div
+              className="grid grid-cols-[1fr_80px_80px_80px_60px] gap-2 px-4 py-3 items-center cursor-pointer hover:bg-muted/50 transition-colors"
+              onClick={() => setExpandedId(isExpanded ? null : result.id)}
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                {isExpanded ? (
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                )}
+                <span className="text-sm truncate">
+                  {result.documentTitle || 'Untitled'}
+                </span>
+              </div>
+              <ScorePill score={result.overallScore} />
+              <span className="text-xs text-muted-foreground">
+                {exactCount}/{fieldCount}
+              </span>
+              <span className="text-xs">
+                {result.lineItemsScore ? (
+                  <ScorePill score={result.lineItemsScore.f1} />
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </span>
+              <StatusIcon score={result.overallScore} />
+            </div>
+
+            {/* Expanded field breakdown */}
+            {isExpanded && (
+              <div className="border-t bg-muted/30 px-4 py-3">
+                <FieldBreakdownView
+                  fieldScores={result.fieldScores}
+                  expectedData={result.expectedData ?? undefined}
+                  predictedData={result.predictedData ?? undefined}
+                />
+                {result.lineItemsScore && (
+                  <LineItemsBreakdownView
+                    lineItemsScore={result.lineItemsScore}
+                    expectedLineItems={
+                      (result.expectedData?.line_items as Record<string, unknown>[] | undefined)
+                    }
+                    predictedLineItems={
+                      (result.predictedData?.line_items as Record<string, unknown>[] | undefined)
+                    }
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function StatusIcon({ score }: { score: number }) {
+  if (score >= 0.9)
+    return <Badge variant="success" className="text-xs px-1.5">ok</Badge>
+  if (score >= 0.7)
+    return <Badge variant="warning" className="text-xs px-1.5">warn</Badge>
+  return <Badge variant="destructive" className="text-xs px-1.5">fail</Badge>
+}

--- a/frontend/src/components/extraction-eval/DocumentResultsTable.tsx
+++ b/frontend/src/components/extraction-eval/DocumentResultsTable.tsx
@@ -35,8 +35,9 @@ export function DocumentResultsTable({ results }: DocumentResultsTableProps) {
       {/* Rows */}
       {results.map((result) => {
         const isExpanded = expandedId === result.id
-        const fieldCount = Object.keys(result.fieldScores).length
-        const exactCount = Object.values(result.fieldScores).filter((s) => s.exact).length
+        const scalarScores = Object.entries(result.fieldScores).filter(([k]) => k !== 'line_items')
+        const fieldCount = scalarScores.length
+        const exactCount = scalarScores.filter(([, s]) => s.exact).length
 
         return (
           <div key={result.id}>

--- a/frontend/src/components/extraction-eval/FieldBreakdownView.tsx
+++ b/frontend/src/components/extraction-eval/FieldBreakdownView.tsx
@@ -1,0 +1,56 @@
+import type { FieldScore } from '@/types/extractionEval'
+import { ScorePill } from '@/components/evaluation/ScorePill'
+import { Badge } from '@/components/ui/badge'
+
+interface FieldBreakdownViewProps {
+  fieldScores: Record<string, FieldScore>
+  expectedData?: Record<string, unknown>
+  predictedData?: Record<string, unknown>
+}
+
+export function FieldBreakdownView({
+  fieldScores,
+  expectedData,
+  predictedData,
+}: FieldBreakdownViewProps) {
+  return (
+    <div className="divide-y text-sm">
+      <div className="grid grid-cols-[1fr_1fr_1fr_80px_60px] gap-2 px-3 py-2 text-xs font-medium text-muted-foreground">
+        <span>Field</span>
+        <span>Expected</span>
+        <span>Got</span>
+        <span>Score</span>
+        <span>Match</span>
+      </div>
+      {Object.entries(fieldScores).filter(([field]) => field !== 'line_items').map(([field, score]) => (
+        <div
+          key={field}
+          className="grid grid-cols-[1fr_1fr_1fr_80px_60px] gap-2 px-3 py-2 items-center"
+        >
+          <span className="font-medium capitalize truncate">
+            {field.replace(/_/g, ' ')}
+          </span>
+          <span className="text-muted-foreground truncate text-xs">
+            {expectedData ? formatValue(expectedData[field]) : '—'}
+          </span>
+          <span className="truncate text-xs">
+            {predictedData ? formatValue(predictedData[field]) : '—'}
+          </span>
+          <ScorePill score={score.score} />
+          <Badge
+            variant={score.exact ? 'success' : 'destructive'}
+            className="text-xs justify-center"
+          >
+            {score.exact ? 'exact' : 'miss'}
+          </Badge>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}

--- a/frontend/src/components/extraction-eval/LineItemsBreakdownView.tsx
+++ b/frontend/src/components/extraction-eval/LineItemsBreakdownView.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import type { LineItemsScore } from '@/types/extractionEval'
+import { Badge } from '@/components/ui/badge'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ScorePill } from '@/components/evaluation/ScorePill'
+
+interface LineItemsBreakdownViewProps {
+  lineItemsScore: LineItemsScore
+  expectedLineItems?: Record<string, unknown>[]
+  predictedLineItems?: Record<string, unknown>[]
+}
+
+interface RowData {
+  status: 'match' | 'miss' | 'extra'
+  expected?: Record<string, unknown>
+  predicted?: Record<string, unknown>
+  similarity?: number
+  expectedIdx?: number
+  predictedIdx?: number
+}
+
+export function LineItemsBreakdownView({
+  lineItemsScore,
+  expectedLineItems,
+  predictedLineItems,
+}: LineItemsBreakdownViewProps) {
+  const [expanded, setExpanded] = useState(false)
+  const matches = lineItemsScore.matches ?? []
+
+  const matchedExpectedIndices = new Set(matches.map((m) => m.expectedIdx))
+  const matchedPredictedIndices = new Set(matches.map((m) => m.predictedIdx))
+
+  const rows: RowData[] = []
+
+  // Matched pairs
+  for (const match of matches) {
+    rows.push({
+      status: 'match',
+      expected: expectedLineItems?.[match.expectedIdx],
+      predicted: predictedLineItems?.[match.predictedIdx],
+      similarity: 1 - match.cost,
+      expectedIdx: match.expectedIdx,
+      predictedIdx: match.predictedIdx,
+    })
+  }
+
+  // Unmatched expected (misses)
+  if (expectedLineItems) {
+    for (let i = 0; i < expectedLineItems.length; i++) {
+      if (!matchedExpectedIndices.has(i)) {
+        rows.push({
+          status: 'miss',
+          expected: expectedLineItems[i],
+          expectedIdx: i,
+        })
+      }
+    }
+  }
+
+  // Extra predicted (false positives)
+  if (predictedLineItems) {
+    for (let i = 0; i < predictedLineItems.length; i++) {
+      if (!matchedPredictedIndices.has(i)) {
+        rows.push({
+          status: 'extra',
+          predicted: predictedLineItems[i],
+          predictedIdx: i,
+        })
+      }
+    }
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t">
+      <div
+        className="flex items-center gap-4 text-xs text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+        )}
+        <span>
+          Line Items: {lineItemsScore.matched} matched of{' '}
+          {lineItemsScore.expected} expected, {lineItemsScore.predicted}{' '}
+          predicted
+        </span>
+        <ScorePill score={lineItemsScore.f1} />
+      </div>
+
+      {expanded && (
+        <div className="mt-2 rounded border bg-background">
+          {/* Header */}
+          <div className="grid grid-cols-[60px_1fr_1fr_70px_60px] gap-2 px-3 py-2 text-xs font-medium text-muted-foreground border-b">
+            <span>Status</span>
+            <span>Expected</span>
+            <span>Predicted</span>
+            <span>Score</span>
+            <span>#</span>
+          </div>
+
+          {rows.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-muted-foreground text-center">
+              No line items to display.
+            </div>
+          ) : (
+            rows.map((row, i) => (
+              <div
+                key={i}
+                className="grid grid-cols-[60px_1fr_1fr_70px_60px] gap-2 px-3 py-2 items-start border-b last:border-b-0 text-xs"
+              >
+                <StatusBadge status={row.status} />
+                <div className="min-w-0">
+                  {row.expected ? (
+                    <FieldValues data={row.expected} />
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </div>
+                <div className="min-w-0">
+                  {row.predicted ? (
+                    <FieldValues data={row.predicted} />
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </div>
+                <div>
+                  {row.similarity !== undefined ? (
+                    <ScorePill score={row.similarity} />
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </div>
+                <span className="text-muted-foreground">
+                  {row.status === 'match'
+                    ? `E${row.expectedIdx!}→P${row.predictedIdx!}`
+                    : row.status === 'miss'
+                      ? `E${row.expectedIdx!}`
+                      : `P${row.predictedIdx!}`}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: 'match' | 'miss' | 'extra' }) {
+  const config = {
+    match: { variant: 'success' as const, label: 'match' },
+    miss: { variant: 'destructive' as const, label: 'miss' },
+    extra: { variant: 'warning' as const, label: 'extra' },
+  }
+  const { variant, label } = config[status]
+  return (
+    <Badge variant={variant} className="text-xs px-1.5 justify-center w-fit">
+      {label}
+    </Badge>
+  )
+}
+
+function FieldValues({ data }: { data: Record<string, unknown> }) {
+  const entries = Object.entries(data).filter(
+    ([, v]) => v !== null && v !== undefined
+  )
+  if (entries.length === 0) return <span className="text-muted-foreground">—</span>
+
+  return (
+    <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+      {entries.map(([key, value]) => (
+        <span key={key}>
+          <span className="text-muted-foreground capitalize">
+            {key.replace(/_/g, ' ')}:
+          </span>{' '}
+          <span className="font-medium">{formatValue(value)}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'number') return value.toLocaleString()
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}

--- a/frontend/src/types/extractionEval.ts
+++ b/frontend/src/types/extractionEval.ts
@@ -1,0 +1,77 @@
+export type ExtractionEvalRunStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+export interface ExtractionEvalRunConfig {
+  fuzzyThreshold?: number
+  numericTolerance?: number
+  weights?: Record<string, number>
+}
+
+export interface ExtractionEvalRunMetrics {
+  overallScoreMean: number
+  overallScoreMedian: number
+  fieldAccuracy: Record<string, { exactMatchRate: number; avgScore: number }>
+  lineItemsF1Mean: number | null
+  documentsEvaluated: number
+  documentsPerfect: number
+}
+
+export interface ExtractionEvalRun {
+  id: string
+  projectId: string
+  groundTruthSetId: string
+  groundTruthSetName: string
+  name: string
+  config: ExtractionEvalRunConfig
+  status: ExtractionEvalRunStatus
+  metrics: ExtractionEvalRunMetrics | null
+  errorMessage: string | null
+  itemsCompleted: number
+  itemsTotal: number
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateExtractionEvalRunRequest {
+  groundTruthSetId: string
+  name?: string
+  config?: ExtractionEvalRunConfig
+}
+
+export interface FieldScore {
+  exact: boolean
+  fuzzy_score: number | null
+  score: number
+}
+
+export interface LineItemMatch {
+  predictedIdx: number
+  expectedIdx: number
+  cost: number
+}
+
+export interface LineItemsScore {
+  precision: number
+  recall: number
+  f1: number
+  matched: number
+  predicted: number
+  expected: number
+  matches?: LineItemMatch[]
+}
+
+export interface ExtractionEvalResult {
+  id: string
+  evalRunId: string
+  extractionResultId: string
+  groundTruthItemId: string
+  documentId: string
+  documentTitle: string
+  overallScore: number
+  fieldScores: Record<string, FieldScore>
+  lineItemsScore: LineItemsScore | null
+  expectedData: Record<string, unknown> | null
+  predictedData: Record<string, unknown> | null
+  evaluationMetadata: Record<string, unknown> | null
+  createdAt: string
+}


### PR DESCRIPTION
## Summary
- Replace static line items summary with an expandable detail view showing matched pairs, unmatched expected items (misses), and extra predicted items (false positives)
- Add `matches` array to `LineItemsScore` TypeScript type to consume existing backend data
- New `LineItemsBreakdownView` component with color-coded badges (green match, red miss, orange extra) and similarity scores

Closes #11

## Test plan
- [ ] Navigate to an extraction eval run with line items results
- [ ] Verify collapsed state shows the same summary stats as before (matched/expected/predicted + F1 pill)
- [ ] Click the line items summary row — detail table should expand
- [ ] Verify matched items show expected and predicted values side-by-side with similarity score and green "match" badge
- [ ] Verify unmatched expected items show with red "miss" badge
- [ ] Verify extra predicted items show with orange "extra" badge
- [ ] Click again to collapse — verify toggle works
- [ ] Test with documents that have no line items (should show no line items section)
- [ ] Test with documents where all items match, none match, or there are no predicted items

🤖 Generated with [Claude Code](https://claude.com/claude-code)