### PR TITLE
feat: LangGraph agent module for receipt processing pipeline

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -15,6 +15,7 @@ from app.models import (
     GoldenSet, GoldenSetQuery, GoldenSetSource,
     EvalRun, EvalRunResult,
     AgentReceipt,
+    AgentConfig,
 )
 
 config = context.config

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,6 +14,7 @@ from app.models import (
     Index, IndexDocument, Chunk, ProviderKey,
     GoldenSet, GoldenSetQuery, GoldenSetSource,
     EvalRun, EvalRunResult,
+    AgentReceipt,
 )
 
 config = context.config

--- a/backend/alembic/versions/0b92f2f67990_add_agent_receipts_table.py
+++ b/backend/alembic/versions/0b92f2f67990_add_agent_receipts_table.py
@@ -1,0 +1,60 @@
+"""add_agent_receipts_table
+
+Revision ID: 0b92f2f67990
+Revises: d2e3f4a5b6c7
+Create Date: 2026-04-10 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '0b92f2f67990'
+down_revision: Union[str, None] = 'd2e3f4a5b6c7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create the enum type
+    agent_receipt_status = postgresql.ENUM(
+        'pending', 'extracting', 'reviewing', 'approved', 'exported', 'failed',
+        name='agent_receipt_status',
+        create_type=True,
+    )
+    agent_receipt_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        'agent_receipts',
+        sa.Column('id', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('project_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('document_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('extraction_schema_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('status', sa.Enum('pending', 'extracting', 'reviewing', 'approved', 'exported', 'failed', name='agent_receipt_status', create_type=False), server_default='pending', nullable=False),
+        sa.Column('status_message', sa.Text(), nullable=True),
+        sa.Column('extracted_data', sa.JSON(), nullable=True),
+        sa.Column('reviewed_data', sa.JSON(), nullable=True),
+        sa.Column('thread_id', sa.String(length=64), nullable=True),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['document_id'], ['documents.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['extraction_schema_id'], ['extraction_schemas.id']),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_agent_receipts_project_id', 'agent_receipts', ['project_id'])
+    op.create_index('ix_agent_receipts_status', 'agent_receipts', ['status'])
+    op.create_index('ix_agent_receipts_thread_id', 'agent_receipts', ['thread_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_agent_receipts_thread_id', table_name='agent_receipts')
+    op.drop_index('ix_agent_receipts_status', table_name='agent_receipts')
+    op.drop_index('ix_agent_receipts_project_id', table_name='agent_receipts')
+    op.drop_table('agent_receipts')
+    sa.Enum(name='agent_receipt_status').drop(op.get_bind(), checkfirst=True)

--- a/backend/alembic/versions/0b92f2f67990_add_agent_receipts_table.py
+++ b/backend/alembic/versions/0b92f2f67990_add_agent_receipts_table.py
@@ -19,13 +19,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Create the enum type
-    agent_receipt_status = postgresql.ENUM(
-        'pending', 'extracting', 'reviewing', 'approved', 'exported', 'failed',
-        name='agent_receipt_status',
-        create_type=True,
-    )
-    agent_receipt_status.create(op.get_bind(), checkfirst=True)
+    # Create the enum type using raw SQL to avoid asyncpg checkfirst issues
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'agent_receipt_status') THEN
+                CREATE TYPE agent_receipt_status AS ENUM (
+                    'pending', 'extracting', 'reviewing', 'approved', 'exported', 'failed'
+                );
+            END IF;
+        END
+        $$;
+    """)
 
     op.create_table(
         'agent_receipts',
@@ -33,7 +38,7 @@ def upgrade() -> None:
         sa.Column('project_id', postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column('document_id', postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column('extraction_schema_id', postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column('status', sa.Enum('pending', 'extracting', 'reviewing', 'approved', 'exported', 'failed', name='agent_receipt_status', create_type=False), server_default='pending', nullable=False),
+        sa.Column('status', postgresql.ENUM('pending', 'extracting', 'reviewing', 'approved', 'exported', 'failed', name='agent_receipt_status', create_type=False), server_default='pending', nullable=False),
         sa.Column('status_message', sa.Text(), nullable=True),
         sa.Column('extracted_data', sa.JSON(), nullable=True),
         sa.Column('reviewed_data', sa.JSON(), nullable=True),
@@ -57,4 +62,4 @@ def downgrade() -> None:
     op.drop_index('ix_agent_receipts_status', table_name='agent_receipts')
     op.drop_index('ix_agent_receipts_project_id', table_name='agent_receipts')
     op.drop_table('agent_receipts')
-    sa.Enum(name='agent_receipt_status').drop(op.get_bind(), checkfirst=True)
+    op.execute("DROP TYPE IF EXISTS agent_receipt_status")

--- a/backend/alembic/versions/1d64baf5d740_add_agent_configs_table.py
+++ b/backend/alembic/versions/1d64baf5d740_add_agent_configs_table.py
@@ -1,6 +1,6 @@
 """add_agent_configs_table
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 1d64baf5d740
 Revises: 0b92f2f67990
 Create Date: 2026-04-10 14:00:00.000000
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision: str = 'a1b2c3d4e5f6'
+revision: str = '1d64baf5d740'
 down_revision: Union[str, None] = '0b92f2f67990'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_agent_configs_table.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_agent_configs_table.py
@@ -1,0 +1,42 @@
+"""add_agent_configs_table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 0b92f2f67990
+Create Date: 2026-04-10 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '0b92f2f67990'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'agent_configs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('project_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('agent_type', sa.String(length=64), nullable=False),
+        sa.Column('config', sa.JSON(), nullable=True),
+        sa.Column('enabled', sa.Boolean(), server_default=sa.text('true'), nullable=False),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('project_id', 'agent_type', name='uq_agent_configs_project_type'),
+    )
+    op.create_index('ix_agent_configs_project_id', 'agent_configs', ['project_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_agent_configs_project_id', table_name='agent_configs')
+    op.drop_table('agent_configs')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.config import settings
-from app.routers import auth, oauth, otel_proxy, projects, users, documents, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_results, extraction, extraction_ground_truth, extraction_eval
+from app.routers import auth, oauth, otel_proxy, projects, users, documents, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_results, extraction, extraction_ground_truth, extraction_eval, agent
 from app.utils.oauth import setup_oauth
 
 # Import database engine for SQLAlchemy instrumentation
@@ -61,6 +61,10 @@ async def lifespan(app: FastAPI):
 
     # Initialize OAuth client
     setup_oauth(settings)
+
+    # Initialize LangGraph checkpointer for agent pipeline
+    from app.services.agent.checkpointer import create_checkpointer
+    app.state.agent_checkpointer = await create_checkpointer()
 
     yield
 
@@ -159,3 +163,4 @@ app.include_router(parse_results.router, prefix="/api/v1")
 app.include_router(extraction.router, prefix="/api/v1")
 app.include_router(extraction_ground_truth.router, prefix="/api/v1")
 app.include_router(extraction_eval.router, prefix="/api/v1")
+app.include_router(agent.router, prefix="/api/v1")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,15 +63,16 @@ async def lifespan(app: FastAPI):
     setup_oauth(settings)
 
     # Initialize LangGraph checkpointer for agent pipeline
-    from app.services.agent.checkpointer import create_checkpointer
-    app.state.agent_checkpointer = await create_checkpointer()
+    from app.services.agent.checkpointer import get_checkpointer_context
+    async with get_checkpointer_context() as checkpointer:
+        await checkpointer.setup()
+        app.state.agent_checkpointer = checkpointer
 
-    yield
+        yield
 
-    # Shutdown
-    # Clean up resources
-    await otel_proxy.close_http_client(app)
-    shutdown_tracing()
+        # Shutdown — clean up resources
+        await otel_proxy.close_http_client(app)
+        shutdown_tracing()
 
 
 # ============================================================================

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,7 @@ from app.models.extraction_schema import ExtractionSchema
 from app.models.extraction_result import ExtractionResult, ExtractionResultStatus
 from app.models.extraction_ground_truth import ExtractionGroundTruthSet, ExtractionGroundTruthItem
 from app.models.extraction_eval import ExtractionEvalRun, ExtractionEvalRunStatus, ExtractionEvalResult
+from app.models.agent_receipt import AgentReceipt, AgentReceiptStatus
 
 __all__ = [
     "User",
@@ -56,4 +57,6 @@ __all__ = [
     "ExtractionEvalRun",
     "ExtractionEvalRunStatus",
     "ExtractionEvalResult",
+    "AgentReceipt",
+    "AgentReceiptStatus",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ from app.models.extraction_result import ExtractionResult, ExtractionResultStatu
 from app.models.extraction_ground_truth import ExtractionGroundTruthSet, ExtractionGroundTruthItem
 from app.models.extraction_eval import ExtractionEvalRun, ExtractionEvalRunStatus, ExtractionEvalResult
 from app.models.agent_receipt import AgentReceipt, AgentReceiptStatus
+from app.models.agent_config import AgentConfig
 
 __all__ = [
     "User",
@@ -59,4 +60,5 @@ __all__ = [
     "ExtractionEvalResult",
     "AgentReceipt",
     "AgentReceiptStatus",
+    "AgentConfig",
 ]

--- a/backend/app/models/agent_config.py
+++ b/backend/app/models/agent_config.py
@@ -1,0 +1,57 @@
+"""Models for per-project agent configuration."""
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, JSON
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class AgentConfig(Base):
+    """Links a project to an agent type with optional config overrides."""
+    __tablename__ = "agent_configs"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=sa.text('gen_random_uuid()')
+    )
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False
+    )
+    agent_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text('true'))
+    created_by: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+        server_default=sa.text('NOW()')
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default=sa.text('NOW()')
+    )
+
+    # Relationships
+    project: Mapped["Project"] = relationship()
+    user: Mapped["User"] = relationship()
+
+    __table_args__ = (
+        sa.UniqueConstraint('project_id', 'agent_type', name='uq_agent_configs_project_type'),
+        sa.Index('ix_agent_configs_project_id', 'project_id'),
+    )

--- a/backend/app/models/agent_receipt.py
+++ b/backend/app/models/agent_receipt.py
@@ -1,0 +1,87 @@
+"""Models for agent receipt processing pipeline."""
+from datetime import datetime
+from uuid import UUID, uuid4
+import enum
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, JSON
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class AgentReceiptStatus(str, enum.Enum):
+    """Receipt processing pipeline status."""
+    pending = "pending"
+    extracting = "extracting"
+    reviewing = "reviewing"
+    approved = "approved"
+    exported = "exported"
+    failed = "failed"
+
+
+class AgentReceipt(Base):
+    """A receipt being processed through the LangGraph agent pipeline."""
+    __tablename__ = "agent_receipts"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=sa.text('gen_random_uuid()')
+    )
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False
+    )
+    document_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        nullable=False
+    )
+    extraction_schema_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("extraction_schemas.id"),
+        nullable=False
+    )
+    status: Mapped[AgentReceiptStatus] = mapped_column(
+        Enum(AgentReceiptStatus, name='agent_receipt_status', create_type=False),
+        nullable=False,
+        default=AgentReceiptStatus.pending,
+        server_default='pending'
+    )
+    status_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    extracted_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    reviewed_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    thread_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    created_by: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+        server_default=sa.text('NOW()')
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default=sa.text('NOW()')
+    )
+
+    # Relationships
+    project: Mapped["Project"] = relationship()
+    document: Mapped["Document"] = relationship()
+    extraction_schema: Mapped["ExtractionSchema"] = relationship()
+    user: Mapped["User"] = relationship()
+
+    __table_args__ = (
+        sa.Index('ix_agent_receipts_project_id', 'project_id'),
+        sa.Index('ix_agent_receipts_status', 'status'),
+    )

--- a/backend/app/repositories/agent_config_repository.py
+++ b/backend/app/repositories/agent_config_repository.py
@@ -1,0 +1,75 @@
+"""Repository for agent config data access."""
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_config import AgentConfig
+
+
+class AgentConfigRepository:
+    """Repository for agent config data access."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(
+        self,
+        project_id: UUID,
+        agent_type: str,
+        created_by: UUID,
+        config: dict | None = None,
+    ) -> AgentConfig:
+        agent_config = AgentConfig(
+            project_id=project_id,
+            agent_type=agent_type,
+            config=config,
+            created_by=created_by,
+        )
+        self.session.add(agent_config)
+        await self.session.commit()
+        await self.session.refresh(agent_config)
+        return agent_config
+
+    async def get_by_id(self, config_id: UUID) -> AgentConfig | None:
+        result = await self.session.execute(
+            select(AgentConfig).where(AgentConfig.id == config_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_project(self, project_id: UUID) -> list[AgentConfig]:
+        result = await self.session.execute(
+            select(AgentConfig)
+            .where(AgentConfig.project_id == project_id)
+            .order_by(AgentConfig.created_at)
+        )
+        return list(result.scalars().all())
+
+    async def get_by_project_and_type(
+        self, project_id: UUID, agent_type: str
+    ) -> AgentConfig | None:
+        result = await self.session.execute(
+            select(AgentConfig)
+            .where(AgentConfig.project_id == project_id)
+            .where(AgentConfig.agent_type == agent_type)
+        )
+        return result.scalar_one_or_none()
+
+    async def update_enabled(
+        self, config_id: UUID, enabled: bool
+    ) -> AgentConfig | None:
+        config = await self.get_by_id(config_id)
+        if not config:
+            return None
+        config.enabled = enabled
+        await self.session.commit()
+        await self.session.refresh(config)
+        return config
+
+    async def delete(self, config_id: UUID) -> bool:
+        config = await self.get_by_id(config_id)
+        if not config:
+            return False
+        await self.session.delete(config)
+        await self.session.commit()
+        return True

--- a/backend/app/repositories/agent_receipt_repository.py
+++ b/backend/app/repositories/agent_receipt_repository.py
@@ -1,0 +1,93 @@
+"""Repository for agent receipt data access."""
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_receipt import AgentReceipt, AgentReceiptStatus
+
+
+class AgentReceiptRepository:
+    """Repository for agent receipt data access."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(
+        self,
+        project_id: UUID,
+        document_id: UUID,
+        extraction_schema_id: UUID,
+        created_by: UUID,
+    ) -> AgentReceipt:
+        receipt = AgentReceipt(
+            project_id=project_id,
+            document_id=document_id,
+            extraction_schema_id=extraction_schema_id,
+            created_by=created_by,
+            status=AgentReceiptStatus.pending,
+        )
+        self.session.add(receipt)
+        await self.session.commit()
+        await self.session.refresh(receipt)
+        return receipt
+
+    async def get_by_id(self, receipt_id: UUID) -> AgentReceipt | None:
+        result = await self.session.execute(
+            select(AgentReceipt).where(AgentReceipt.id == receipt_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_project(self, project_id: UUID) -> list[AgentReceipt]:
+        result = await self.session.execute(
+            select(AgentReceipt)
+            .where(AgentReceipt.project_id == project_id)
+            .order_by(AgentReceipt.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def update_status(
+        self,
+        receipt_id: UUID,
+        status: AgentReceiptStatus,
+        status_message: str | None = None,
+    ) -> AgentReceipt | None:
+        receipt = await self.get_by_id(receipt_id)
+        if not receipt:
+            return None
+        receipt.status = status
+        receipt.status_message = status_message
+        await self.session.commit()
+        await self.session.refresh(receipt)
+        return receipt
+
+    async def update_extracted_data(
+        self,
+        receipt_id: UUID,
+        extracted_data: dict,
+        thread_id: str,
+    ) -> AgentReceipt | None:
+        receipt = await self.get_by_id(receipt_id)
+        if not receipt:
+            return None
+        receipt.extracted_data = extracted_data
+        receipt.thread_id = thread_id
+        receipt.status = AgentReceiptStatus.reviewing
+        await self.session.commit()
+        await self.session.refresh(receipt)
+        return receipt
+
+    async def update_reviewed_data(
+        self,
+        receipt_id: UUID,
+        reviewed_data: dict | None,
+        status: AgentReceiptStatus,
+    ) -> AgentReceipt | None:
+        receipt = await self.get_by_id(receipt_id)
+        if not receipt:
+            return None
+        receipt.reviewed_data = reviewed_data
+        receipt.status = status
+        await self.session.commit()
+        await self.session.refresh(receipt)
+        return receipt

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -1,4 +1,4 @@
-"""Agent API router — receipt processing pipeline endpoints."""
+"""Agent API router — agent configs, types, and receipt processing endpoints."""
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -7,17 +7,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.dependencies.auth import get_current_active_user
 from app.models import User
+from app.repositories.agent_config_repository import AgentConfigRepository
 from app.repositories.agent_receipt_repository import AgentReceiptRepository
 from app.repositories.document_repository import DocumentRepository
 from app.repositories.extraction_schema_repository import ExtractionSchemaRepository
 from app.schemas.agent import (
+    AgentTypeResponse,
+    AgentConfigCreate,
+    AgentConfigResponse,
     StartProcessingRequest,
     SubmitReviewRequest,
     AgentReceiptResponse,
     AgentReceiptListItem,
 )
 from app.services.agent.service import AgentService
-from app.services.exceptions import NotFoundError
+from app.services.agent.types import list_agent_types, get_agent_type
+from app.services.exceptions import NotFoundError, ConflictError
 
 
 router = APIRouter(tags=["agent"])
@@ -37,6 +42,103 @@ def get_agent_service(
         checkpointer=checkpointer,
     )
 
+
+# --- Agent Types ---
+
+@router.get(
+    "/agent/types",
+    response_model=list[AgentTypeResponse],
+    summary="List available agent types",
+)
+async def list_types(
+    current_user: User = Depends(get_current_active_user),
+):
+    types = list_agent_types()
+    return [
+        AgentTypeResponse(
+            slug=t.slug,
+            name=t.name,
+            description=t.description,
+            nodes=t.nodes,
+            configSchema=t.config_schema,
+        )
+        for t in types
+    ]
+
+
+# --- Agent Configs ---
+
+@router.get(
+    "/agent/projects/{project_id}/configs",
+    response_model=list[AgentConfigResponse],
+    summary="List agent configs for a project",
+)
+async def list_configs(
+    project_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    repo = AgentConfigRepository(db)
+    configs = await repo.list_by_project(project_id)
+    return [AgentConfigResponse.from_orm_model(c) for c in configs]
+
+
+@router.post(
+    "/agent/projects/{project_id}/configs",
+    response_model=AgentConfigResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Enable an agent type for a project",
+)
+async def create_config(
+    project_id: UUID,
+    body: AgentConfigCreate,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # Validate agent type exists
+    agent_type = get_agent_type(body.agent_type)
+    if not agent_type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown agent type: {body.agent_type}",
+        )
+
+    repo = AgentConfigRepository(db)
+
+    # Check for duplicate
+    existing = await repo.get_by_project_and_type(project_id, body.agent_type)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Agent type '{body.agent_type}' already configured for this project",
+        )
+
+    config = await repo.create(
+        project_id=project_id,
+        agent_type=body.agent_type,
+        created_by=current_user.id,
+        config=body.config,
+    )
+    return AgentConfigResponse.from_orm_model(config)
+
+
+@router.delete(
+    "/agent/configs/{config_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove an agent config",
+)
+async def delete_config(
+    config_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    repo = AgentConfigRepository(db)
+    deleted = await repo.delete(config_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Config not found")
+
+
+# --- Receipt Processing ---
 
 @router.post(
     "/agent/projects/{project_id}/receipts",

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -1,0 +1,115 @@
+"""Agent API router — receipt processing pipeline endpoints."""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_active_user
+from app.models import User
+from app.repositories.agent_receipt_repository import AgentReceiptRepository
+from app.repositories.document_repository import DocumentRepository
+from app.repositories.extraction_schema_repository import ExtractionSchemaRepository
+from app.schemas.agent import (
+    StartProcessingRequest,
+    SubmitReviewRequest,
+    AgentReceiptResponse,
+    AgentReceiptListItem,
+)
+from app.services.agent.service import AgentService
+from app.services.exceptions import NotFoundError
+
+
+router = APIRouter(tags=["agent"])
+
+
+def get_agent_service(
+    db: AsyncSession = Depends(get_db),
+) -> AgentService:
+    """Dependency to create AgentService with checkpointer from app state."""
+    from app.main import app
+    checkpointer = app.state.agent_checkpointer
+
+    return AgentService(
+        receipt_repo=AgentReceiptRepository(db),
+        document_repo=DocumentRepository(db),
+        schema_repo=ExtractionSchemaRepository(db),
+        checkpointer=checkpointer,
+    )
+
+
+@router.post(
+    "/agent/projects/{project_id}/receipts",
+    response_model=AgentReceiptResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start processing a receipt",
+)
+async def start_processing(
+    project_id: UUID,
+    body: StartProcessingRequest,
+    current_user: User = Depends(get_current_active_user),
+    service: AgentService = Depends(get_agent_service),
+):
+    try:
+        return await service.start_processing(
+            project_id=project_id,
+            document_id=body.document_id,
+            extraction_schema_id=body.extraction_schema_id,
+            user_id=current_user.id,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get(
+    "/agent/projects/{project_id}/receipts",
+    response_model=list[AgentReceiptListItem],
+    summary="List receipts for a project",
+)
+async def list_receipts(
+    project_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: AgentService = Depends(get_agent_service),
+):
+    return await service.list_receipts(project_id)
+
+
+@router.get(
+    "/agent/receipts/{receipt_id}",
+    response_model=AgentReceiptResponse,
+    summary="Get a receipt",
+)
+async def get_receipt(
+    receipt_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: AgentService = Depends(get_agent_service),
+):
+    try:
+        return await service.get_receipt(receipt_id)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.post(
+    "/agent/receipts/{receipt_id}/review",
+    response_model=AgentReceiptResponse,
+    summary="Submit review for a receipt",
+)
+async def submit_review(
+    receipt_id: UUID,
+    body: SubmitReviewRequest,
+    current_user: User = Depends(get_current_active_user),
+    service: AgentService = Depends(get_agent_service),
+):
+    try:
+        return await service.submit_review(
+            receipt_id=receipt_id,
+            action=body.action,
+            data=body.data,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -1,11 +1,61 @@
-"""Pydantic schemas for the agent receipt processing pipeline."""
+"""Pydantic schemas for the agent module."""
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.agent_receipt import AgentReceiptStatus
+
+
+# --- Agent Type schemas ---
+
+class AgentTypeResponse(BaseModel):
+    """Available agent type from the registry."""
+    slug: str
+    name: str
+    description: str
+    nodes: list[dict[str, str]]
+    config_schema: dict[str, Any] = Field(default_factory=dict, alias="configSchema")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+# --- Agent Config schemas ---
+
+class AgentConfigCreate(BaseModel):
+    """Request to enable an agent type for a project."""
+    agent_type: str = Field(..., alias="agentType")
+    config: dict | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AgentConfigResponse(BaseModel):
+    """Agent config response."""
+    id: UUID
+    project_id: UUID = Field(..., alias="projectId")
+    agent_type: str = Field(..., alias="agentType")
+    config: dict | None = None
+    enabled: bool
+    created_by: UUID = Field(..., alias="createdBy")
+    created_at: datetime = Field(..., alias="createdAt")
+    updated_at: datetime = Field(..., alias="updatedAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_model(cls, obj) -> "AgentConfigResponse":
+        return cls(
+            id=obj.id,
+            projectId=obj.project_id,
+            agentType=obj.agent_type,
+            config=obj.config,
+            enabled=obj.enabled,
+            createdBy=obj.created_by,
+            createdAt=obj.created_at,
+            updatedAt=obj.updated_at,
+        )
 
 
 class StartProcessingRequest(BaseModel):

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -1,0 +1,82 @@
+"""Pydantic schemas for the agent receipt processing pipeline."""
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.agent_receipt import AgentReceiptStatus
+
+
+class StartProcessingRequest(BaseModel):
+    """Request to start processing a receipt."""
+    document_id: UUID = Field(..., alias="documentId")
+    extraction_schema_id: UUID = Field(..., alias="extractionSchemaId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SubmitReviewRequest(BaseModel):
+    """Request to submit a review decision."""
+    action: Literal["approve", "edit", "reject"]
+    data: dict | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AgentReceiptResponse(BaseModel):
+    """Full agent receipt response."""
+    id: UUID
+    project_id: UUID = Field(..., alias="projectId")
+    document_id: UUID = Field(..., alias="documentId")
+    extraction_schema_id: UUID = Field(..., alias="extractionSchemaId")
+    status: AgentReceiptStatus
+    status_message: str | None = Field(None, alias="statusMessage")
+    extracted_data: dict | None = Field(None, alias="extractedData")
+    reviewed_data: dict | None = Field(None, alias="reviewedData")
+    thread_id: str | None = Field(None, alias="threadId")
+    created_by: UUID = Field(..., alias="createdBy")
+    created_at: datetime = Field(..., alias="createdAt")
+    updated_at: datetime = Field(..., alias="updatedAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_model(cls, obj) -> "AgentReceiptResponse":
+        return cls(
+            id=obj.id,
+            projectId=obj.project_id,
+            documentId=obj.document_id,
+            extractionSchemaId=obj.extraction_schema_id,
+            status=obj.status,
+            statusMessage=obj.status_message,
+            extractedData=obj.extracted_data,
+            reviewedData=obj.reviewed_data,
+            threadId=obj.thread_id,
+            createdBy=obj.created_by,
+            createdAt=obj.created_at,
+            updatedAt=obj.updated_at,
+        )
+
+
+class AgentReceiptListItem(BaseModel):
+    """Summary agent receipt for list endpoint."""
+    id: UUID
+    document_id: UUID = Field(..., alias="documentId")
+    status: AgentReceiptStatus
+    status_message: str | None = Field(None, alias="statusMessage")
+    extracted_data: dict | None = Field(None, alias="extractedData")
+    created_at: datetime = Field(..., alias="createdAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_model(cls, obj) -> "AgentReceiptListItem":
+        return cls(
+            id=obj.id,
+            documentId=obj.document_id,
+            status=obj.status,
+            statusMessage=obj.status_message,
+            extractedData=obj.extracted_data,
+            createdAt=obj.created_at,
+        )

--- a/backend/app/services/agent/__init__.py
+++ b/backend/app/services/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Agent service package — LangGraph-based receipt processing pipeline."""

--- a/backend/app/services/agent/checkpointer.py
+++ b/backend/app/services/agent/checkpointer.py
@@ -1,0 +1,24 @@
+"""AsyncPostgresSaver factory for LangGraph checkpointing."""
+import re
+
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+from app.config import settings
+
+
+def get_checkpoint_connection_string() -> str:
+    """Convert async DATABASE_URL to psycopg-compatible connection string.
+
+    LangGraph's AsyncPostgresSaver uses psycopg (not asyncpg),
+    so we convert from postgresql+asyncpg:// to postgresql://.
+    """
+    url = settings.DATABASE_URL
+    return re.sub(r"^postgresql\+asyncpg://", "postgresql://", url)
+
+
+async def create_checkpointer() -> AsyncPostgresSaver:
+    """Create and set up the AsyncPostgresSaver checkpointer."""
+    conn_string = get_checkpoint_connection_string()
+    checkpointer = AsyncPostgresSaver.from_conn_string(conn_string)
+    await checkpointer.setup()
+    return checkpointer

--- a/backend/app/services/agent/checkpointer.py
+++ b/backend/app/services/agent/checkpointer.py
@@ -16,9 +16,7 @@ def get_checkpoint_connection_string() -> str:
     return re.sub(r"^postgresql\+asyncpg://", "postgresql://", url)
 
 
-async def create_checkpointer() -> AsyncPostgresSaver:
-    """Create and set up the AsyncPostgresSaver checkpointer."""
+def get_checkpointer_context():
+    """Return an async context manager for the checkpointer."""
     conn_string = get_checkpoint_connection_string()
-    checkpointer = AsyncPostgresSaver.from_conn_string(conn_string)
-    await checkpointer.setup()
-    return checkpointer
+    return AsyncPostgresSaver.from_conn_string(conn_string)

--- a/backend/app/services/agent/graph.py
+++ b/backend/app/services/agent/graph.py
@@ -1,0 +1,28 @@
+"""LangGraph StateGraph builder for the receipt processing pipeline."""
+from langgraph.graph import StateGraph, START, END
+
+from app.services.agent.state import AgentState
+from app.services.agent.nodes import extract_node, review_node, export_node
+
+
+def route_after_review(state: AgentState) -> str:
+    """Route to export or end based on review action."""
+    if state.get("current_step") == "rejected":
+        return END
+    return "export"
+
+
+def build_receipt_graph(checkpointer=None):
+    """Build and compile the receipt processing graph."""
+    graph = StateGraph(AgentState)
+
+    graph.add_node("extract", extract_node)
+    graph.add_node("review", review_node)
+    graph.add_node("export", export_node)
+
+    graph.add_edge(START, "extract")
+    graph.add_edge("extract", "review")
+    graph.add_conditional_edges("review", route_after_review, ["export", END])
+    graph.add_edge("export", END)
+
+    return graph.compile(checkpointer=checkpointer)

--- a/backend/app/services/agent/nodes.py
+++ b/backend/app/services/agent/nodes.py
@@ -1,0 +1,65 @@
+"""LangGraph node functions for the receipt processing pipeline."""
+import logging
+
+from langgraph.types import interrupt
+
+from app.adapters.extraction.registry import get_extractor
+from app.services.agent.state import AgentState
+
+logger = logging.getLogger(__name__)
+
+
+async def extract_node(state: AgentState) -> AgentState:
+    """Extract structured data from receipt image using DataExtractor."""
+    logger.info("extract_node: processing receipt %s", state["receipt_id"])
+
+    extractor = get_extractor("llamaextract")
+    if extractor is None:
+        return {
+            **state,
+            "error": "llamaextract extractor not available",
+            "current_step": "failed",
+        }
+
+    config = dict(state.get("extraction_config") or {})
+    config["extraction_target"] = "PER_DOC"
+
+    output = await extractor.extract(
+        file_path=state["file_path"],
+        schema=state["schema_definition"],
+        config=config,
+    )
+
+    return {
+        **state,
+        "extracted_data": output.structured_data,
+        "current_step": "review",
+    }
+
+
+async def review_node(state: AgentState) -> AgentState:
+    """Interrupt graph execution for human review of extracted data."""
+    logger.info("review_node: awaiting review for receipt %s", state["receipt_id"])
+
+    review_input = interrupt(state.get("extracted_data", {}))
+
+    action = review_input.get("action", "reject")
+    data = review_input.get("data")
+
+    return {
+        **state,
+        "review_action": action,
+        "reviewed_data": data if action == "edit" else state.get("extracted_data"),
+        "current_step": "export" if action in ("approve", "edit") else "rejected",
+    }
+
+
+async def export_node(state: AgentState) -> AgentState:
+    """Mark data as exported (actual DB save happens in the service layer)."""
+    logger.info("export_node: exporting receipt %s", state["receipt_id"])
+
+    return {
+        **state,
+        "exported": True,
+        "current_step": "done",
+    }

--- a/backend/app/services/agent/service.py
+++ b/backend/app/services/agent/service.py
@@ -1,0 +1,181 @@
+"""Agent service — orchestrates the receipt processing pipeline."""
+import logging
+from uuid import UUID, uuid4
+
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from langgraph.types import Command
+
+from app.models.agent_receipt import AgentReceiptStatus
+from app.repositories.agent_receipt_repository import AgentReceiptRepository
+from app.repositories.document_repository import DocumentRepository
+from app.repositories.extraction_schema_repository import ExtractionSchemaRepository
+from app.schemas.agent import AgentReceiptResponse, AgentReceiptListItem
+from app.services.agent.graph import build_receipt_graph
+from app.services.exceptions import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class AgentService:
+    """Service for the LangGraph receipt processing pipeline."""
+
+    def __init__(
+        self,
+        receipt_repo: AgentReceiptRepository,
+        document_repo: DocumentRepository,
+        schema_repo: ExtractionSchemaRepository,
+        checkpointer: AsyncPostgresSaver,
+    ):
+        self.receipt_repo = receipt_repo
+        self.document_repo = document_repo
+        self.schema_repo = schema_repo
+        self.checkpointer = checkpointer
+
+    async def start_processing(
+        self,
+        project_id: UUID,
+        document_id: UUID,
+        extraction_schema_id: UUID,
+        user_id: UUID,
+    ) -> AgentReceiptResponse:
+        """Start processing a receipt through the extract -> review -> export pipeline."""
+        # Validate document
+        document = await self.document_repo.get_by_id_unscoped(document_id)
+        if not document:
+            raise NotFoundError(f"Document {document_id} not found")
+
+        file_path = document.source_metadata.get("file_path")
+        if not file_path:
+            raise NotFoundError("Document has no file path")
+
+        # Validate schema
+        schema = await self.schema_repo.get_by_id(extraction_schema_id)
+        if not schema:
+            raise NotFoundError(f"Extraction schema {extraction_schema_id} not found")
+
+        # Create receipt record
+        receipt = await self.receipt_repo.create(
+            project_id=project_id,
+            document_id=document_id,
+            extraction_schema_id=extraction_schema_id,
+            created_by=user_id,
+        )
+
+        # Update status to extracting
+        await self.receipt_repo.update_status(receipt.id, AgentReceiptStatus.extracting)
+
+        # Build and run graph (synchronous — runs extract then interrupts at review)
+        thread_id = str(uuid4())
+        compiled = build_receipt_graph(checkpointer=self.checkpointer)
+
+        initial_state = {
+            "receipt_id": str(receipt.id),
+            "document_id": str(document_id),
+            "file_path": file_path,
+            "extraction_schema_id": str(extraction_schema_id),
+            "schema_definition": schema.schema_definition,
+            "extraction_config": {},
+            "current_step": "extract",
+        }
+
+        config = {"configurable": {"thread_id": thread_id}}
+
+        try:
+            # This runs extract_node, then interrupts at review_node
+            result = await compiled.ainvoke(initial_state, config=config)
+
+            # Check for extraction error
+            if result.get("error"):
+                await self.receipt_repo.update_status(
+                    receipt.id,
+                    AgentReceiptStatus.failed,
+                    result["error"],
+                )
+                receipt = await self.receipt_repo.get_by_id(receipt.id)
+                return AgentReceiptResponse.from_orm_model(receipt)
+
+            # Graph interrupted at review — update receipt with extracted data
+            # When interrupt() is called, ainvoke returns the state at that point
+            extracted_data = result.get("extracted_data", {})
+            receipt = await self.receipt_repo.update_extracted_data(
+                receipt.id,
+                extracted_data=extracted_data,
+                thread_id=thread_id,
+            )
+
+        except Exception as e:
+            logger.exception("Graph execution failed for receipt %s", receipt.id)
+            await self.receipt_repo.update_status(
+                receipt.id,
+                AgentReceiptStatus.failed,
+                str(e),
+            )
+            receipt = await self.receipt_repo.get_by_id(receipt.id)
+
+        return AgentReceiptResponse.from_orm_model(receipt)
+
+    async def get_receipt(self, receipt_id: UUID) -> AgentReceiptResponse:
+        """Get a receipt by ID."""
+        receipt = await self.receipt_repo.get_by_id(receipt_id)
+        if not receipt:
+            raise NotFoundError(f"Agent receipt {receipt_id} not found")
+        return AgentReceiptResponse.from_orm_model(receipt)
+
+    async def list_receipts(self, project_id: UUID) -> list[AgentReceiptListItem]:
+        """List receipts for a project."""
+        receipts = await self.receipt_repo.list_by_project(project_id)
+        return [AgentReceiptListItem.from_orm_model(r) for r in receipts]
+
+    async def submit_review(
+        self,
+        receipt_id: UUID,
+        action: str,
+        data: dict | None = None,
+    ) -> AgentReceiptResponse:
+        """Resume the graph with review decision."""
+        receipt = await self.receipt_repo.get_by_id(receipt_id)
+        if not receipt:
+            raise NotFoundError(f"Agent receipt {receipt_id} not found")
+
+        if receipt.status != AgentReceiptStatus.reviewing:
+            raise ValueError(f"Receipt {receipt_id} is not in reviewing status")
+
+        if not receipt.thread_id:
+            raise ValueError(f"Receipt {receipt_id} has no thread_id")
+
+        compiled = build_receipt_graph(checkpointer=self.checkpointer)
+        config = {"configurable": {"thread_id": receipt.thread_id}}
+
+        try:
+            # Resume graph with review decision
+            result = await compiled.ainvoke(
+                Command(resume={"action": action, "data": data}),
+                config=config,
+            )
+
+            if action == "reject":
+                await self.receipt_repo.update_status(
+                    receipt_id,
+                    AgentReceiptStatus.failed,
+                    "Rejected by reviewer",
+                )
+                receipt = await self.receipt_repo.get_by_id(receipt_id)
+            else:
+                # approve or edit — export_node ran
+                final_data = result.get("reviewed_data") or receipt.extracted_data
+                receipt = await self.receipt_repo.update_reviewed_data(
+                    receipt_id,
+                    reviewed_data=final_data,
+                    status=AgentReceiptStatus.exported,
+                )
+
+        except Exception as e:
+            logger.exception("Review submission failed for receipt %s", receipt_id)
+            await self.receipt_repo.update_status(
+                receipt_id,
+                AgentReceiptStatus.failed,
+                str(e),
+            )
+            receipt = await self.receipt_repo.get_by_id(receipt_id)
+
+        return AgentReceiptResponse.from_orm_model(receipt)

--- a/backend/app/services/agent/state.py
+++ b/backend/app/services/agent/state.py
@@ -1,0 +1,18 @@
+"""LangGraph state definition for the receipt processing pipeline."""
+from typing import TypedDict
+
+
+class AgentState(TypedDict, total=False):
+    """State passed through the receipt processing graph."""
+    receipt_id: str
+    document_id: str
+    file_path: str
+    extraction_schema_id: str
+    schema_definition: dict
+    extraction_config: dict
+    extracted_data: dict
+    review_action: str
+    reviewed_data: dict | None
+    exported: bool
+    error: str | None
+    current_step: str

--- a/backend/app/services/agent/types/__init__.py
+++ b/backend/app/services/agent/types/__init__.py
@@ -1,0 +1,47 @@
+"""Agent type registry — discovers and provides available agent types."""
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class AgentTypeDefinition:
+    """Metadata for a registered agent type."""
+    slug: str
+    name: str
+    description: str
+    nodes: list[dict[str, str]]  # [{"name": "extract", "label": "Extract Data"}, ...]
+    graph_builder: Callable  # (checkpointer) -> compiled graph
+    config_schema: dict[str, Any] = field(default_factory=dict)
+
+
+_registry: dict[str, AgentTypeDefinition] = {}
+
+
+def register_agent_type(definition: AgentTypeDefinition) -> None:
+    """Register an agent type in the global registry."""
+    _registry[definition.slug] = definition
+
+
+def get_agent_type(slug: str) -> AgentTypeDefinition | None:
+    """Get an agent type by slug."""
+    _ensure_loaded()
+    return _registry.get(slug)
+
+
+def list_agent_types() -> list[AgentTypeDefinition]:
+    """List all registered agent types."""
+    _ensure_loaded()
+    return list(_registry.values())
+
+
+_loaded = False
+
+
+def _ensure_loaded() -> None:
+    """Lazy-load agent type modules on first access."""
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+    # Import type modules to trigger registration
+    from app.services.agent.types import receipt_processing  # noqa: F401

--- a/backend/app/services/agent/types/receipt_processing/__init__.py
+++ b/backend/app/services/agent/types/receipt_processing/__init__.py
@@ -1,0 +1,17 @@
+"""Receipt processing agent type — extract → review → export pipeline."""
+from app.services.agent.graph import build_receipt_graph
+from app.services.agent.types import AgentTypeDefinition, register_agent_type
+
+definition = AgentTypeDefinition(
+    slug="receipt-processing",
+    name="Receipt Processing",
+    description="Extract structured data from receipt photos, review, and export",
+    nodes=[
+        {"name": "extract", "label": "Extract Data"},
+        {"name": "review", "label": "Human Review"},
+        {"name": "export", "label": "Export"},
+    ],
+    graph_builder=build_receipt_graph,
+)
+
+register_agent_type(definition)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -59,6 +59,12 @@ dependencies = [
     # -------------------------------------------------------------------------
     "rapidfuzz>=3.0.0", # Fuzzy string matching for field comparison
     "scipy>=1.11.0", # Hungarian algorithm for line item matching
+    # -------------------------------------------------------------------------
+    # Agent - LangGraph workflow orchestration
+    # -------------------------------------------------------------------------
+    "langgraph>=0.4.0", # StateGraph, nodes, edges, interrupt
+    "langgraph-checkpoint-postgres>=2.0.0", # AsyncPostgresSaver for graph state
+    "psycopg[binary]>=3.1.0", # PostgreSQL driver for langgraph checkpointer
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1202,6 +1202,77 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/44/a8df45d1e8b4637e29789fa8bae1db022c953cc7ac80093cfc52e923547e/langgraph_checkpoint-4.0.1.tar.gz", hash = "sha256:b433123735df11ade28829e40ce25b9be614930cd50245ff2af60629234befd9", size = 158135, upload-time = "2026-02-27T21:06:16.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/4c/09a4a0c42f5d2fc38d6c4d67884788eff7fd2cfdf367fdf7033de908b4c0/langgraph_checkpoint-4.0.1-py3-none-any.whl", hash = "sha256:e3adcd7a0e0166f3b48b8cf508ce0ea366e7420b5a73aa81289888727769b034", size = 50453, upload-time = "2026-02-27T21:06:14.293Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-postgres"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+    { name = "orjson" },
+    { name = "psycopg" },
+    { name = "psycopg-pool" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7a/8f439966643d32111248a225e6cb33a182d07c90de780c4dbfc1e0377832/langgraph_checkpoint_postgres-3.0.5.tar.gz", hash = "sha256:a8fd7278a63f4f849b5cbc7884a15ca8f41e7d5f7467d0a66b31e8c24492f7eb", size = 127856, upload-time = "2026-03-18T21:25:29.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/87/b0f98b33a67204bca9d5619bcd9574222f6b025cf3c125eedcec9a50ecbc/langgraph_checkpoint_postgres-3.0.5-py3-none-any.whl", hash = "sha256:86d7040a88fd70087eaafb72251d796696a0a2d856168f5c11ef620771411552", size = 42907, upload-time = "2026-03-18T21:25:28.75Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/db/77a45127dddcfea5e4256ba916182903e4c31dc4cfca305b8c386f0a9e53/langgraph_sdk-0.3.13.tar.gz", hash = "sha256:419ca5663eec3cec192ad194ac0647c0c826866b446073eb40f384f950986cd5", size = 196360, upload-time = "2026-04-07T20:34:18.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ef/64d64e9f8eea47ce7b939aa6da6863b674c8d418647813c20111645fcc62/langgraph_sdk-0.3.13-py3-none-any.whl", hash = "sha256:aee09e345c90775f6de9d6f4c7b847cfc652e49055c27a2aed0d981af2af3bd0", size = 96668, upload-time = "2026-04-07T20:34:17.866Z" },
+]
+
+[[package]]
 name = "langsmith"
 version = "0.6.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1996,6 +2067,45 @@ wheels = [
 ]
 
 [[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2261,6 +2371,76 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]
@@ -2594,6 +2774,8 @@ dependencies = [
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "langchain-text-splitters" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
     { name = "llama-cloud" },
     { name = "llama-index" },
     { name = "llama-index-readers-file" },
@@ -2607,6 +2789,7 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pgvector" },
     { name = "pillow" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pytesseract" },
@@ -2645,6 +2828,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "langchain-text-splitters", specifier = ">=0.0.1" },
+    { name = "langgraph", specifier = ">=0.4.0" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
     { name = "llama-cloud", specifier = ">=1.0.0" },
     { name = "llama-index", specifier = ">=0.10.0" },
     { name = "llama-index-readers-file", specifier = ">=0.1.0" },
@@ -2658,6 +2843,7 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.3.0" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytesseract", specifier = ">=0.3.10" },

--- a/docs/specs/agent-receipt-processing.md
+++ b/docs/specs/agent-receipt-processing.md
@@ -292,3 +292,84 @@ frontend/src/App.tsx                   # Add routes
 - Non-receipt document types (mpesa, bank statements — future)
 - File upload in Agent UI (uses existing Documents upload)
 - Receipt image preview in review UI (future enhancement)
+
+---
+
+## Future: Per-Project Agent Types & Registry
+
+### Motivation
+
+Different projects need different agent workflows:
+- **Personal Budget** project → receipt processing (extract → review → export)
+- **REIT Financial Analysis** project → financial research (research → analyze → review → report)
+- **Digital Ocean Analysis** project → its own flow
+
+The Agent page should show only the flows relevant to the current project. Adding a new flow means writing a new Python module — Claude Code writes and tests each one.
+
+### Design: Agent Types as Code Modules
+
+```
+backend/app/services/agent/types/
+  __init__.py                          # Registry — discovers available agent types
+  receipt_processing/
+    __init__.py                        # AgentTypeDefinition metadata
+    graph.py                           # StateGraph builder
+    nodes.py                           # Node functions
+    state.py                           # TypedDict state
+  financial_research/
+    __init__.py
+    graph.py
+    nodes.py
+    state.py
+```
+
+Each agent type module exports an `AgentTypeDefinition` with:
+- `slug`: unique identifier (e.g., `receipt-processing`)
+- `name`: display name
+- `description`: what this flow does
+- `graph_builder`: function that returns a compiled StateGraph
+- `node_descriptions`: ordered list of node names + labels for UI status display
+- `review_schema`: hints for what the review UI should render (JSON editor, form fields, etc.)
+
+### Data Model Changes
+
+**`agent_configs` table** — links projects to agent types:
+
+| Column | Type | Description |
+|---|---|---|
+| id | UUID | PK |
+| project_id | UUID | FK projects.id |
+| agent_type | VARCHAR | Slug matching a registered agent type |
+| config | JSON | Per-project config overrides (LLM model, prompts, etc.) |
+| enabled | BOOLEAN | Toggle without deleting |
+| created_at | TIMESTAMPTZ | |
+
+**`agent_runs` table** — generalizes `agent_receipts` for any agent type:
+
+| Column | Type | Description |
+|---|---|---|
+| id | UUID | PK |
+| project_id | UUID | FK |
+| agent_config_id | UUID | FK agent_configs.id |
+| status | enum | Pipeline status |
+| input_data | JSON | What was fed into the graph |
+| extracted_data | JSON | Output from processing nodes |
+| reviewed_data | JSON | Human-reviewed output |
+| thread_id | VARCHAR | LangGraph checkpointer thread |
+| created_by | UUID | FK |
+| created_at / updated_at | TIMESTAMPTZ | |
+
+### Frontend Changes
+
+- Agent page queries agent configs for current project
+- If no configs → shows "Configure an agent for this project" prompt
+- If configs exist → shows tabs/sections per enabled agent type
+- Each agent type can declare its own review component (or fall back to JSON editor)
+
+### Adding a New Agent Type (Developer Workflow)
+
+1. Create new directory under `services/agent/types/<slug>/`
+2. Define state, nodes, graph, and metadata
+3. Register in the type registry `__init__.py`
+4. Create an `agent_config` row linking it to a project
+5. The UI picks it up automatically

--- a/docs/specs/agent-receipt-processing.md
+++ b/docs/specs/agent-receipt-processing.md
@@ -1,0 +1,294 @@
+# LangGraph Agent — Receipt Processing Pipeline
+
+**Status:** Ready for Implementation
+**Date:** 2026-04-10
+**Scope:** LangGraph-based agent module for processing receipt photos through extract → human review → export pipeline
+
+---
+
+## Overview
+
+Add a new Agent module to rag-admin that uses LangGraph to orchestrate receipt photo processing. The agent runs a 3-node graph (extract → review → export) with a human-in-the-loop interrupt at the review step. This reuses the existing extraction infrastructure (DataExtractor port, LlamaExtract adapter, extraction schemas) and adds LangGraph for workflow orchestration and state management.
+
+The primary goal is to learn LangGraph patterns (StateGraph, interrupts, checkpointing) while building a production-style document processing pipeline. The receipts (~30 photos) are the test case, with future extensibility to mpesa statements, bank statements, etc.
+
+---
+
+## Architecture
+
+```
+User uploads receipt via Documents → Selects document + schema in Agent UI
+                                              ↓
+                                    POST /agent/projects/{id}/receipts
+                                              ↓
+                                    AgentService.start_processing()
+                                              ↓
+                                    LangGraph StateGraph invoked
+                                              ↓
+                            ┌─────────────────────────────────┐
+                            │  extract_node                   │
+                            │  (calls DataExtractor.extract()) │
+                            └──────────────┬──────────────────┘
+                                           ↓
+                            ┌─────────────────────────────────┐
+                            │  review_node                    │
+                            │  interrupt() → returns to API   │
+                            │  User reviews in UI             │
+                            │  POST .../review resumes graph  │
+                            └──────────────┬──────────────────┘
+                                           ↓
+                              ┌──────────┴──────────┐
+                              ↓                     ↓
+                         approve/edit             reject
+                              ↓                     ↓
+                    ┌──────────────────┐          END
+                    │  export_node     │
+                    │  saves to DB     │
+                    └────────┬─────────┘
+                             ↓
+                            END
+```
+
+### Reused Infrastructure
+
+| Component | Location | Usage |
+|---|---|---|
+| DataExtractor port | `app/ports/data_extraction.py` | Interface for extraction — called by extract_node |
+| LlamaExtract adapter | `app/adapters/extraction/llamaextract.py` | Handles OCR + structured extraction in MULTIMODAL mode |
+| Extractor registry | `app/adapters/extraction/registry.py` | `get_extractor("llamaextract")` |
+| ExtractionSchema model | `app/models/extraction_schema.py` | Stores receipt JSON schema definition |
+| StorageService | `app/ports/storage.py` | File path lookup for receipt images |
+| DocumentRepository | `app/repositories/document_repository.py` | Document metadata + file path |
+
+---
+
+## Dependencies
+
+| Package | Version | Purpose |
+|---|---|---|
+| `langgraph` | >=0.4.0 | StateGraph, nodes, edges, interrupt |
+| `langgraph-checkpoint-postgres` | >=2.0.0 | AsyncPostgresSaver for persisting graph state |
+
+No new frontend dependencies — uses existing shadcn/ui components.
+
+---
+
+## Data Model
+
+### `agent_receipts` table
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PK, default gen_random_uuid() | |
+| project_id | UUID | FK projects.id, CASCADE, NOT NULL | |
+| document_id | UUID | FK documents.id, CASCADE, NOT NULL | Receipt image document |
+| extraction_schema_id | UUID | FK extraction_schemas.id, NOT NULL | JSON schema used for extraction |
+| status | agent_receipt_status enum | NOT NULL, default 'pending' | Pipeline status |
+| status_message | TEXT | nullable | Error or info message |
+| extracted_data | JSON | nullable | Raw extraction output |
+| reviewed_data | JSON | nullable | Human-corrected data (null until review) |
+| thread_id | VARCHAR(64) | nullable, indexed | LangGraph thread for checkpointing |
+| created_by | UUID | FK users.id, NOT NULL | |
+| created_at | TIMESTAMPTZ | NOT NULL, default NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL, default NOW() | |
+
+### `AgentReceiptStatus` enum
+
+`pending` → `extracting` → `reviewing` → `approved` / `exported` / `failed`
+
+---
+
+## API Design
+
+### Start Processing
+
+```
+POST /api/v1/agent/projects/{project_id}/receipts
+Content-Type: application/json
+
+{
+  "documentId": "uuid",
+  "extractionSchemaId": "uuid"
+}
+```
+
+**Response 202:**
+```json
+{
+  "id": "uuid",
+  "projectId": "uuid",
+  "documentId": "uuid",
+  "extractionSchemaId": "uuid",
+  "status": "reviewing",
+  "extractedData": { "vendor": "Naivas", "total": 2450, ... },
+  "reviewedData": null,
+  "threadId": "uuid-string",
+  "createdAt": "2026-04-10T...",
+  "updatedAt": "2026-04-10T..."
+}
+```
+
+Note: The graph runs extract synchronously (may take 10-30s), then interrupts at review. The response comes back with status=reviewing and extracted_data populated.
+
+### List Receipts
+
+```
+GET /api/v1/agent/projects/{project_id}/receipts
+```
+
+**Response 200:** Array of `AgentReceiptListItem` (id, status, vendor, total, date, createdAt).
+
+### Get Receipt Detail
+
+```
+GET /api/v1/agent/receipts/{receipt_id}
+```
+
+**Response 200:** Full `AgentReceiptResponse`.
+
+### Submit Review
+
+```
+POST /api/v1/agent/receipts/{receipt_id}/review
+Content-Type: application/json
+
+{
+  "action": "approve" | "edit" | "reject",
+  "data": { ... }  // required if action is "edit"
+}
+```
+
+**Response 200:** Updated `AgentReceiptResponse` with status=exported (approve/edit) or status=failed (reject).
+
+---
+
+## LangGraph Graph Definition
+
+### State
+
+```python
+class AgentState(TypedDict, total=False):
+    receipt_id: str
+    document_id: str
+    file_path: str
+    extraction_schema_id: str
+    schema_definition: dict
+    extraction_config: dict
+    extracted_data: dict
+    review_action: str          # "approve", "edit", "reject"
+    reviewed_data: dict | None
+    exported: bool
+    error: str | None
+    current_step: str
+```
+
+### Nodes
+
+1. **extract_node** — calls `get_extractor("llamaextract").extract(file_path, schema_definition, config)`
+2. **review_node** — calls `interrupt(extracted_data)`, receives `{action, data}` on resume
+3. **export_node** — writes final data to AgentReceipt row
+
+### Edges
+
+```
+START → extract → review → conditional:
+  - approve/edit → export → END
+  - reject → END
+```
+
+### Checkpointer
+
+`AsyncPostgresSaver` from `langgraph-checkpoint-postgres`, using the existing PostgreSQL database. Connection string converted from `postgresql+asyncpg://` to `postgresql://` (psycopg format). Checkpoint tables created automatically via `setup()`.
+
+---
+
+## Frontend UX
+
+### Agent Page (`/agent`)
+
+Two-section layout:
+- **Top/Right:** Form to start processing — select document (dropdown), select extraction schema (dropdown), "Process" button
+- **Main:** Table of receipts with columns: Status (badge), Vendor, Total, Date, Created. Each row links to detail page.
+
+### Receipt Detail Page (`/agent/receipts/:id`)
+
+- **Status timeline** showing pipeline progress
+- **When status=reviewing:** Editable form with extracted fields + Approve / Edit & Approve / Reject buttons
+- **When status=exported:** Read-only view of final data
+- **When status=failed:** Error message display
+
+### Status Badges
+
+| Status | Color | Label |
+|---|---|---|
+| pending | gray | Pending |
+| extracting | blue | Extracting |
+| reviewing | amber | Needs Review |
+| approved | green | Approved |
+| exported | emerald | Exported |
+| failed | red | Failed |
+
+---
+
+## File Structure
+
+### Backend (new files)
+
+```
+backend/app/
+  models/agent_receipt.py              # Model + status enum
+  repositories/agent_receipt_repository.py  # CRUD
+  services/agent/
+    __init__.py
+    state.py                           # AgentState TypedDict
+    nodes.py                           # extract, review, export nodes
+    graph.py                           # StateGraph builder
+    checkpointer.py                    # AsyncPostgresSaver singleton
+    service.py                         # AgentService
+  schemas/agent.py                     # Pydantic request/response
+  routers/agent.py                     # API endpoints
+```
+
+### Backend (modified files)
+
+```
+backend/pyproject.toml                 # Add langgraph deps
+backend/app/models/__init__.py         # Register model
+backend/app/main.py                    # Register router + init checkpointer
+backend/alembic/versions/...          # Migration
+```
+
+### Frontend (new files)
+
+```
+frontend/src/
+  types/agent.ts
+  api/agent.ts
+  hooks/useAgentReceipts.ts
+  hooks/useAgentReceipt.ts
+  components/agent/
+    ReceiptProcessForm.tsx
+    ReceiptList.tsx
+    ReceiptReviewForm.tsx
+    ReceiptDetail.tsx
+    StatusBadge.tsx
+  pages/AgentPage.tsx
+  pages/AgentReceiptPage.tsx
+```
+
+### Frontend (modified files)
+
+```
+frontend/src/config/navigation.ts      # Add Agent nav item
+frontend/src/App.tsx                   # Add routes
+```
+
+---
+
+## Out of Scope
+
+- Natural language query/analysis layer (future milestone)
+- Batch processing of multiple receipts
+- Non-receipt document types (mpesa, bank statements — future)
+- File upload in Agent UI (uses existing Documents upload)
+- Receipt image preview in review UI (future enhancement)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@xyflow/react": "^12.10.2",
         "axios": "^1.6.5",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
@@ -4246,6 +4247,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -4670,6 +4720,38 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -5182,6 +5264,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -5395,6 +5483,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -11255,6 +11448,34 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
       "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
       "license": "MIT"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@xyflow/react": "^12.10.2",
     "axios": "^1.6.5",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,8 @@ import EvalResultDetailPage from './pages/EvalResultDetailPage'
 import RunComparisonPage from './pages/RunComparisonPage'
 import ExperimentDetailPage from './pages/ExperimentDetailPage'
 import ExtractionPage from './pages/ExtractionPage'
+import AgentPage from './pages/AgentPage'
+import AgentReceiptPage from './pages/AgentReceiptPage'
 
 const router = createBrowserRouter([
   {
@@ -88,6 +90,16 @@ const router = createBrowserRouter([
             path: 'extraction',
             element: <ExtractionPage />,
             handle: { breadcrumb: 'Extraction' },
+          },
+          {
+            path: 'agent',
+            element: <AgentPage />,
+            handle: { breadcrumb: 'Agent' },
+          },
+          {
+            path: 'agent/receipts/:receiptId',
+            element: <AgentReceiptPage />,
+            handle: { breadcrumb: 'Receipt Detail' },
           },
 {
             path: 'evaluation',

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -1,0 +1,47 @@
+import apiClient from './client'
+import type {
+  AgentReceipt,
+  AgentReceiptListItem,
+  StartProcessingRequest,
+  SubmitReviewRequest,
+} from '@/types/agent'
+
+export async function startProcessing(
+  projectId: string,
+  data: StartProcessingRequest
+): Promise<AgentReceipt> {
+  const response = await apiClient.post<AgentReceipt>(
+    `/agent/projects/${projectId}/receipts`,
+    data
+  )
+  return response.data
+}
+
+export async function listReceipts(
+  projectId: string
+): Promise<AgentReceiptListItem[]> {
+  const response = await apiClient.get<AgentReceiptListItem[]>(
+    `/agent/projects/${projectId}/receipts`
+  )
+  return response.data
+}
+
+export async function getReceipt(
+  receiptId: string
+): Promise<AgentReceipt> {
+  const response = await apiClient.get<AgentReceipt>(
+    `/agent/receipts/${receiptId}`
+  )
+  return response.data
+}
+
+export async function submitReview(
+  receiptId: string,
+  data: SubmitReviewRequest
+): Promise<AgentReceipt> {
+  const response = await apiClient.post<AgentReceipt>(
+    `/agent/receipts/${receiptId}/review`,
+    data
+  )
+  return response.data
+}

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -1,10 +1,50 @@
 import apiClient from './client'
 import type {
+  AgentType,
+  AgentConfig,
+  AgentConfigCreate,
   AgentReceipt,
   AgentReceiptListItem,
   StartProcessingRequest,
   SubmitReviewRequest,
 } from '@/types/agent'
+
+// --- Agent Types ---
+
+export async function listAgentTypes(): Promise<AgentType[]> {
+  const response = await apiClient.get<AgentType[]>('/agent/types')
+  return response.data
+}
+
+// --- Agent Configs ---
+
+export async function listAgentConfigs(
+  projectId: string
+): Promise<AgentConfig[]> {
+  const response = await apiClient.get<AgentConfig[]>(
+    `/agent/projects/${projectId}/configs`
+  )
+  return response.data
+}
+
+export async function createAgentConfig(
+  projectId: string,
+  data: AgentConfigCreate
+): Promise<AgentConfig> {
+  const response = await apiClient.post<AgentConfig>(
+    `/agent/projects/${projectId}/configs`,
+    data
+  )
+  return response.data
+}
+
+export async function deleteAgentConfig(
+  configId: string
+): Promise<void> {
+  await apiClient.delete(`/agent/configs/${configId}`)
+}
+
+// --- Receipt Processing ---
 
 export async function startProcessing(
   projectId: string,

--- a/frontend/src/components/agent/AgentFlowGraph.tsx
+++ b/frontend/src/components/agent/AgentFlowGraph.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react'
+import {
+  ReactFlow,
+  Background,
+  type Node,
+  type Edge,
+  Position,
+  MarkerType,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import type { AgentReceiptStatus } from '@/types/agent'
+
+interface AgentFlowGraphProps {
+  nodes: { name: string; label: string }[]
+  currentStep?: string | null
+  status?: AgentReceiptStatus | null
+  height?: number
+}
+
+type NodeStatus = 'completed' | 'active' | 'pending' | 'failed'
+
+function getNodeStatus(
+  _nodeName: string,
+  nodeIndex: number,
+  nodes: { name: string }[],
+  currentStep: string | null,
+  status: AgentReceiptStatus | null
+): NodeStatus {
+  if (!status || !currentStep) return 'pending'
+  if (status === 'failed') {
+    const currentIndex = nodes.findIndex((n) => n.name === currentStep)
+    if (nodeIndex < currentIndex) return 'completed'
+    if (nodeIndex === currentIndex) return 'failed'
+    return 'pending'
+  }
+
+  // Map receipt status to which step is "current"
+  const statusToStep: Record<string, string> = {
+    pending: '',
+    extracting: 'extract',
+    reviewing: 'review',
+    approved: 'export',
+    exported: 'export',
+  }
+  const activeStep = statusToStep[status] || currentStep
+  const activeIndex = nodes.findIndex((n) => n.name === activeStep)
+
+  if (status === 'exported' || status === 'approved') return 'completed'
+  if (nodeIndex < activeIndex) return 'completed'
+  if (nodeIndex === activeIndex) return 'active'
+  return 'pending'
+}
+
+const statusColors: Record<NodeStatus, { bg: string; border: string; text: string }> = {
+  completed: { bg: 'bg-emerald-50', border: 'border-emerald-400', text: 'text-emerald-700' },
+  active: { bg: 'bg-blue-50', border: 'border-blue-400', text: 'text-blue-700' },
+  pending: { bg: 'bg-gray-50', border: 'border-gray-200', text: 'text-gray-400' },
+  failed: { bg: 'bg-red-50', border: 'border-red-400', text: 'text-red-700' },
+}
+
+const statusIcons: Record<NodeStatus, string> = {
+  completed: '✓',
+  active: '●',
+  pending: '○',
+  failed: '✕',
+}
+
+function FlowNode({ data }: { data: { label: string; nodeStatus: NodeStatus } }) {
+  const colors = statusColors[data.nodeStatus]
+  const icon = statusIcons[data.nodeStatus]
+  return (
+    <div
+      className={`px-4 py-3 rounded-lg border-2 ${colors.bg} ${colors.border} min-w-[140px] text-center shadow-sm`}
+    >
+      <div className={`text-xs font-mono mb-1 ${colors.text}`}>{icon}</div>
+      <div className={`text-sm font-medium ${colors.text}`}>{data.label}</div>
+    </div>
+  )
+}
+
+const nodeTypes = { flowNode: FlowNode }
+
+export function AgentFlowGraph({
+  nodes: graphNodes,
+  currentStep = null,
+  status = null,
+  height = 120,
+}: AgentFlowGraphProps) {
+  const { nodes, edges } = useMemo(() => {
+    const NODE_WIDTH = 160
+    const NODE_SPACING = 80
+    const totalWidth = graphNodes.length * NODE_WIDTH + (graphNodes.length - 1) * NODE_SPACING
+    const startX = -totalWidth / 2 + NODE_WIDTH / 2
+
+    const rfNodes: Node[] = graphNodes.map((node, i) => ({
+      id: node.name,
+      type: 'flowNode',
+      position: { x: startX + i * (NODE_WIDTH + NODE_SPACING), y: 0 },
+      data: {
+        label: node.label,
+        nodeStatus: getNodeStatus(node.name, i, graphNodes, currentStep, status),
+      },
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+    }))
+
+    const rfEdges: Edge[] = graphNodes.slice(0, -1).map((node, i) => {
+      const sourceStatus = getNodeStatus(node.name, i, graphNodes, currentStep, status)
+      const isActive = sourceStatus === 'completed' || sourceStatus === 'active'
+      return {
+        id: `${node.name}-${graphNodes[i + 1].name}`,
+        source: node.name,
+        target: graphNodes[i + 1].name,
+        type: 'default',
+        animated: sourceStatus === 'active',
+        style: {
+          stroke: isActive ? '#10b981' : '#d1d5db',
+          strokeWidth: 2,
+        },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          color: isActive ? '#10b981' : '#d1d5db',
+        },
+      }
+    })
+
+    return { nodes: rfNodes, edges: rfEdges }
+  }, [graphNodes, currentStep, status])
+
+  return (
+    <div style={{ height }} className="w-full rounded-lg border bg-white">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.3 }}
+        proOptions={{ hideAttribution: true }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        panOnDrag={false}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        zoomOnDoubleClick={false}
+      >
+        <Background gap={16} size={1} color="#f1f5f9" />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/frontend/src/components/agent/AgentSetup.tsx
+++ b/frontend/src/components/agent/AgentSetup.tsx
@@ -1,0 +1,103 @@
+import { Button } from '@/components/ui/button'
+import { Plus, Trash2, Bot } from 'lucide-react'
+import type { AgentType, AgentConfig } from '@/types/agent'
+
+interface AgentSetupProps {
+  agentTypes: AgentType[]
+  configs?: AgentConfig[]
+  onEnable: (agentType: string) => Promise<void>
+  onRemove?: (configId: string) => Promise<void>
+}
+
+export function AgentSetup({
+  agentTypes,
+  configs = [],
+  onEnable,
+  onRemove,
+}: AgentSetupProps) {
+  const enabledSlugs = new Set(configs.map((c) => c.agentType))
+  const availableTypes = agentTypes.filter((t) => !enabledSlugs.has(t.slug))
+
+  return (
+    <div className="space-y-4">
+      {/* Enabled agents */}
+      {configs.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium">Enabled Agents</h2>
+          {configs.map((config) => {
+            const agentType = agentTypes.find((t) => t.slug === config.agentType)
+            return (
+              <div
+                key={config.id}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="flex items-center gap-3">
+                  <Bot className="h-4 w-4 text-muted-foreground" />
+                  <div>
+                    <p className="text-sm font-medium">
+                      {agentType?.name || config.agentType}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {agentType?.description}
+                    </p>
+                  </div>
+                </div>
+                {onRemove && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onRemove(config.id)}
+                  >
+                    <Trash2 className="h-4 w-4 text-muted-foreground" />
+                  </Button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Available to add */}
+      {availableTypes.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium">
+            {configs.length === 0
+              ? 'No agents configured for this project'
+              : 'Add More Agents'}
+          </h2>
+          {configs.length === 0 && (
+            <p className="text-sm text-muted-foreground mb-3">
+              Enable an agent type to get started with automated workflows.
+            </p>
+          )}
+          {availableTypes.map((agentType) => (
+            <div
+              key={agentType.slug}
+              className="flex items-center justify-between rounded-lg border border-dashed p-3"
+            >
+              <div className="flex items-center gap-3">
+                <Bot className="h-4 w-4 text-muted-foreground/50" />
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground">
+                    {agentType.name}
+                  </p>
+                  <p className="text-xs text-muted-foreground/70">
+                    {agentType.description}
+                  </p>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onEnable(agentType.slug)}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Enable
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/agent/AgentSetup.tsx
+++ b/frontend/src/components/agent/AgentSetup.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { AgentFlowGraph } from './AgentFlowGraph'
 import { Plus, Trash2, Bot } from 'lucide-react'
 import type { AgentType, AgentConfig } from '@/types/agent'
 
@@ -22,34 +23,36 @@ export function AgentSetup({
     <div className="space-y-4">
       {/* Enabled agents */}
       {configs.length > 0 && (
-        <div className="space-y-2">
+        <div className="space-y-3">
           <h2 className="text-sm font-medium">Enabled Agents</h2>
           {configs.map((config) => {
             const agentType = agentTypes.find((t) => t.slug === config.agentType)
             return (
-              <div
-                key={config.id}
-                className="flex items-center justify-between rounded-lg border p-3"
-              >
-                <div className="flex items-center gap-3">
-                  <Bot className="h-4 w-4 text-muted-foreground" />
-                  <div>
-                    <p className="text-sm font-medium">
-                      {agentType?.name || config.agentType}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {agentType?.description}
-                    </p>
+              <div key={config.id} className="rounded-lg border p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <Bot className="h-4 w-4 text-muted-foreground" />
+                    <div>
+                      <p className="text-sm font-medium">
+                        {agentType?.name || config.agentType}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {agentType?.description}
+                      </p>
+                    </div>
                   </div>
+                  {onRemove && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onRemove(config.id)}
+                    >
+                      <Trash2 className="h-4 w-4 text-muted-foreground" />
+                    </Button>
+                  )}
                 </div>
-                {onRemove && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onRemove(config.id)}
-                  >
-                    <Trash2 className="h-4 w-4 text-muted-foreground" />
-                  </Button>
+                {agentType && (
+                  <AgentFlowGraph nodes={agentType.nodes} height={100} />
                 )}
               </div>
             )
@@ -71,29 +74,29 @@ export function AgentSetup({
             </p>
           )}
           {availableTypes.map((agentType) => (
-            <div
-              key={agentType.slug}
-              className="flex items-center justify-between rounded-lg border border-dashed p-3"
-            >
-              <div className="flex items-center gap-3">
-                <Bot className="h-4 w-4 text-muted-foreground/50" />
-                <div>
-                  <p className="text-sm font-medium text-muted-foreground">
-                    {agentType.name}
-                  </p>
-                  <p className="text-xs text-muted-foreground/70">
-                    {agentType.description}
-                  </p>
+            <div key={agentType.slug} className="rounded-lg border border-dashed p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Bot className="h-4 w-4 text-muted-foreground/50" />
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">
+                      {agentType.name}
+                    </p>
+                    <p className="text-xs text-muted-foreground/70">
+                      {agentType.description}
+                    </p>
+                  </div>
                 </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onEnable(agentType.slug)}
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  Enable
+                </Button>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onEnable(agentType.slug)}
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                Enable
-              </Button>
+              <AgentFlowGraph nodes={agentType.nodes} height={100} />
             </div>
           ))}
         </div>

--- a/frontend/src/components/agent/ReceiptDetail.tsx
+++ b/frontend/src/components/agent/ReceiptDetail.tsx
@@ -1,9 +1,16 @@
 import { StatusBadge } from './StatusBadge'
+import { AgentFlowGraph } from './AgentFlowGraph'
 import { ReceiptReviewForm } from './ReceiptReviewForm'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Loader2 } from 'lucide-react'
 import type { AgentReceipt, SubmitReviewRequest } from '@/types/agent'
+
+const RECEIPT_NODES = [
+  { name: 'extract', label: 'Extract Data' },
+  { name: 'review', label: 'Human Review' },
+  { name: 'export', label: 'Export' },
+]
 
 interface ReceiptDetailProps {
   receipt: AgentReceipt | null
@@ -54,6 +61,18 @@ export function ReceiptDetail({
           })}
         </span>
       </div>
+
+      {/* Flow visualization */}
+      <AgentFlowGraph
+        nodes={RECEIPT_NODES}
+        status={receipt.status}
+        currentStep={
+          receipt.status === 'extracting' ? 'extract' :
+          receipt.status === 'reviewing' ? 'review' :
+          receipt.status === 'exported' || receipt.status === 'approved' ? 'export' :
+          receipt.status === 'failed' ? 'review' : null
+        }
+      />
 
       {error && (
         <Alert variant="destructive">

--- a/frontend/src/components/agent/ReceiptDetail.tsx
+++ b/frontend/src/components/agent/ReceiptDetail.tsx
@@ -1,0 +1,109 @@
+import { StatusBadge } from './StatusBadge'
+import { ReceiptReviewForm } from './ReceiptReviewForm'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Loader2 } from 'lucide-react'
+import type { AgentReceipt, SubmitReviewRequest } from '@/types/agent'
+
+interface ReceiptDetailProps {
+  receipt: AgentReceipt | null
+  isLoading: boolean
+  isSubmitting: boolean
+  error: string | null
+  onSubmitReview: (request: SubmitReviewRequest) => Promise<void>
+}
+
+export function ReceiptDetail({
+  receipt,
+  isLoading,
+  isSubmitting,
+  error,
+  onSubmitReview,
+}: ReceiptDetailProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (!receipt) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Receipt not found.</AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <StatusBadge status={receipt.status} />
+        <span className="text-sm text-muted-foreground">
+          Created{' '}
+          {new Date(receipt.createdAt).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          })}
+        </span>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Status-specific content */}
+      {(receipt.status === 'pending' || receipt.status === 'extracting') && (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
+          <p className="text-sm text-muted-foreground">
+            {receipt.status === 'pending'
+              ? 'Waiting to start extraction...'
+              : 'Extracting data from receipt...'}
+          </p>
+          <p className="text-xs text-muted-foreground/70 mt-1">
+            This may take 10-30 seconds
+          </p>
+        </div>
+      )}
+
+      {receipt.status === 'reviewing' && receipt.extractedData && (
+        <ReceiptReviewForm
+          extractedData={receipt.extractedData}
+          isSubmitting={isSubmitting}
+          onSubmit={onSubmitReview}
+        />
+      )}
+
+      {(receipt.status === 'approved' || receipt.status === 'exported') && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium">Final Data</h3>
+          <pre className="rounded-lg border bg-muted/50 p-4 text-sm font-mono overflow-auto max-h-[400px]">
+            {JSON.stringify(
+              receipt.reviewedData || receipt.extractedData,
+              null,
+              2
+            )}
+          </pre>
+        </div>
+      )}
+
+      {receipt.status === 'failed' && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {receipt.statusMessage || 'Processing failed.'}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/agent/ReceiptList.tsx
+++ b/frontend/src/components/agent/ReceiptList.tsx
@@ -1,0 +1,86 @@
+import { useNavigate } from 'react-router-dom'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Skeleton } from '@/components/ui/skeleton'
+import { StatusBadge } from './StatusBadge'
+import type { AgentReceiptListItem } from '@/types/agent'
+
+interface ReceiptListProps {
+  receipts: AgentReceiptListItem[]
+  isLoading: boolean
+}
+
+function extractField(data: Record<string, unknown> | null, field: string): string {
+  if (!data) return '—'
+  const value = data[field]
+  if (value === null || value === undefined) return '—'
+  return String(value)
+}
+
+export function ReceiptList({ receipts, isLoading }: ReceiptListProps) {
+  const navigate = useNavigate()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (receipts.length === 0) {
+    return (
+      <div className="text-center py-8 text-sm text-muted-foreground">
+        No receipts processed yet. Use the form above to start processing.
+      </div>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Status</TableHead>
+          <TableHead>Vendor</TableHead>
+          <TableHead className="text-right">Total</TableHead>
+          <TableHead>Date</TableHead>
+          <TableHead>Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {receipts.map((receipt) => (
+          <TableRow
+            key={receipt.id}
+            className="cursor-pointer hover:bg-muted/50"
+            onClick={() => navigate(`/agent/receipts/${receipt.id}`)}
+          >
+            <TableCell>
+              <StatusBadge status={receipt.status} />
+            </TableCell>
+            <TableCell>{extractField(receipt.extractedData, 'vendor')}</TableCell>
+            <TableCell className="text-right">
+              {extractField(receipt.extractedData, 'total')}
+            </TableCell>
+            <TableCell>{extractField(receipt.extractedData, 'date')}</TableCell>
+            <TableCell className="text-muted-foreground text-sm">
+              {new Date(receipt.createdAt).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/src/components/agent/ReceiptProcessForm.tsx
+++ b/frontend/src/components/agent/ReceiptProcessForm.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Loader2 } from 'lucide-react'
+import type { DocumentListItem } from '@/types/document'
+import type { ExtractionSchema } from '@/types/extraction'
+import type { StartProcessingRequest } from '@/types/agent'
+
+interface ReceiptProcessFormProps {
+  documents: DocumentListItem[]
+  schemas: ExtractionSchema[]
+  isProcessing: boolean
+  onProcess: (request: StartProcessingRequest) => Promise<void>
+}
+
+export function ReceiptProcessForm({
+  documents,
+  schemas,
+  isProcessing,
+  onProcess,
+}: ReceiptProcessFormProps) {
+  const [documentId, setDocumentId] = useState<string>('')
+  const [schemaId, setSchemaId] = useState<string>('')
+
+  const readyDocuments = documents.filter((d) => d.status === 'ready')
+  const canSubmit = documentId && schemaId && !isProcessing
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return
+    await onProcess({
+      documentId,
+      extractionSchemaId: schemaId,
+    })
+    setDocumentId('')
+    setSchemaId('')
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Document</label>
+          <Select value={documentId} onValueChange={setDocumentId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a document..." />
+            </SelectTrigger>
+            <SelectContent>
+              {readyDocuments.map((doc) => (
+                <SelectItem key={doc.id} value={doc.id}>
+                  {doc.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Extraction Schema</label>
+          <Select value={schemaId} onValueChange={setSchemaId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a schema..." />
+            </SelectTrigger>
+            <SelectContent>
+              {schemas.map((schema) => (
+                <SelectItem key={schema.id} value={schema.id}>
+                  {schema.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <Button onClick={handleSubmit} disabled={!canSubmit} size="sm">
+        {isProcessing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        Process Receipt
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/agent/ReceiptReviewForm.tsx
+++ b/frontend/src/components/agent/ReceiptReviewForm.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Loader2, Check, Pencil, X } from 'lucide-react'
+import type { SubmitReviewRequest } from '@/types/agent'
+
+interface ReceiptReviewFormProps {
+  extractedData: Record<string, unknown>
+  isSubmitting: boolean
+  onSubmit: (request: SubmitReviewRequest) => Promise<void>
+}
+
+export function ReceiptReviewForm({
+  extractedData,
+  isSubmitting,
+  onSubmit,
+}: ReceiptReviewFormProps) {
+  const [editedJson, setEditedJson] = useState(
+    JSON.stringify(extractedData, null, 2)
+  )
+  const [isEditing, setIsEditing] = useState(false)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  const handleApprove = async () => {
+    await onSubmit({ action: 'approve' })
+  }
+
+  const handleEditApprove = async () => {
+    setParseError(null)
+    try {
+      const parsed = JSON.parse(editedJson)
+      await onSubmit({ action: 'edit', data: parsed })
+    } catch {
+      setParseError('Invalid JSON')
+    }
+  }
+
+  const handleReject = async () => {
+    await onSubmit({ action: 'reject' })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Extracted Data</h3>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsEditing(!isEditing)}
+          >
+            <Pencil className="h-3.5 w-3.5 mr-1" />
+            {isEditing ? 'Preview' : 'Edit'}
+          </Button>
+        </div>
+
+        {isEditing ? (
+          <div className="space-y-1">
+            <Textarea
+              value={editedJson}
+              onChange={(e) => {
+                setEditedJson(e.target.value)
+                setParseError(null)
+              }}
+              className="font-mono text-sm min-h-[300px]"
+            />
+            {parseError && (
+              <p className="text-xs text-destructive">{parseError}</p>
+            )}
+          </div>
+        ) : (
+          <pre className="rounded-lg border bg-muted/50 p-4 text-sm font-mono overflow-auto max-h-[400px]">
+            {JSON.stringify(extractedData, null, 2)}
+          </pre>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 pt-2">
+        <Button onClick={handleApprove} disabled={isSubmitting} size="sm">
+          {isSubmitting ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="mr-2 h-4 w-4" />
+          )}
+          Approve
+        </Button>
+
+        {isEditing && (
+          <Button
+            onClick={handleEditApprove}
+            disabled={isSubmitting}
+            size="sm"
+            variant="secondary"
+          >
+            {isSubmitting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Pencil className="mr-2 h-4 w-4" />
+            )}
+            Edit & Approve
+          </Button>
+        )}
+
+        <Button
+          onClick={handleReject}
+          disabled={isSubmitting}
+          size="sm"
+          variant="destructive"
+        >
+          <X className="mr-2 h-4 w-4" />
+          Reject
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/agent/StatusBadge.tsx
+++ b/frontend/src/components/agent/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from '@/components/ui/badge'
+import type { AgentReceiptStatus } from '@/types/agent'
+
+const statusConfig: Record<
+  AgentReceiptStatus,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline'; className: string }
+> = {
+  pending: { label: 'Pending', variant: 'secondary', className: 'bg-gray-100 text-gray-700' },
+  extracting: { label: 'Extracting', variant: 'secondary', className: 'bg-blue-100 text-blue-700' },
+  reviewing: { label: 'Needs Review', variant: 'default', className: 'bg-amber-100 text-amber-700' },
+  approved: { label: 'Approved', variant: 'default', className: 'bg-green-100 text-green-700' },
+  exported: { label: 'Exported', variant: 'default', className: 'bg-emerald-100 text-emerald-700' },
+  failed: { label: 'Failed', variant: 'destructive', className: '' },
+}
+
+interface StatusBadgeProps {
+  status: AgentReceiptStatus
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const config = statusConfig[status]
+  return (
+    <Badge variant={config.variant} className={config.className}>
+      {config.label}
+    </Badge>
+  )
+}

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, FolderKanban, FileText, Database, BarChart3, Settings, FileSearch } from 'lucide-react'
+import { LayoutDashboard, FolderKanban, FileText, Database, BarChart3, Settings, FileSearch, Bot } from 'lucide-react'
 
 export const navigationItems = [
   { label: 'Dashboard', href: '/', icon: LayoutDashboard, activeColor: 'border-l-primary' },
@@ -7,5 +7,6 @@ export const navigationItems = [
   { label: 'Index', href: '/index', icon: Database, activeColor: 'border-l-teal-500' },
   { label: 'Extraction', href: '/extraction', icon: FileSearch, activeColor: 'border-l-orange-500' },
   { label: 'Evaluation', href: '/evaluation', icon: BarChart3, activeColor: 'border-l-amber-500' },
+  { label: 'Agent', href: '/agent', icon: Bot, activeColor: 'border-l-purple-500' },
   { label: 'Settings', href: '/settings', icon: Settings, activeColor: 'border-l-gray-400' },
 ] as const

--- a/frontend/src/hooks/useAgentConfigs.ts
+++ b/frontend/src/hooks/useAgentConfigs.ts
@@ -1,0 +1,82 @@
+import { useState, useCallback, useEffect } from 'react'
+import type { AgentType, AgentConfig, AgentConfigCreate } from '@/types/agent'
+import * as agentApi from '@/api/agent'
+
+interface UseAgentConfigsReturn {
+  agentTypes: AgentType[]
+  configs: AgentConfig[]
+  isLoading: boolean
+  error: string | null
+  fetchConfigs: () => Promise<void>
+  enableAgentType: (data: AgentConfigCreate) => Promise<AgentConfig>
+  removeConfig: (configId: string) => Promise<void>
+}
+
+export function useAgentConfigs(
+  projectId: string | null
+): UseAgentConfigsReturn {
+  const [agentTypes, setAgentTypes] = useState<AgentType[]>([])
+  const [configs, setConfigs] = useState<AgentConfig[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchConfigs = useCallback(async () => {
+    if (!projectId) {
+      setConfigs([])
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    try {
+      const [typesData, configsData] = await Promise.all([
+        agentApi.listAgentTypes(),
+        agentApi.listAgentConfigs(projectId),
+      ])
+      setAgentTypes(typesData)
+      setConfigs(configsData)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch agent configs'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [projectId])
+
+  const enableAgentType = useCallback(
+    async (data: AgentConfigCreate): Promise<AgentConfig> => {
+      if (!projectId) throw new Error('No project selected')
+      const config = await agentApi.createAgentConfig(projectId, data)
+      await fetchConfigs()
+      return config
+    },
+    [projectId, fetchConfigs]
+  )
+
+  const removeConfig = useCallback(
+    async (configId: string): Promise<void> => {
+      await agentApi.deleteAgentConfig(configId)
+      await fetchConfigs()
+    },
+    [fetchConfigs]
+  )
+
+  useEffect(() => {
+    if (projectId) {
+      fetchConfigs()
+    } else {
+      setConfigs([])
+      setAgentTypes([])
+    }
+  }, [projectId, fetchConfigs])
+
+  return {
+    agentTypes,
+    configs,
+    isLoading,
+    error,
+    fetchConfigs,
+    enableAgentType,
+    removeConfig,
+  }
+}

--- a/frontend/src/hooks/useAgentReceipt.ts
+++ b/frontend/src/hooks/useAgentReceipt.ts
@@ -1,0 +1,127 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type { AgentReceipt, SubmitReviewRequest } from '@/types/agent'
+import * as agentApi from '@/api/agent'
+
+interface UseAgentReceiptReturn {
+  receipt: AgentReceipt | null
+  isLoading: boolean
+  isSubmitting: boolean
+  error: string | null
+  fetchReceipt: () => Promise<void>
+  submitReview: (request: SubmitReviewRequest) => Promise<AgentReceipt>
+}
+
+const POLLING_INTERVAL = 3000
+const POLLING_TIMEOUT = 10 * 60 * 1000
+
+export function useAgentReceipt(
+  receiptId: string | null
+): UseAgentReceiptReturn {
+  const [receipt, setReceipt] = useState<AgentReceipt | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<NodeJS.Timeout | null>(null)
+  const pollingStartRef = useRef<number | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+    pollingStartRef.current = null
+  }, [])
+
+  const fetchReceipt = useCallback(async () => {
+    if (!receiptId) {
+      setReceipt(null)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await agentApi.getReceipt(receiptId)
+      setReceipt(data)
+
+      const isActive =
+        data.status === 'pending' || data.status === 'extracting'
+      if (isActive && !pollingRef.current) {
+        pollingStartRef.current = Date.now()
+        pollingRef.current = setInterval(async () => {
+          if (
+            pollingStartRef.current &&
+            Date.now() - pollingStartRef.current > POLLING_TIMEOUT
+          ) {
+            stopPolling()
+            return
+          }
+          try {
+            const updated = await agentApi.getReceipt(receiptId)
+            setReceipt(updated)
+            const stillActive =
+              updated.status === 'pending' || updated.status === 'extracting'
+            if (!stillActive) {
+              stopPolling()
+            }
+          } catch {
+            stopPolling()
+          }
+        }, POLLING_INTERVAL)
+      } else if (!isActive) {
+        stopPolling()
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch receipt'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [receiptId, stopPolling])
+
+  const submitReview = useCallback(
+    async (request: SubmitReviewRequest): Promise<AgentReceipt> => {
+      if (!receiptId) throw new Error('No receipt selected')
+      setIsSubmitting(true)
+      setError(null)
+      try {
+        const result = await agentApi.submitReview(receiptId, request)
+        setReceipt(result)
+        stopPolling()
+        return result
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to submit review'
+        setError(message)
+        throw err
+      } finally {
+        setIsSubmitting(false)
+      }
+    },
+    [receiptId, stopPolling]
+  )
+
+  useEffect(() => {
+    if (receiptId) {
+      fetchReceipt()
+    } else {
+      setReceipt(null)
+    }
+  }, [receiptId, fetchReceipt])
+
+  useEffect(() => {
+    return () => {
+      stopPolling()
+    }
+  }, [stopPolling])
+
+  return {
+    receipt,
+    isLoading,
+    isSubmitting,
+    error,
+    fetchReceipt,
+    submitReview,
+  }
+}

--- a/frontend/src/hooks/useAgentReceipts.ts
+++ b/frontend/src/hooks/useAgentReceipts.ts
@@ -1,0 +1,132 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type {
+  AgentReceipt,
+  AgentReceiptListItem,
+  StartProcessingRequest,
+} from '@/types/agent'
+import * as agentApi from '@/api/agent'
+
+interface UseAgentReceiptsReturn {
+  receipts: AgentReceiptListItem[]
+  isLoading: boolean
+  isProcessing: boolean
+  error: string | null
+  fetchReceipts: () => Promise<void>
+  startProcessing: (request: StartProcessingRequest) => Promise<AgentReceipt>
+}
+
+const POLLING_INTERVAL = 3000
+const POLLING_TIMEOUT = 10 * 60 * 1000
+
+export function useAgentReceipts(
+  projectId: string | null
+): UseAgentReceiptsReturn {
+  const [receipts, setReceipts] = useState<AgentReceiptListItem[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<NodeJS.Timeout | null>(null)
+  const pollingStartRef = useRef<number | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+    pollingStartRef.current = null
+  }, [])
+
+  const fetchReceipts = useCallback(async () => {
+    if (!projectId) {
+      setReceipts([])
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await agentApi.listReceipts(projectId)
+      setReceipts(data)
+
+      const hasActive = data.some(
+        (r) => r.status === 'pending' || r.status === 'extracting'
+      )
+      if (hasActive && !pollingRef.current) {
+        pollingStartRef.current = Date.now()
+        pollingRef.current = setInterval(async () => {
+          if (
+            pollingStartRef.current &&
+            Date.now() - pollingStartRef.current > POLLING_TIMEOUT
+          ) {
+            stopPolling()
+            return
+          }
+          try {
+            const updated = await agentApi.listReceipts(projectId)
+            setReceipts(updated)
+            const stillActive = updated.some(
+              (r) => r.status === 'pending' || r.status === 'extracting'
+            )
+            if (!stillActive) {
+              stopPolling()
+            }
+          } catch {
+            stopPolling()
+          }
+        }, POLLING_INTERVAL)
+      } else if (!hasActive) {
+        stopPolling()
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch receipts'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [projectId, stopPolling])
+
+  const startProcessing = useCallback(
+    async (request: StartProcessingRequest): Promise<AgentReceipt> => {
+      if (!projectId) throw new Error('No project selected')
+      setIsProcessing(true)
+      setError(null)
+      try {
+        const result = await agentApi.startProcessing(projectId, request)
+        await fetchReceipts()
+        return result
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to start processing'
+        setError(message)
+        throw err
+      } finally {
+        setIsProcessing(false)
+      }
+    },
+    [projectId, fetchReceipts]
+  )
+
+  useEffect(() => {
+    if (projectId) {
+      fetchReceipts()
+    } else {
+      setReceipts([])
+    }
+  }, [projectId, fetchReceipts])
+
+  useEffect(() => {
+    return () => {
+      stopPolling()
+    }
+  }, [stopPolling])
+
+  return {
+    receipts,
+    isLoading,
+    isProcessing,
+    error,
+    fetchReceipts,
+    startProcessing,
+  }
+}

--- a/frontend/src/pages/AgentPage.tsx
+++ b/frontend/src/pages/AgentPage.tsx
@@ -1,0 +1,96 @@
+import { useProject } from '@/contexts/ProjectContext'
+import { useDocuments } from '@/hooks/useDocuments'
+import { useExtractionSchemas } from '@/hooks/useExtractionSchemas'
+import { useAgentReceipts } from '@/hooks/useAgentReceipts'
+import { ReceiptProcessForm } from '@/components/agent/ReceiptProcessForm'
+import { ReceiptList } from '@/components/agent/ReceiptList'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Separator } from '@/components/ui/separator'
+import { Bot } from 'lucide-react'
+import { toast } from 'sonner'
+import type { StartProcessingRequest } from '@/types/agent'
+
+export default function AgentPage(): JSX.Element {
+  const { currentProject } = useProject()
+  const projectId = currentProject?.id || null
+
+  const { documents, isLoading: documentsLoading } = useDocuments(projectId)
+  const { schemas } = useExtractionSchemas(projectId)
+  const {
+    receipts,
+    isLoading: receiptsLoading,
+    isProcessing,
+    error,
+    startProcessing,
+  } = useAgentReceipts(projectId)
+
+  const handleProcess = async (request: StartProcessingRequest) => {
+    try {
+      await startProcessing(request)
+      toast.success('Processing started', {
+        description: 'Extracting data from receipt...',
+      })
+    } catch (err) {
+      toast.error('Processing failed', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
+  }
+
+  if (!currentProject) {
+    return (
+      <div className="space-y-6">
+        <Alert>
+          <AlertDescription>Loading project...</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-2">
+          <Bot className="h-5 w-5" />
+          <h1 className="text-lg font-semibold">Agent</h1>
+        </div>
+        <p className="text-sm text-muted-foreground mt-1">
+          Process receipts through the extract → review → export pipeline
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Process form */}
+      <div className="rounded-lg border p-4">
+        <h2 className="text-sm font-medium mb-3">Process New Receipt</h2>
+        <ReceiptProcessForm
+          documents={documents}
+          schemas={schemas}
+          isProcessing={isProcessing || documentsLoading}
+          onProcess={handleProcess}
+        />
+      </div>
+
+      <Separator />
+
+      {/* Receipt list */}
+      <div>
+        <h2 className="text-sm font-medium mb-3">
+          Processed Receipts
+          {receipts.length > 0 && (
+            <span className="text-muted-foreground font-normal ml-1.5">
+              ({receipts.length})
+            </span>
+          )}
+        </h2>
+        <ReceiptList receipts={receipts} isLoading={receiptsLoading} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AgentPage.tsx
+++ b/frontend/src/pages/AgentPage.tsx
@@ -2,10 +2,13 @@ import { useProject } from '@/contexts/ProjectContext'
 import { useDocuments } from '@/hooks/useDocuments'
 import { useExtractionSchemas } from '@/hooks/useExtractionSchemas'
 import { useAgentReceipts } from '@/hooks/useAgentReceipts'
+import { useAgentConfigs } from '@/hooks/useAgentConfigs'
 import { ReceiptProcessForm } from '@/components/agent/ReceiptProcessForm'
 import { ReceiptList } from '@/components/agent/ReceiptList'
+import { AgentSetup } from '@/components/agent/AgentSetup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Bot } from 'lucide-react'
 import { toast } from 'sonner'
 import type { StartProcessingRequest } from '@/types/agent'
@@ -14,15 +17,28 @@ export default function AgentPage(): JSX.Element {
   const { currentProject } = useProject()
   const projectId = currentProject?.id || null
 
+  const {
+    agentTypes,
+    configs,
+    isLoading: configsLoading,
+    error: configsError,
+    enableAgentType,
+    removeConfig,
+  } = useAgentConfigs(projectId)
+
+  const hasReceiptProcessing = configs.some(
+    (c) => c.agentType === 'receipt-processing' && c.enabled
+  )
+
   const { documents, isLoading: documentsLoading } = useDocuments(projectId)
   const { schemas } = useExtractionSchemas(projectId)
   const {
     receipts,
     isLoading: receiptsLoading,
     isProcessing,
-    error,
+    error: receiptsError,
     startProcessing,
-  } = useAgentReceipts(projectId)
+  } = useAgentReceipts(hasReceiptProcessing ? projectId : null)
 
   const handleProcess = async (request: StartProcessingRequest) => {
     try {
@@ -32,6 +48,28 @@ export default function AgentPage(): JSX.Element {
       })
     } catch (err) {
       toast.error('Processing failed', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
+  }
+
+  const handleEnableAgent = async (agentType: string) => {
+    try {
+      await enableAgentType({ agentType })
+      toast.success('Agent enabled')
+    } catch (err) {
+      toast.error('Failed to enable agent', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
+  }
+
+  const handleRemoveAgent = async (configId: string) => {
+    try {
+      await removeConfig(configId)
+      toast.success('Agent removed')
+    } catch (err) {
+      toast.error('Failed to remove agent', {
         description: err instanceof Error ? err.message : 'An error occurred',
       })
     }
@@ -47,6 +85,8 @@ export default function AgentPage(): JSX.Element {
     )
   }
 
+  const error = configsError || receiptsError
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -56,7 +96,7 @@ export default function AgentPage(): JSX.Element {
           <h1 className="text-lg font-semibold">Agent</h1>
         </div>
         <p className="text-sm text-muted-foreground mt-1">
-          Process receipts through the extract → review → export pipeline
+          Configure and run agent workflows for {currentProject.name}
         </p>
       </div>
 
@@ -66,31 +106,60 @@ export default function AgentPage(): JSX.Element {
         </Alert>
       )}
 
-      {/* Process form */}
-      <div className="rounded-lg border p-4">
-        <h2 className="text-sm font-medium mb-3">Process New Receipt</h2>
-        <ReceiptProcessForm
-          documents={documents}
-          schemas={schemas}
-          isProcessing={isProcessing || documentsLoading}
-          onProcess={handleProcess}
+      {configsLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : configs.length === 0 ? (
+        /* No agents configured — show setup */
+        <AgentSetup
+          agentTypes={agentTypes}
+          onEnable={handleEnableAgent}
         />
-      </div>
+      ) : (
+        /* Show configured agents */
+        <div className="space-y-6">
+          {/* Agent config management */}
+          <AgentSetup
+            agentTypes={agentTypes}
+            configs={configs}
+            onEnable={handleEnableAgent}
+            onRemove={handleRemoveAgent}
+          />
 
-      <Separator />
+          {/* Receipt processing flow */}
+          {hasReceiptProcessing && (
+            <>
+              <Separator />
 
-      {/* Receipt list */}
-      <div>
-        <h2 className="text-sm font-medium mb-3">
-          Processed Receipts
-          {receipts.length > 0 && (
-            <span className="text-muted-foreground font-normal ml-1.5">
-              ({receipts.length})
-            </span>
+              <div className="rounded-lg border p-4">
+                <h2 className="text-sm font-medium mb-3">Process New Receipt</h2>
+                <ReceiptProcessForm
+                  documents={documents}
+                  schemas={schemas}
+                  isProcessing={isProcessing || documentsLoading}
+                  onProcess={handleProcess}
+                />
+              </div>
+
+              <Separator />
+
+              <div>
+                <h2 className="text-sm font-medium mb-3">
+                  Processed Receipts
+                  {receipts.length > 0 && (
+                    <span className="text-muted-foreground font-normal ml-1.5">
+                      ({receipts.length})
+                    </span>
+                  )}
+                </h2>
+                <ReceiptList receipts={receipts} isLoading={receiptsLoading} />
+              </div>
+            </>
           )}
-        </h2>
-        <ReceiptList receipts={receipts} isLoading={receiptsLoading} />
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/AgentReceiptPage.tsx
+++ b/frontend/src/pages/AgentReceiptPage.tsx
@@ -1,0 +1,55 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useAgentReceipt } from '@/hooks/useAgentReceipt'
+import { ReceiptDetail } from '@/components/agent/ReceiptDetail'
+import { Button } from '@/components/ui/button'
+import { ArrowLeft } from 'lucide-react'
+import { toast } from 'sonner'
+import type { SubmitReviewRequest } from '@/types/agent'
+
+export default function AgentReceiptPage(): JSX.Element {
+  const { receiptId } = useParams<{ receiptId: string }>()
+  const navigate = useNavigate()
+  const { receipt, isLoading, isSubmitting, error, submitReview } =
+    useAgentReceipt(receiptId || null)
+
+  const handleSubmitReview = async (request: SubmitReviewRequest) => {
+    try {
+      await submitReview(request)
+      if (request.action === 'reject') {
+        toast.info('Receipt rejected')
+      } else {
+        toast.success('Receipt approved and exported')
+      }
+    } catch (err) {
+      toast.error('Review submission failed', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+      throw err
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/agent')}
+          className="mb-2"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Agent
+        </Button>
+        <h1 className="text-lg font-semibold">Receipt Detail</h1>
+      </div>
+
+      <ReceiptDetail
+        receipt={receipt}
+        isLoading={isLoading}
+        isSubmitting={isSubmitting}
+        error={error}
+        onSubmitReview={handleSubmitReview}
+      />
+    </div>
+  )
+}

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -1,3 +1,31 @@
+// --- Agent Types & Configs ---
+
+export interface AgentType {
+  slug: string
+  name: string
+  description: string
+  nodes: { name: string; label: string }[]
+  configSchema: Record<string, unknown>
+}
+
+export interface AgentConfig {
+  id: string
+  projectId: string
+  agentType: string
+  config: Record<string, unknown> | null
+  enabled: boolean
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AgentConfigCreate {
+  agentType: string
+  config?: Record<string, unknown>
+}
+
+// --- Receipt Processing ---
+
 export type AgentReceiptStatus =
   | 'pending'
   | 'extracting'

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -1,0 +1,41 @@
+export type AgentReceiptStatus =
+  | 'pending'
+  | 'extracting'
+  | 'reviewing'
+  | 'approved'
+  | 'exported'
+  | 'failed'
+
+export interface AgentReceipt {
+  id: string
+  projectId: string
+  documentId: string
+  extractionSchemaId: string
+  status: AgentReceiptStatus
+  statusMessage: string | null
+  extractedData: Record<string, unknown> | null
+  reviewedData: Record<string, unknown> | null
+  threadId: string | null
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AgentReceiptListItem {
+  id: string
+  documentId: string
+  status: AgentReceiptStatus
+  statusMessage: string | null
+  extractedData: Record<string, unknown> | null
+  createdAt: string
+}
+
+export interface StartProcessingRequest {
+  documentId: string
+  extractionSchemaId: string
+}
+
+export interface SubmitReviewRequest {
+  action: 'approve' | 'edit' | 'reject'
+  data?: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary
- Adds a new **Agent** module using LangGraph to orchestrate receipt photo processing through an **extract → human review → export** pipeline
- Reuses existing extraction infrastructure (DataExtractor, LlamaExtract, extraction schemas) with LangGraph for workflow orchestration and human-in-the-loop via `interrupt()`
- Full-stack implementation: backend (model, migration, repository, LangGraph service, schemas, router) + frontend (types, API, hooks, components, pages, routes, nav)

## Backend
- `AgentReceipt` model with 6-status enum (pending → extracting → reviewing → approved/exported/failed)
- LangGraph `StateGraph` with 3 nodes: extract → review (interrupt) → export, conditional edges for approve/reject
- `AsyncPostgresSaver` checkpointer for persisting graph state to existing Postgres
- 4 API endpoints: `POST` start processing, `GET` list, `GET` detail, `POST` submit review
- Dependencies: `langgraph`, `langgraph-checkpoint-postgres`, `psycopg[binary]`

## Frontend
- Agent page (`/agent`) with process form (document + schema selectors) and receipt list table
- Receipt detail page (`/agent/receipts/:id`) with status-dependent views (extracting spinner, review form, read-only export, error)
- Review form with editable JSON, Approve / Edit & Approve / Reject actions
- Status badges with color coding per status
- Polling hooks for active receipts
- Bot icon nav item in sidebar

## Test plan
- [ ] Run `uv sync --extra dev` and verify langgraph deps install
- [ ] Run alembic migration: `alembic upgrade head`
- [ ] Backend tests pass: `pytest tests/ -o "addopts="` (328 passed)
- [ ] Frontend builds: `npm run build` (clean)
- [ ] TypeScript: `npx tsc --noEmit` (clean)
- [ ] Manual: Upload receipt → Agent page → Select doc + schema → Process → Review → Approve → Verify exported data
- [ ] Manual: Test reject flow → receipt shows failed status
- [ ] Manual: Test edit & approve flow → corrected data saved

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)