### PR TITLE
feat: add UI for managing and editing extraction schemas

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@opentelemetry/sdk-trace-base": "^2.5.0",
         "@opentelemetry/sdk-trace-web": "^2.5.0",
         "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -1836,6 +1837,75 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@opentelemetry/sdk-trace-base": "^2.5.0",
     "@opentelemetry/sdk-trace-web": "^2.5.0",
     "@opentelemetry/semantic-conventions": "^1.39.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/frontend/src/components/extraction/ExtractionForm.tsx
+++ b/frontend/src/components/extraction/ExtractionForm.tsx
@@ -11,13 +11,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Play } from 'lucide-react'
+import { Pencil, Play } from 'lucide-react'
 
 interface ExtractionFormProps {
   documentId: string
   schemas: ExtractionSchema[]
   extractors: ExtractorInfo[]
   onRun: (request: RunExtractionRequest) => Promise<void>
+  onEditSchema?: (schema: ExtractionSchema) => void
 }
 
 export function ExtractionForm({
@@ -25,6 +26,7 @@ export function ExtractionForm({
   schemas,
   extractors,
   onRun,
+  onEditSchema,
 }: ExtractionFormProps) {
   const [schemaId, setSchemaId] = useState('')
   const [extractionMethod, setExtractionMethod] = useState('')
@@ -95,18 +97,34 @@ export function ExtractionForm({
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
           <Label className="text-xs">Schema</Label>
-          <Select value={schemaId} onValueChange={setSchemaId}>
-            <SelectTrigger className="h-9">
-              <SelectValue placeholder="Select schema" />
-            </SelectTrigger>
-            <SelectContent>
-              {schemas.map((s) => (
-                <SelectItem key={s.id} value={s.id}>
-                  {s.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <div className="flex items-center gap-1">
+            <Select value={schemaId} onValueChange={setSchemaId}>
+              <SelectTrigger className="h-9">
+                <SelectValue placeholder="Select schema" />
+              </SelectTrigger>
+              <SelectContent>
+                {schemas.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    {s.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {onEditSchema && schemaId && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 shrink-0"
+                title="Edit selected schema"
+                onClick={() => {
+                  const selected = schemas.find((s) => s.id === schemaId)
+                  if (selected) onEditSchema(selected)
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
         </div>
 
         {extractors.length > 1 ? (

--- a/frontend/src/components/extraction/SchemaManager.tsx
+++ b/frontend/src/components/extraction/SchemaManager.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+import type { ExtractionSchema } from '@/types/extraction'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { ChevronDown, ChevronRight, Eye, Pencil, Plus, Trash2 } from 'lucide-react'
+
+const TARGET_LABELS: Record<string, string> = {
+  PER_DOC: 'Per Doc',
+  PER_PAGE: 'Per Page',
+  PER_TABLE_ROW: 'Per Row',
+}
+
+interface SchemaManagerProps {
+  schemas: ExtractionSchema[]
+  onEdit: (schema: ExtractionSchema) => void
+  onDelete: (schemaId: string) => Promise<void>
+  onCreate: () => void
+}
+
+export function SchemaManager({
+  schemas,
+  onEdit,
+  onDelete,
+  onCreate,
+}: SchemaManagerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [previewSchema, setPreviewSchema] = useState<ExtractionSchema | null>(null)
+  const [deletingSchema, setDeletingSchema] = useState<ExtractionSchema | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = async () => {
+    if (!deletingSchema) return
+    setIsDeleting(true)
+    try {
+      await onDelete(deletingSchema.id)
+    } finally {
+      setIsDeleting(false)
+      setDeletingSchema(null)
+    }
+  }
+
+  return (
+    <>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <div className="flex items-center justify-between">
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="gap-1.5 px-2 -ml-2 text-sm font-medium">
+              {isOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+              Schemas
+              <span className="text-muted-foreground font-normal">({schemas.length})</span>
+            </Button>
+          </CollapsibleTrigger>
+          <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={onCreate}>
+            <Plus className="h-3 w-3 mr-1" />
+            New
+          </Button>
+        </div>
+
+        <CollapsibleContent className="mt-1">
+          {schemas.length === 0 ? (
+            <div className="rounded-md border border-dashed p-4 text-center">
+              <p className="text-sm text-muted-foreground">No schemas yet.</p>
+              <Button variant="link" size="sm" className="mt-1 text-xs" onClick={onCreate}>
+                Create your first schema
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {schemas.map((schema) => (
+                <div
+                  key={schema.id}
+                  className="group flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium truncate">{schema.name}</span>
+                      <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+                        {TARGET_LABELS[schema.extractionTarget] ?? schema.extractionTarget}
+                      </Badge>
+                    </div>
+                    {schema.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">
+                        {schema.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      title="Preview schema"
+                      onClick={() => setPreviewSchema(previewSchema?.id === schema.id ? null : schema)}
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      title="Edit schema"
+                      onClick={() => onEdit(schema)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-destructive hover:text-destructive"
+                      title="Delete schema"
+                      onClick={() => setDeletingSchema(schema)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* JSON preview */}
+          {previewSchema && (
+            <div className="mt-2 rounded-md border bg-muted/50 p-3">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-medium">{previewSchema.name} - Schema Definition</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  onClick={() => setPreviewSchema(null)}
+                >
+                  Close
+                </Button>
+              </div>
+              <pre className="text-xs font-mono whitespace-pre-wrap overflow-x-auto max-h-64 overflow-y-auto">
+                {JSON.stringify(previewSchema.schemaDefinition, null, 2)}
+              </pre>
+            </div>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Delete confirmation */}
+      <AlertDialog open={!!deletingSchema} onOpenChange={(open) => !open && setDeletingSchema(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete schema</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete <strong>{deletingSchema?.name}</strong>?
+              This may affect existing extraction results that reference this schema.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/src/pages/ExtractionPage.tsx
+++ b/frontend/src/pages/ExtractionPage.tsx
@@ -16,13 +16,13 @@ import type { ParseConfig } from '@/types/parsing'
 import { ExtractionSchemaEditor } from '@/components/extraction/ExtractionSchemaEditor'
 import { ExtractionForm } from '@/components/extraction/ExtractionForm'
 import { ExtractionHistory } from '@/components/extraction/ExtractionHistory'
+import { SchemaManager } from '@/components/extraction/SchemaManager'
 import { DocumentSelector } from '@/components/extraction/DocumentSelector'
 import { DocumentUploadDialog } from '@/components/documents/DocumentUploadDialog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-import { Plus, FileSearch } from 'lucide-react'
+import { FileSearch } from 'lucide-react'
 import { toast } from 'sonner'
 import * as extractionApi from '@/api/extraction'
 
@@ -40,6 +40,7 @@ export default function ExtractionPage(): JSX.Element {
     error: schemasError,
     createSchema,
     updateSchema,
+    deleteSchema,
   } = useExtractionSchemas(projectId)
 
   const [searchParams, setSearchParams] = useSearchParams()
@@ -88,6 +89,22 @@ export default function ExtractionPage(): JSX.Element {
   const handleCreateSchema = () => {
     setEditingSchema(null)
     setSchemaEditorOpen(true)
+  }
+
+  const handleEditSchema = (schema: ExtractionSchema) => {
+    setEditingSchema(schema)
+    setSchemaEditorOpen(true)
+  }
+
+  const handleDeleteSchema = async (schemaId: string) => {
+    try {
+      await deleteSchema(schemaId)
+      toast.success('Schema deleted')
+    } catch (err) {
+      toast.error('Failed to delete schema', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
   }
 
   const handleSaveSchema = async (
@@ -169,10 +186,6 @@ export default function ExtractionPage(): JSX.Element {
           <h1 className="text-lg font-semibold">Extraction</h1>
           <p className="text-xs text-muted-foreground">{currentProject.name}</p>
         </div>
-        <Button variant="outline" size="sm" onClick={handleCreateSchema}>
-          <Plus className="h-3.5 w-3.5 mr-1.5" />
-          New Schema
-        </Button>
       </div>
 
       {/* Errors */}
@@ -212,6 +225,16 @@ export default function ExtractionPage(): JSX.Element {
             </div>
           ) : (
             <div className="p-6 space-y-6 max-w-3xl">
+              {/* Schema management */}
+              <SchemaManager
+                schemas={schemas}
+                onEdit={handleEditSchema}
+                onDelete={handleDeleteSchema}
+                onCreate={handleCreateSchema}
+              />
+
+              <Separator />
+
               {/* Document header */}
               {selectedDocument && (
                 <div className="flex items-center gap-3">
@@ -253,6 +276,7 @@ export default function ExtractionPage(): JSX.Element {
                       schemas={schemas}
                       extractors={extractors}
                       onRun={handleRunExtraction}
+                      onEditSchema={handleEditSchema}
                     />
                   </div>
                 ) : (


### PR DESCRIPTION
## Summary
- Add **SchemaManager** component — collapsible schema list with edit, delete (with confirmation dialog), and JSON preview actions per schema
- Add **inline edit button** next to the schema dropdown in `ExtractionForm` to edit the currently selected schema
- Wire up existing `deleteSchema` from `useExtractionSchemas` hook and `handleEditSchema`/`handleDeleteSchema` in `ExtractionPage`
- Install `alert-dialog` shadcn component for delete confirmation

Closes #13

## Test plan
- [ ] Open Extraction page, select a document — verify "Schemas" collapsible section appears above the extraction form
- [ ] Expand schemas section — verify schema list shows name, extraction target badge, and description
- [ ] Click eye icon — verify read-only JSON preview appears inline
- [ ] Click pencil icon on a schema row — verify ExtractionSchemaEditor opens pre-populated with that schema's data
- [ ] Click pencil icon next to schema dropdown in extraction form — verify same edit behavior
- [ ] Edit a schema and save — verify toast confirmation and updated data in list
- [ ] Click trash icon — verify confirmation dialog warns about existing extraction results
- [ ] Confirm delete — verify schema removed and toast shown
- [ ] With no schemas, verify empty state with "Create your first schema" link
- [ ] All 312 backend + 48 frontend tests pass, lint and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)