### PR TITLE
feat: generic flow execution engine

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -17,6 +17,7 @@ from app.models import (
     AgentReceipt,
     AgentConfig,
     FlowDefinition,
+    FlowRun,
 )
 
 config = context.config

--- a/backend/alembic/versions/23528140ed0b_add_flow_runs_table.py
+++ b/backend/alembic/versions/23528140ed0b_add_flow_runs_table.py
@@ -1,0 +1,64 @@
+"""add_flow_runs_table
+
+Revision ID: 23528140ed0b
+Revises: 1bd1c32cd72c
+Create Date: 2026-04-11 11:24:55.731039
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = '23528140ed0b'
+down_revision: Union[str, None] = '1bd1c32cd72c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'flow_run_status') THEN
+                CREATE TYPE flow_run_status AS ENUM (
+                    'pending', 'running', 'waiting_for_input', 'completed', 'failed'
+                );
+            END IF;
+        END
+        $$;
+    """)
+
+    op.create_table('flow_runs',
+        sa.Column('id', sa.UUID(), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('project_id', sa.UUID(), nullable=False),
+        sa.Column('flow_definition_id', sa.UUID(), nullable=False),
+        sa.Column('status', postgresql.ENUM('pending', 'running', 'waiting_for_input', 'completed', 'failed', name='flow_run_status', create_type=False), server_default='pending', nullable=False),
+        sa.Column('status_message', sa.Text(), nullable=True),
+        sa.Column('initial_state', sa.JSON(), nullable=True),
+        sa.Column('current_state', sa.JSON(), nullable=True),
+        sa.Column('current_node', sa.String(length=255), nullable=True),
+        sa.Column('thread_id', sa.String(length=64), nullable=True),
+        sa.Column('created_by', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id']),
+        sa.ForeignKeyConstraint(['flow_definition_id'], ['flow_definitions.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_flow_runs_project_id', 'flow_runs', ['project_id'], unique=False)
+    op.create_index('ix_flow_runs_status', 'flow_runs', ['status'], unique=False)
+    op.create_index('ix_flow_runs_flow_definition_id', 'flow_runs', ['flow_definition_id'], unique=False)
+    op.create_index('ix_flow_runs_thread_id', 'flow_runs', ['thread_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_flow_runs_thread_id', table_name='flow_runs')
+    op.drop_index('ix_flow_runs_flow_definition_id', table_name='flow_runs')
+    op.drop_index('ix_flow_runs_status', table_name='flow_runs')
+    op.drop_index('ix_flow_runs_project_id', table_name='flow_runs')
+    op.drop_table('flow_runs')
+    op.execute("DROP TYPE IF EXISTS flow_run_status")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.extraction_eval import ExtractionEvalRun, ExtractionEvalRunStatu
 from app.models.agent_receipt import AgentReceipt, AgentReceiptStatus
 from app.models.agent_config import AgentConfig
 from app.models.flow_definition import FlowDefinition
+from app.models.flow_run import FlowRun, FlowRunStatus
 
 __all__ = [
     "User",
@@ -63,4 +64,6 @@ __all__ = [
     "AgentReceiptStatus",
     "AgentConfig",
     "FlowDefinition",
+    "FlowRun",
+    "FlowRunStatus",
 ]

--- a/backend/app/models/flow_run.py
+++ b/backend/app/models/flow_run.py
@@ -1,0 +1,83 @@
+"""Model for generic flow execution runs."""
+import enum
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, JSON
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class FlowRunStatus(str, enum.Enum):
+    """Status of a flow run."""
+    pending = "pending"
+    running = "running"
+    waiting_for_input = "waiting_for_input"
+    completed = "completed"
+    failed = "failed"
+
+
+class FlowRun(Base):
+    """A single execution of a flow definition."""
+    __tablename__ = "flow_runs"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=sa.text('gen_random_uuid()')
+    )
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False
+    )
+    flow_definition_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("flow_definitions.id", ondelete="CASCADE"),
+        nullable=False
+    )
+    status: Mapped[FlowRunStatus] = mapped_column(
+        Enum(FlowRunStatus, name='flow_run_status', create_type=False),
+        nullable=False,
+        default=FlowRunStatus.pending,
+        server_default='pending'
+    )
+    status_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    initial_state: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    current_state: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    current_node: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    thread_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_by: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+        server_default=sa.text('NOW()')
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default=sa.text('NOW()')
+    )
+
+    # Relationships
+    project: Mapped["Project"] = relationship()
+    flow_definition: Mapped["FlowDefinition"] = relationship()
+    user: Mapped["User"] = relationship()
+
+    __table_args__ = (
+        sa.Index('ix_flow_runs_project_id', 'project_id'),
+        sa.Index('ix_flow_runs_status', 'status'),
+        sa.Index('ix_flow_runs_flow_definition_id', 'flow_definition_id'),
+        sa.Index('ix_flow_runs_thread_id', 'thread_id'),
+    )

--- a/backend/app/repositories/flow_run_repository.py
+++ b/backend/app/repositories/flow_run_repository.py
@@ -97,3 +97,12 @@ class FlowRunRepository:
         await self.session.commit()
         await self.session.refresh(run)
         return run
+
+    async def delete(self, run_id: UUID) -> bool:
+        """Delete a flow run."""
+        run = await self.get_by_id(run_id)
+        if not run:
+            return False
+        await self.session.delete(run)
+        await self.session.commit()
+        return True

--- a/backend/app/repositories/flow_run_repository.py
+++ b/backend/app/repositories/flow_run_repository.py
@@ -1,0 +1,99 @@
+"""Repository for flow run data access."""
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.flow_run import FlowRun, FlowRunStatus
+
+
+class FlowRunRepository:
+    """Repository for flow run CRUD operations."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(
+        self,
+        project_id: UUID,
+        flow_definition_id: UUID,
+        created_by: UUID,
+        initial_state: dict | None = None,
+    ) -> FlowRun:
+        """Create a new flow run."""
+        obj = FlowRun(
+            project_id=project_id,
+            flow_definition_id=flow_definition_id,
+            initial_state=initial_state,
+            created_by=created_by,
+        )
+        self.session.add(obj)
+        await self.session.commit()
+        await self.session.refresh(obj)
+        return obj
+
+    async def get_by_id(self, run_id: UUID) -> FlowRun | None:
+        """Get a flow run by ID."""
+        result = await self.session.execute(
+            select(FlowRun).where(FlowRun.id == run_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_project(self, project_id: UUID) -> list[FlowRun]:
+        """List flow runs for a project."""
+        result = await self.session.execute(
+            select(FlowRun)
+            .where(FlowRun.project_id == project_id)
+            .order_by(FlowRun.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def list_by_flow(self, flow_definition_id: UUID) -> list[FlowRun]:
+        """List flow runs for a specific flow definition."""
+        result = await self.session.execute(
+            select(FlowRun)
+            .where(FlowRun.flow_definition_id == flow_definition_id)
+            .order_by(FlowRun.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def update_status(
+        self,
+        run_id: UUID,
+        status: FlowRunStatus,
+        status_message: str | None = None,
+    ) -> FlowRun | None:
+        """Update run status and optional message."""
+        run = await self.get_by_id(run_id)
+        if not run:
+            return None
+        run.status = status
+        if status_message is not None:
+            run.status_message = status_message
+        await self.session.commit()
+        await self.session.refresh(run)
+        return run
+
+    async def update_state(
+        self,
+        run_id: UUID,
+        current_state: dict | None,
+        current_node: str | None,
+        status: FlowRunStatus,
+        thread_id: str | None = None,
+        status_message: str | None = None,
+    ) -> FlowRun | None:
+        """Update run state after graph invocation."""
+        run = await self.get_by_id(run_id)
+        if not run:
+            return None
+        run.current_state = current_state
+        run.current_node = current_node
+        run.status = status
+        if thread_id is not None:
+            run.thread_id = thread_id
+        if status_message is not None:
+            run.status_message = status_message
+        await self.session.commit()
+        await self.session.refresh(run)
+        return run

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -218,14 +218,28 @@ async def create_flow(
     current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ):
+    from sqlalchemy.exc import IntegrityError
+
     repo = FlowDefinitionRepository(db)
-    flow = await repo.create(
-        project_id=project_id,
-        name=body.name,
-        description=body.description,
-        definition=body.definition,
-        created_by=current_user.id,
-    )
+    try:
+        flow = await repo.create(
+            project_id=project_id,
+            name=body.name,
+            description=body.description,
+            definition=body.definition,
+            created_by=current_user.id,
+        )
+    except IntegrityError as e:
+        error_str = str(e).lower()
+        if 'uq_flow_definitions_project_name' in error_str:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"A flow named '{body.name}' already exists in this project",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to create flow definition",
+        )
     return FlowDefinitionResponse.from_orm_model(flow)
 
 
@@ -257,13 +271,27 @@ async def update_flow(
     current_user: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ):
+    from sqlalchemy.exc import IntegrityError
+
     repo = FlowDefinitionRepository(db)
-    flow = await repo.update(
-        flow_id=flow_id,
-        name=body.name,
-        description=body.description,
-        definition=body.definition,
-    )
+    try:
+        flow = await repo.update(
+            flow_id=flow_id,
+            name=body.name,
+            description=body.description,
+            definition=body.definition,
+        )
+    except IntegrityError as e:
+        error_str = str(e).lower()
+        if 'uq_flow_definitions_project_name' in error_str:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"A flow named '{body.name}' already exists in this project",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update flow definition",
+        )
     if not flow:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flow not found")
     return FlowDefinitionResponse.from_orm_model(flow)

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -12,6 +12,7 @@ from app.repositories.agent_receipt_repository import AgentReceiptRepository
 from app.repositories.document_repository import DocumentRepository
 from app.repositories.extraction_schema_repository import ExtractionSchemaRepository
 from app.repositories.flow_definition_repository import FlowDefinitionRepository
+from app.repositories.flow_run_repository import FlowRunRepository
 from app.schemas.agent import (
     AgentToolResponse,
     AgentTypeResponse,
@@ -20,11 +21,16 @@ from app.schemas.agent import (
     FlowDefinitionCreate,
     FlowDefinitionUpdate,
     FlowDefinitionResponse,
+    StartFlowRunRequest,
+    ResumeFlowRunRequest,
+    FlowRunResponse,
+    FlowRunListItem,
     StartProcessingRequest,
     SubmitReviewRequest,
     AgentReceiptResponse,
     AgentReceiptListItem,
 )
+from app.services.agent.flow_run_service import FlowRunService
 from app.services.agent.service import AgentService
 from app.services.agent.tools import list_tools
 from app.services.agent.types import list_agent_types, get_agent_type
@@ -275,6 +281,98 @@ async def delete_flow(
     deleted = await repo.delete(flow_id)
     if not deleted:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flow not found")
+
+
+# --- Flow Runs ---
+
+def get_flow_run_service(
+    db: AsyncSession = Depends(get_db),
+) -> FlowRunService:
+    """Dependency to create FlowRunService with checkpointer from app state."""
+    from app.main import app
+    checkpointer = app.state.agent_checkpointer
+
+    return FlowRunService(
+        flow_run_repo=FlowRunRepository(db),
+        flow_def_repo=FlowDefinitionRepository(db),
+        checkpointer=checkpointer,
+    )
+
+
+@router.post(
+    "/agent/projects/{project_id}/runs",
+    response_model=FlowRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start a flow run",
+)
+async def start_flow_run(
+    project_id: UUID,
+    body: StartFlowRunRequest,
+    current_user: User = Depends(get_current_active_user),
+    service: FlowRunService = Depends(get_flow_run_service),
+):
+    try:
+        return await service.start_run(
+            project_id=project_id,
+            flow_definition_id=body.flow_definition_id,
+            initial_state=body.initial_state,
+            user_id=current_user.id,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get(
+    "/agent/projects/{project_id}/runs",
+    response_model=list[FlowRunListItem],
+    summary="List flow runs for a project",
+)
+async def list_flow_runs(
+    project_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: FlowRunService = Depends(get_flow_run_service),
+):
+    return await service.list_runs(project_id)
+
+
+@router.get(
+    "/agent/runs/{run_id}",
+    response_model=FlowRunResponse,
+    summary="Get a flow run",
+)
+async def get_flow_run(
+    run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: FlowRunService = Depends(get_flow_run_service),
+):
+    try:
+        return await service.get_run(run_id)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.post(
+    "/agent/runs/{run_id}/resume",
+    response_model=FlowRunResponse,
+    summary="Resume an interrupted flow run",
+)
+async def resume_flow_run(
+    run_id: UUID,
+    body: ResumeFlowRunRequest,
+    current_user: User = Depends(get_current_active_user),
+    service: FlowRunService = Depends(get_flow_run_service),
+):
+    try:
+        return await service.resume_run(
+            run_id=run_id,
+            resume_value=body.resume_value,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 # --- Receipt Processing ---

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -21,6 +21,7 @@ from app.schemas.agent import (
     FlowDefinitionCreate,
     FlowDefinitionUpdate,
     FlowDefinitionResponse,
+    StartExtractRunRequest,
     StartFlowRunRequest,
     ResumeFlowRunRequest,
     FlowRunResponse,
@@ -30,6 +31,7 @@ from app.schemas.agent import (
     AgentReceiptResponse,
     AgentReceiptListItem,
 )
+from app.services.agent.extract_run_service import ExtractRunService
 from app.services.agent.flow_run_service import FlowRunService
 from app.services.agent.service import AgentService
 from app.services.agent.tools import list_tools
@@ -299,6 +301,18 @@ def get_flow_run_service(
     )
 
 
+def get_extract_run_service(
+    db: AsyncSession = Depends(get_db),
+    flow_run_service: FlowRunService = Depends(get_flow_run_service),
+) -> ExtractRunService:
+    """Dependency to create ExtractRunService."""
+    return ExtractRunService(
+        flow_run_service=flow_run_service,
+        document_repo=DocumentRepository(db),
+        schema_repo=ExtractionSchemaRepository(db),
+    )
+
+
 @router.post(
     "/agent/projects/{project_id}/runs",
     response_model=FlowRunResponse,
@@ -368,6 +382,50 @@ async def resume_flow_run(
         return await service.resume_run(
             run_id=run_id,
             resume_value=body.resume_value,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.delete(
+    "/agent/runs/{run_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a flow run",
+)
+async def delete_flow_run(
+    run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    repo = FlowRunRepository(db)
+    deleted = await repo.delete(run_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found")
+
+
+# --- Extract Runs ---
+
+@router.post(
+    "/agent/extract/projects/{project_id}/runs",
+    response_model=FlowRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start an extract flow run",
+)
+async def start_extract_run(
+    project_id: UUID,
+    body: StartExtractRunRequest,
+    current_user: User = Depends(get_current_active_user),
+    service: ExtractRunService = Depends(get_extract_run_service),
+):
+    try:
+        return await service.start_extract_run(
+            project_id=project_id,
+            flow_definition_id=body.flow_definition_id,
+            document_id=body.document_id,
+            extraction_schema_id=body.extraction_schema_id,
+            user_id=current_user.id,
         )
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.agent_receipt import AgentReceiptStatus
+from app.models.flow_run import FlowRunStatus
 
 
 # --- Agent Tool schemas ---
@@ -213,5 +214,80 @@ class AgentReceiptListItem(BaseModel):
             status=obj.status,
             statusMessage=obj.status_message,
             extractedData=obj.extracted_data,
+            createdAt=obj.created_at,
+        )
+
+
+# --- Flow Run schemas ---
+
+class StartFlowRunRequest(BaseModel):
+    """Request to start a flow run."""
+    flow_definition_id: UUID = Field(..., alias="flowDefinitionId")
+    initial_state: dict[str, Any] = Field(default_factory=dict, alias="initialState")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ResumeFlowRunRequest(BaseModel):
+    """Request to resume an interrupted flow run."""
+    resume_value: dict[str, Any] = Field(..., alias="resumeValue")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class FlowRunResponse(BaseModel):
+    """Full flow run response."""
+    id: UUID
+    project_id: UUID = Field(..., alias="projectId")
+    flow_definition_id: UUID = Field(..., alias="flowDefinitionId")
+    status: FlowRunStatus
+    status_message: str | None = Field(None, alias="statusMessage")
+    initial_state: dict[str, Any] | None = Field(None, alias="initialState")
+    current_state: dict[str, Any] | None = Field(None, alias="currentState")
+    current_node: str | None = Field(None, alias="currentNode")
+    thread_id: str | None = Field(None, alias="threadId")
+    created_by: UUID = Field(..., alias="createdBy")
+    created_at: datetime = Field(..., alias="createdAt")
+    updated_at: datetime = Field(..., alias="updatedAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_model(cls, obj) -> "FlowRunResponse":
+        return cls(
+            id=obj.id,
+            projectId=obj.project_id,
+            flowDefinitionId=obj.flow_definition_id,
+            status=obj.status,
+            statusMessage=obj.status_message,
+            initialState=obj.initial_state,
+            currentState=obj.current_state,
+            currentNode=obj.current_node,
+            threadId=obj.thread_id,
+            createdBy=obj.created_by,
+            createdAt=obj.created_at,
+            updatedAt=obj.updated_at,
+        )
+
+
+class FlowRunListItem(BaseModel):
+    """Summary flow run for list endpoint."""
+    id: UUID
+    flow_definition_id: UUID = Field(..., alias="flowDefinitionId")
+    status: FlowRunStatus
+    status_message: str | None = Field(None, alias="statusMessage")
+    current_node: str | None = Field(None, alias="currentNode")
+    created_at: datetime = Field(..., alias="createdAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_model(cls, obj) -> "FlowRunListItem":
+        return cls(
+            id=obj.id,
+            flowDefinitionId=obj.flow_definition_id,
+            status=obj.status,
+            statusMessage=obj.status_message,
+            currentNode=obj.current_node,
             createdAt=obj.created_at,
         )

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -220,6 +220,15 @@ class AgentReceiptListItem(BaseModel):
 
 # --- Flow Run schemas ---
 
+class StartExtractRunRequest(BaseModel):
+    """Request to start an extract flow run."""
+    flow_definition_id: UUID = Field(..., alias="flowDefinitionId")
+    document_id: UUID = Field(..., alias="documentId")
+    extraction_schema_id: UUID = Field(..., alias="extractionSchemaId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class StartFlowRunRequest(BaseModel):
     """Request to start a flow run."""
     flow_definition_id: UUID = Field(..., alias="flowDefinitionId")

--- a/backend/app/services/agent/extract_run_service.py
+++ b/backend/app/services/agent/extract_run_service.py
@@ -1,0 +1,65 @@
+"""Extract run service — resolves document/schema inputs and delegates to FlowRunService."""
+import logging
+from uuid import UUID
+
+from app.repositories.document_repository import DocumentRepository
+from app.repositories.extraction_schema_repository import ExtractionSchemaRepository
+from app.schemas.agent import FlowRunResponse
+from app.services.agent.flow_run_service import FlowRunService
+from app.services.exceptions import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class ExtractRunService:
+    """Thin service that resolves extraction-specific inputs into a generic initial state."""
+
+    def __init__(
+        self,
+        flow_run_service: FlowRunService,
+        document_repo: DocumentRepository,
+        schema_repo: ExtractionSchemaRepository,
+    ):
+        self.flow_run_service = flow_run_service
+        self.document_repo = document_repo
+        self.schema_repo = schema_repo
+
+    async def start_extract_run(
+        self,
+        project_id: UUID,
+        flow_definition_id: UUID,
+        document_id: UUID,
+        extraction_schema_id: UUID,
+        user_id: UUID,
+    ) -> FlowRunResponse:
+        """Resolve document + schema into initial state and start a flow run."""
+        # Validate and resolve document
+        document = await self.document_repo.get_by_id_unscoped(document_id)
+        if not document:
+            raise NotFoundError(f"Document {document_id} not found")
+
+        file_path = document.source_metadata.get("file_path")
+        if not file_path:
+            raise NotFoundError("Document has no file path")
+
+        # Validate and resolve schema
+        schema = await self.schema_repo.get_by_id(extraction_schema_id)
+        if not schema:
+            raise NotFoundError(f"Extraction schema {extraction_schema_id} not found")
+
+        # Build initial state
+        initial_state = {
+            "document_id": str(document_id),
+            "file_path": file_path,
+            "extraction_schema_id": str(extraction_schema_id),
+            "schema_definition": schema.schema_definition,
+            "extraction_config": {},
+            "current_step": "extract",
+        }
+
+        return await self.flow_run_service.start_run(
+            project_id=project_id,
+            flow_definition_id=flow_definition_id,
+            initial_state=initial_state,
+            user_id=user_id,
+        )

--- a/backend/app/services/agent/flow_run_service.py
+++ b/backend/app/services/agent/flow_run_service.py
@@ -1,4 +1,5 @@
 """Flow run service — generic execution engine for composed flows."""
+import json
 import logging
 from uuid import UUID, uuid4
 
@@ -14,6 +15,24 @@ from app.services.agent.state import GenericFlowState
 from app.services.exceptions import NotFoundError
 
 logger = logging.getLogger(__name__)
+
+
+def _make_json_safe(obj: dict) -> dict:
+    """Strip non-JSON-serializable values from a state dict.
+
+    LangGraph may embed Interrupt objects or other internal types in the
+    state returned by ainvoke. We need to remove them before storing in
+    a JSON column.
+    """
+    safe = {}
+    for key, value in obj.items():
+        try:
+            json.dumps(value)
+            safe[key] = value
+        except (TypeError, ValueError):
+            # Convert to string representation as fallback
+            safe[key] = str(value)
+    return safe
 
 
 class FlowRunService:
@@ -68,7 +87,7 @@ class FlowRunService:
             if result.get("error"):
                 await self.flow_run_repo.update_state(
                     run.id,
-                    current_state=result,
+                    current_state=_make_json_safe(result),
                     current_node=result.get("current_step"),
                     status=FlowRunStatus.failed,
                     thread_id=thread_id,
@@ -81,7 +100,7 @@ class FlowRunService:
                     # Interrupted — waiting for human input
                     await self.flow_run_repo.update_state(
                         run.id,
-                        current_state=result,
+                        current_state=_make_json_safe(result),
                         current_node=snapshot.next[0] if snapshot.next else None,
                         status=FlowRunStatus.waiting_for_input,
                         thread_id=thread_id,
@@ -90,7 +109,7 @@ class FlowRunService:
                     # Completed
                     await self.flow_run_repo.update_state(
                         run.id,
-                        current_state=result,
+                        current_state=_make_json_safe(result),
                         current_node=None,
                         status=FlowRunStatus.completed,
                         thread_id=thread_id,
@@ -156,14 +175,14 @@ class FlowRunService:
             if snapshot.next:
                 await self.flow_run_repo.update_state(
                     run.id,
-                    current_state=result,
+                    current_state=_make_json_safe(result),
                     current_node=snapshot.next[0] if snapshot.next else None,
                     status=FlowRunStatus.waiting_for_input,
                 )
             else:
                 await self.flow_run_repo.update_state(
                     run.id,
-                    current_state=result,
+                    current_state=_make_json_safe(result),
                     current_node=None,
                     status=FlowRunStatus.completed,
                 )

--- a/backend/app/services/agent/flow_run_service.py
+++ b/backend/app/services/agent/flow_run_service.py
@@ -1,0 +1,178 @@
+"""Flow run service — generic execution engine for composed flows."""
+import logging
+from uuid import UUID, uuid4
+
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from langgraph.types import Command
+
+from app.models.flow_run import FlowRunStatus
+from app.repositories.flow_definition_repository import FlowDefinitionRepository
+from app.repositories.flow_run_repository import FlowRunRepository
+from app.schemas.agent import FlowRunResponse, FlowRunListItem
+from app.services.agent.graph import build_graph_from_definition
+from app.services.agent.state import GenericFlowState
+from app.services.exceptions import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class FlowRunService:
+    """Service for executing flow definitions through the LangGraph engine."""
+
+    def __init__(
+        self,
+        flow_run_repo: FlowRunRepository,
+        flow_def_repo: FlowDefinitionRepository,
+        checkpointer: AsyncPostgresSaver,
+    ):
+        self.flow_run_repo = flow_run_repo
+        self.flow_def_repo = flow_def_repo
+        self.checkpointer = checkpointer
+
+    async def start_run(
+        self,
+        project_id: UUID,
+        flow_definition_id: UUID,
+        initial_state: dict,
+        user_id: UUID,
+    ) -> FlowRunResponse:
+        """Start executing a flow definition with the given initial state."""
+        # Validate flow definition exists
+        flow_def = await self.flow_def_repo.get_by_id(flow_definition_id)
+        if not flow_def:
+            raise NotFoundError(f"Flow definition {flow_definition_id} not found")
+
+        # Create run record
+        run = await self.flow_run_repo.create(
+            project_id=project_id,
+            flow_definition_id=flow_definition_id,
+            created_by=user_id,
+            initial_state=initial_state,
+        )
+
+        # Update status to running
+        await self.flow_run_repo.update_status(run.id, FlowRunStatus.running)
+
+        # Build and invoke graph
+        thread_id = str(uuid4())
+        compiled = build_graph_from_definition(
+            flow=flow_def.definition,
+            checkpointer=self.checkpointer,
+            state_type=GenericFlowState,
+        )
+        config = {"configurable": {"thread_id": thread_id}}
+
+        try:
+            result = await compiled.ainvoke(initial_state, config=config)
+
+            if result.get("error"):
+                await self.flow_run_repo.update_state(
+                    run.id,
+                    current_state=result,
+                    current_node=result.get("current_step"),
+                    status=FlowRunStatus.failed,
+                    thread_id=thread_id,
+                    status_message=result.get("error"),
+                )
+            else:
+                # Check if graph completed or interrupted
+                snapshot = await compiled.aget_state(config)
+                if snapshot.next:
+                    # Interrupted — waiting for human input
+                    await self.flow_run_repo.update_state(
+                        run.id,
+                        current_state=result,
+                        current_node=snapshot.next[0] if snapshot.next else None,
+                        status=FlowRunStatus.waiting_for_input,
+                        thread_id=thread_id,
+                    )
+                else:
+                    # Completed
+                    await self.flow_run_repo.update_state(
+                        run.id,
+                        current_state=result,
+                        current_node=None,
+                        status=FlowRunStatus.completed,
+                        thread_id=thread_id,
+                    )
+
+        except Exception as e:
+            logger.exception("Flow run failed for run %s", run.id)
+            await self.flow_run_repo.update_status(
+                run.id, FlowRunStatus.failed, str(e)
+            )
+
+        run = await self.flow_run_repo.get_by_id(run.id)
+        return FlowRunResponse.from_orm_model(run)
+
+    async def get_run(self, run_id: UUID) -> FlowRunResponse:
+        """Get a flow run by ID."""
+        run = await self.flow_run_repo.get_by_id(run_id)
+        if not run:
+            raise NotFoundError(f"Flow run {run_id} not found")
+        return FlowRunResponse.from_orm_model(run)
+
+    async def list_runs(self, project_id: UUID) -> list[FlowRunListItem]:
+        """List flow runs for a project."""
+        runs = await self.flow_run_repo.list_by_project(project_id)
+        return [FlowRunListItem.from_orm_model(r) for r in runs]
+
+    async def resume_run(
+        self,
+        run_id: UUID,
+        resume_value: dict,
+    ) -> FlowRunResponse:
+        """Resume an interrupted flow run with the given value."""
+        run = await self.flow_run_repo.get_by_id(run_id)
+        if not run:
+            raise NotFoundError(f"Flow run {run_id} not found")
+
+        if run.status != FlowRunStatus.waiting_for_input:
+            raise ValueError(f"Flow run {run_id} is not waiting for input")
+
+        if not run.thread_id:
+            raise ValueError(f"Flow run {run_id} has no thread_id")
+
+        # Load flow definition to rebuild graph
+        flow_def = await self.flow_def_repo.get_by_id(run.flow_definition_id)
+        if not flow_def:
+            raise NotFoundError(f"Flow definition {run.flow_definition_id} not found")
+
+        compiled = build_graph_from_definition(
+            flow=flow_def.definition,
+            checkpointer=self.checkpointer,
+            state_type=GenericFlowState,
+        )
+        config = {"configurable": {"thread_id": run.thread_id}}
+
+        try:
+            result = await compiled.ainvoke(
+                Command(resume=resume_value),
+                config=config,
+            )
+
+            # Check if graph completed or hit another interrupt
+            snapshot = await compiled.aget_state(config)
+            if snapshot.next:
+                await self.flow_run_repo.update_state(
+                    run.id,
+                    current_state=result,
+                    current_node=snapshot.next[0] if snapshot.next else None,
+                    status=FlowRunStatus.waiting_for_input,
+                )
+            else:
+                await self.flow_run_repo.update_state(
+                    run.id,
+                    current_state=result,
+                    current_node=None,
+                    status=FlowRunStatus.completed,
+                )
+
+        except Exception as e:
+            logger.exception("Resume failed for flow run %s", run.id)
+            await self.flow_run_repo.update_status(
+                run.id, FlowRunStatus.failed, str(e)
+            )
+
+        run = await self.flow_run_repo.get_by_id(run.id)
+        return FlowRunResponse.from_orm_model(run)

--- a/backend/app/services/agent/graph.py
+++ b/backend/app/services/agent/graph.py
@@ -78,16 +78,56 @@ def build_graph_from_definition(
         graph.add_node(node["id"], tool.node_fn)
 
     # Add edges
+    has_start = False
+    has_end = False
+    edge_targets = set()  # nodes that are targets of an edge
+    edge_sources = set()  # nodes that are sources of an edge
+
     for edge in flow.get("edges", []):
         source = START if edge["source"] == "__start__" else edge["source"]
         target = END if edge["target"] == "__end__" else edge["target"]
+        if source is START:
+            has_start = True
+        if target is END:
+            has_end = True
+        if source is not START:
+            edge_sources.add(edge["source"])
+        if target is not END:
+            edge_targets.add(edge["target"])
         graph.add_edge(source, target)
 
     # Add conditional edges
     for cond in flow.get("conditional_edges", []):
         router_fn = get_router(cond["router"])
         targets = [END if t == "__end__" else t for t in cond["targets"]]
+        edge_sources.add(cond["source"])
+        for t in cond["targets"]:
+            if t == "__end__":
+                has_end = True
+            else:
+                edge_targets.add(t)
         graph.add_conditional_edges(cond["source"], router_fn, targets)
+
+    # Auto-infer START and END if not explicitly provided
+    node_ids = {n["id"] for n in flow["nodes"]}
+    if not has_start:
+        # Entry nodes: nodes that are never a target of another node
+        entry_nodes = node_ids - edge_targets
+        if entry_nodes:
+            graph.add_edge(START, entry_nodes.pop())
+        elif node_ids:
+            # Fallback: use the first node in definition order
+            graph.add_edge(START, flow["nodes"][0]["id"])
+
+    if not has_end:
+        # Exit nodes: nodes that are never a source of another edge
+        exit_nodes = node_ids - edge_sources
+        if exit_nodes:
+            for exit_node in exit_nodes:
+                graph.add_edge(exit_node, END)
+        elif node_ids:
+            # Fallback: use the last node in definition order
+            graph.add_edge(flow["nodes"][-1]["id"], END)
 
     return graph.compile(checkpointer=checkpointer)
 

--- a/backend/app/services/agent/graph.py
+++ b/backend/app/services/agent/graph.py
@@ -65,9 +65,10 @@ Structure:
 def build_graph_from_definition(
     flow: FlowDefinition,
     checkpointer=None,
+    state_type=None,
 ) -> Any:
     """Build and compile a LangGraph StateGraph from a flow definition."""
-    graph = StateGraph(AgentState)
+    graph = StateGraph(state_type or AgentState)
 
     # Add nodes
     for node in flow["nodes"]:

--- a/backend/app/services/agent/nodes.py
+++ b/backend/app/services/agent/nodes.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 async def extract_node(state: AgentState) -> AgentState:
     """Extract structured data from receipt image using DataExtractor."""
-    logger.info("extract_node: processing receipt %s", state.get("receipt_id", state.get("document_id", "unknown")))
+    logger.info("extract_node: processing receipt %s", state.get("document_id", "unknown"))
 
     extractor = get_extractor("llamaextract")
     if extractor is None:
@@ -39,7 +39,7 @@ async def extract_node(state: AgentState) -> AgentState:
 
 async def review_node(state: AgentState) -> AgentState:
     """Interrupt graph execution for human review of extracted data."""
-    logger.info("review_node: awaiting review for receipt %s", state.get("receipt_id", state.get("document_id", "unknown")))
+    logger.info("review_node: awaiting review for receipt %s", state.get("document_id", "unknown"))
 
     review_input = interrupt(state.get("extracted_data", {}))
 
@@ -56,7 +56,7 @@ async def review_node(state: AgentState) -> AgentState:
 
 async def export_node(state: AgentState) -> AgentState:
     """Mark data as exported (actual DB save happens in the service layer)."""
-    logger.info("export_node: exporting receipt %s", state.get("receipt_id", state.get("document_id", "unknown")))
+    logger.info("export_node: exporting receipt %s", state.get("document_id", "unknown"))
 
     return {
         **state,

--- a/backend/app/services/agent/nodes.py
+++ b/backend/app/services/agent/nodes.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 async def extract_node(state: AgentState) -> AgentState:
     """Extract structured data from receipt image using DataExtractor."""
-    logger.info("extract_node: processing receipt %s", state["receipt_id"])
+    logger.info("extract_node: processing receipt %s", state.get("receipt_id", state.get("document_id", "unknown")))
 
     extractor = get_extractor("llamaextract")
     if extractor is None:
@@ -39,7 +39,7 @@ async def extract_node(state: AgentState) -> AgentState:
 
 async def review_node(state: AgentState) -> AgentState:
     """Interrupt graph execution for human review of extracted data."""
-    logger.info("review_node: awaiting review for receipt %s", state["receipt_id"])
+    logger.info("review_node: awaiting review for receipt %s", state.get("receipt_id", state.get("document_id", "unknown")))
 
     review_input = interrupt(state.get("extracted_data", {}))
 
@@ -56,7 +56,7 @@ async def review_node(state: AgentState) -> AgentState:
 
 async def export_node(state: AgentState) -> AgentState:
     """Mark data as exported (actual DB save happens in the service layer)."""
-    logger.info("export_node: exporting receipt %s", state["receipt_id"])
+    logger.info("export_node: exporting receipt %s", state.get("receipt_id", state.get("document_id", "unknown")))
 
     return {
         **state,

--- a/backend/app/services/agent/nodes.py
+++ b/backend/app/services/agent/nodes.py
@@ -1,17 +1,16 @@
-"""LangGraph node functions for the receipt processing pipeline."""
+"""LangGraph node functions for agent pipelines."""
 import logging
 
 from langgraph.types import interrupt
 
 from app.adapters.extraction.registry import get_extractor
-from app.services.agent.state import AgentState
 
 logger = logging.getLogger(__name__)
 
 
-async def extract_node(state: AgentState) -> AgentState:
-    """Extract structured data from receipt image using DataExtractor."""
-    logger.info("extract_node: processing receipt %s", state.get("document_id", "unknown"))
+async def extract_node(state: dict) -> dict:
+    """Extract structured data from a document using DataExtractor."""
+    logger.info("extract_node: processing document %s", state.get("document_id", "unknown"))
 
     extractor = get_extractor("llamaextract")
     if extractor is None:
@@ -37,9 +36,9 @@ async def extract_node(state: AgentState) -> AgentState:
     }
 
 
-async def review_node(state: AgentState) -> AgentState:
+async def review_node(state: dict) -> dict:
     """Interrupt graph execution for human review of extracted data."""
-    logger.info("review_node: awaiting review for receipt %s", state.get("document_id", "unknown"))
+    logger.info("review_node: awaiting review for document %s", state.get("document_id", "unknown"))
 
     review_input = interrupt(state.get("extracted_data", {}))
 
@@ -54,9 +53,9 @@ async def review_node(state: AgentState) -> AgentState:
     }
 
 
-async def export_node(state: AgentState) -> AgentState:
+async def export_node(state: dict) -> dict:
     """Mark data as exported (actual DB save happens in the service layer)."""
-    logger.info("export_node: exporting receipt %s", state.get("document_id", "unknown"))
+    logger.info("export_node: exporting document %s", state.get("document_id", "unknown"))
 
     return {
         **state,

--- a/backend/app/services/agent/state.py
+++ b/backend/app/services/agent/state.py
@@ -1,4 +1,4 @@
-"""LangGraph state definition for the receipt processing pipeline."""
+"""LangGraph state definitions for agent pipelines."""
 from typing import TypedDict
 
 
@@ -16,3 +16,13 @@ class AgentState(TypedDict, total=False):
     exported: bool
     error: str | None
     current_step: str
+
+
+class GenericFlowState(TypedDict, total=False):
+    """Minimal state for the generic flow engine.
+
+    total=False means no keys are required. Arbitrary keys from the
+    initial_state dict pass through the graph unvalidated.
+    """
+    current_step: str
+    error: str | None

--- a/backend/app/services/agent/state.py
+++ b/backend/app/services/agent/state.py
@@ -18,11 +18,6 @@ class AgentState(TypedDict, total=False):
     current_step: str
 
 
-class GenericFlowState(TypedDict, total=False):
-    """Minimal state for the generic flow engine.
-
-    total=False means no keys are required. Arbitrary keys from the
-    initial_state dict pass through the graph unvalidated.
-    """
-    current_step: str
-    error: str | None
+# Generic flow state: plain dict so LangGraph preserves all keys.
+# TypedDict(total=False) drops undeclared keys, so we use dict instead.
+GenericFlowState = dict

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,8 @@ import ExtractionPage from './pages/ExtractionPage'
 import AgentPage from './pages/AgentPage'
 import AgentReceiptPage from './pages/AgentReceiptPage'
 import FlowComposerPage from './pages/FlowComposerPage'
+import FlowRunsPage from './pages/FlowRunsPage'
+import FlowRunDetailPage from './pages/FlowRunDetailPage'
 
 const router = createBrowserRouter([
   {
@@ -111,6 +113,16 @@ const router = createBrowserRouter([
             path: 'agent/flows/:flowId',
             element: <FlowComposerPage />,
             handle: { breadcrumb: 'Edit Flow' },
+          },
+          {
+            path: 'agent/flows/:flowId/runs',
+            element: <FlowRunsPage />,
+            handle: { breadcrumb: 'Flow Runs' },
+          },
+          {
+            path: 'agent/runs/:runId',
+            element: <FlowRunDetailPage />,
+            handle: { breadcrumb: 'Run Detail' },
           },
 {
             path: 'evaluation',

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -11,6 +11,10 @@ import type {
   AgentReceiptListItem,
   StartProcessingRequest,
   SubmitReviewRequest,
+  FlowRun,
+  FlowRunListItem,
+  StartFlowRunRequest,
+  ResumeFlowRunRequest,
 } from '@/types/agent'
 
 // --- Agent Tools ---
@@ -140,6 +144,48 @@ export async function submitReview(
 ): Promise<AgentReceipt> {
   const response = await apiClient.post<AgentReceipt>(
     `/agent/receipts/${receiptId}/review`,
+    data
+  )
+  return response.data
+}
+
+// --- Flow Runs ---
+
+export async function startFlowRun(
+  projectId: string,
+  data: StartFlowRunRequest
+): Promise<FlowRun> {
+  const response = await apiClient.post<FlowRun>(
+    `/agent/projects/${projectId}/runs`,
+    data
+  )
+  return response.data
+}
+
+export async function listFlowRuns(
+  projectId: string
+): Promise<FlowRunListItem[]> {
+  const response = await apiClient.get<FlowRunListItem[]>(
+    `/agent/projects/${projectId}/runs`
+  )
+  return response.data
+}
+
+export async function getFlowRun(
+  runId: string
+): Promise<FlowRun> {
+  const response = await apiClient.get<FlowRun>(
+    `/agent/runs/${runId}`
+  )
+  return response.data
+}
+
+export async function resumeFlowRun(
+  runId: string,
+  data: ResumeFlowRunRequest
+): Promise<FlowRun> {
+  const response = await apiClient.post<FlowRun>(
+    `/agent/runs/${runId}/resume`,
     data
   )
   return response.data

--- a/frontend/src/api/agent.ts
+++ b/frontend/src/api/agent.ts
@@ -14,6 +14,7 @@ import type {
   FlowRun,
   FlowRunListItem,
   StartFlowRunRequest,
+  StartExtractRunRequest,
   ResumeFlowRunRequest,
 } from '@/types/agent'
 
@@ -186,6 +187,23 @@ export async function resumeFlowRun(
 ): Promise<FlowRun> {
   const response = await apiClient.post<FlowRun>(
     `/agent/runs/${runId}/resume`,
+    data
+  )
+  return response.data
+}
+
+export async function deleteFlowRun(
+  runId: string
+): Promise<void> {
+  await apiClient.delete(`/agent/runs/${runId}`)
+}
+
+export async function startExtractRun(
+  projectId: string,
+  data: StartExtractRunRequest
+): Promise<FlowRun> {
+  const response = await apiClient.post<FlowRun>(
+    `/agent/extract/projects/${projectId}/runs`,
     data
   )
   return response.data

--- a/frontend/src/components/agent/AgentFlowGraph.tsx
+++ b/frontend/src/components/agent/AgentFlowGraph.tsx
@@ -8,12 +8,13 @@ import {
   MarkerType,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import type { AgentReceiptStatus } from '@/types/agent'
+import type { AgentReceiptStatus, FlowRunStatus } from '@/types/agent'
 
 interface AgentFlowGraphProps {
   nodes: { name: string; label: string }[]
   currentStep?: string | null
   status?: AgentReceiptStatus | null
+  flowRunStatus?: FlowRunStatus | null
   height?: number
 }
 
@@ -24,8 +25,28 @@ function getNodeStatus(
   nodeIndex: number,
   nodes: { name: string }[],
   currentStep: string | null,
-  status: AgentReceiptStatus | null
+  status: AgentReceiptStatus | null,
+  flowRunStatus: FlowRunStatus | null = null
 ): NodeStatus {
+  // Generic flow run status handling
+  if (flowRunStatus) {
+    if (flowRunStatus === 'completed') return 'completed'
+    if (flowRunStatus === 'failed') {
+      const currentIndex = nodes.findIndex((n) => n.name === currentStep)
+      if (nodeIndex < currentIndex) return 'completed'
+      if (nodeIndex === currentIndex) return 'failed'
+      return 'pending'
+    }
+    if (flowRunStatus === 'pending') return 'pending'
+    // running or waiting_for_input
+    const currentIndex = nodes.findIndex((n) => n.name === currentStep)
+    if (currentIndex < 0) return nodeIndex === 0 ? 'active' : 'pending'
+    if (nodeIndex < currentIndex) return 'completed'
+    if (nodeIndex === currentIndex) return 'active'
+    return 'pending'
+  }
+
+  // Receipt-specific status handling
   if (!status || !currentStep) return 'pending'
   if (status === 'failed') {
     const currentIndex = nodes.findIndex((n) => n.name === currentStep)
@@ -84,6 +105,7 @@ export function AgentFlowGraph({
   nodes: graphNodes,
   currentStep = null,
   status = null,
+  flowRunStatus = null,
   height = 120,
 }: AgentFlowGraphProps) {
   const { nodes, edges } = useMemo(() => {
@@ -98,14 +120,14 @@ export function AgentFlowGraph({
       position: { x: startX + i * (NODE_WIDTH + NODE_SPACING), y: 0 },
       data: {
         label: node.label,
-        nodeStatus: getNodeStatus(node.name, i, graphNodes, currentStep, status),
+        nodeStatus: getNodeStatus(node.name, i, graphNodes, currentStep, status, flowRunStatus),
       },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
     }))
 
     const rfEdges: Edge[] = graphNodes.slice(0, -1).map((node, i) => {
-      const sourceStatus = getNodeStatus(node.name, i, graphNodes, currentStep, status)
+      const sourceStatus = getNodeStatus(node.name, i, graphNodes, currentStep, status, flowRunStatus)
       const isActive = sourceStatus === 'completed' || sourceStatus === 'active'
       return {
         id: `${node.name}-${graphNodes[i + 1].name}`,
@@ -125,7 +147,7 @@ export function AgentFlowGraph({
     })
 
     return { nodes: rfNodes, edges: rfEdges }
-  }, [graphNodes, currentStep, status])
+  }, [graphNodes, currentStep, status, flowRunStatus])
 
   return (
     <div style={{ height }} className="w-full rounded-lg border bg-white">

--- a/frontend/src/components/agent/FlowList.tsx
+++ b/frontend/src/components/agent/FlowList.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom'
 import type { FlowDefinition } from '@/types/agent'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Pencil, Trash2, Workflow } from 'lucide-react'
+import { Pencil, Play, Trash2, Workflow } from 'lucide-react'
 
 interface FlowListProps {
   flows: FlowDefinition[]
@@ -53,6 +53,15 @@ export function FlowList({ flows, isLoading, onDelete }: FlowListProps) {
             </div>
           </div>
           <div className="flex items-center gap-1 shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              onClick={() => navigate(`/agent/flows/${flow.id}/runs`)}
+              title="Runs"
+            >
+              <Play className="h-3.5 w-3.5" />
+            </Button>
             <Button
               variant="ghost"
               size="sm"

--- a/frontend/src/components/agent/FlowRunDetail.tsx
+++ b/frontend/src/components/agent/FlowRunDetail.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react'
+import type { FlowRun, FlowDefinition, SubmitReviewRequest } from '@/types/agent'
+import { AgentFlowGraph } from '@/components/agent/AgentFlowGraph'
+import { ReceiptReviewForm } from '@/components/agent/ReceiptReviewForm'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Button } from '@/components/ui/button'
+import { Loader2, ChevronDown, ChevronRight } from 'lucide-react'
+
+interface FlowRunDetailProps {
+  run: FlowRun | null
+  flowDefinition: FlowDefinition | null
+  isLoading: boolean
+  isResuming: boolean
+  error: string | null
+  onResume: (data: SubmitReviewRequest) => Promise<void>
+}
+
+export function FlowRunDetail({
+  run,
+  flowDefinition,
+  isLoading,
+  isResuming,
+  error,
+  onResume,
+}: FlowRunDetailProps) {
+  const [stateOpen, setStateOpen] = useState(false)
+
+  if (isLoading || !run) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  // Derive flow graph nodes from flow definition
+  const graphNodes = flowDefinition
+    ? flowDefinition.definition.nodes.map((n) => ({
+        name: n.id,
+        label: n.tool,
+      }))
+    : []
+
+  const extractedData =
+    (run.currentState?.extracted_data as Record<string, unknown>) ?? null
+  const reviewedData =
+    (run.currentState?.reviewed_data as Record<string, unknown>) ?? null
+  const finalData = reviewedData ?? extractedData
+
+  return (
+    <div className="space-y-4">
+      {/* Status header */}
+      <div className="flex items-center gap-3">
+        <Badge
+          variant={
+            run.status === 'failed'
+              ? 'destructive'
+              : run.status === 'completed'
+                ? 'default'
+                : 'secondary'
+          }
+        >
+          {run.status.replace('_', ' ')}
+        </Badge>
+        <span className="text-xs text-muted-foreground">
+          Started {new Date(run.createdAt).toLocaleString()}
+        </span>
+      </div>
+
+      {/* Flow graph */}
+      {graphNodes.length > 0 && (
+        <AgentFlowGraph
+          nodes={graphNodes}
+          currentStep={run.currentNode}
+          flowRunStatus={run.status}
+          height={120}
+        />
+      )}
+
+      {/* Status-driven content */}
+      {(run.status === 'pending' || run.status === 'running') && (
+        <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {run.status === 'pending' ? 'Waiting to start...' : 'Running...'}
+          {run.currentNode && (
+            <span className="font-mono">({run.currentNode})</span>
+          )}
+        </div>
+      )}
+
+      {run.status === 'waiting_for_input' && extractedData && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Review Extracted Data</h3>
+          <ReceiptReviewForm
+            extractedData={extractedData}
+            isSubmitting={isResuming}
+            onSubmit={onResume}
+          />
+        </div>
+      )}
+
+      {run.status === 'waiting_for_input' && !extractedData && (
+        <Alert>
+          <AlertDescription>
+            Waiting for input at node <span className="font-mono">{run.currentNode}</span>.
+            No extracted data available to review.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {run.status === 'completed' && finalData && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Results</h3>
+          <pre className="rounded-lg border bg-gray-50 p-4 text-xs overflow-auto max-h-96">
+            {JSON.stringify(finalData, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {run.status === 'completed' && !finalData && (
+        <Alert>
+          <AlertDescription>Run completed with no output data.</AlertDescription>
+        </Alert>
+      )}
+
+      {run.status === 'failed' && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {run.statusMessage || 'Run failed with no error message.'}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Raw state inspector */}
+      {run.currentState && (
+        <Collapsible open={stateOpen} onOpenChange={setStateOpen}>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="gap-1.5 text-xs text-muted-foreground">
+              {stateOpen ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              Raw State
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <pre className="mt-2 rounded-lg border bg-gray-50 p-4 text-xs overflow-auto max-h-96">
+              {JSON.stringify(run.currentState, null, 2)}
+            </pre>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/agent/FlowRunInputForm.tsx
+++ b/frontend/src/components/agent/FlowRunInputForm.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Play } from 'lucide-react'
+import type { DocumentListItem } from '@/types/document'
+import type { ExtractionSchema } from '@/types/extraction'
+import type { StartExtractRunRequest } from '@/types/agent'
+
+interface FlowRunInputFormProps {
+  flowDefinitionId: string
+  documents: DocumentListItem[]
+  schemas: ExtractionSchema[]
+  isStarting: boolean
+  onStart: (request: StartExtractRunRequest) => Promise<void>
+}
+
+export function FlowRunInputForm({
+  flowDefinitionId,
+  documents,
+  schemas,
+  isStarting,
+  onStart,
+}: FlowRunInputFormProps) {
+  const [documentId, setDocumentId] = useState('')
+  const [schemaId, setSchemaId] = useState('')
+
+  const readyDocuments = documents.filter((d) => d.status === 'ready')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!documentId || !schemaId) return
+    await onStart({
+      flowDefinitionId,
+      documentId,
+      extractionSchemaId: schemaId,
+    })
+    setDocumentId('')
+    setSchemaId('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label className="text-xs">Document</Label>
+          <select
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={documentId}
+            onChange={(e) => setDocumentId(e.target.value)}
+          >
+            <option value="">Select a document...</option>
+            {readyDocuments.map((doc) => (
+              <option key={doc.id} value={doc.id}>
+                {doc.title}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Extraction Schema</Label>
+          <select
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={schemaId}
+            onChange={(e) => setSchemaId(e.target.value)}
+          >
+            <option value="">Select a schema...</option>
+            {schemas.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <Button
+        type="submit"
+        size="sm"
+        disabled={!documentId || !schemaId || isStarting}
+      >
+        <Play className="h-4 w-4 mr-1.5" />
+        {isStarting ? 'Starting...' : 'Run'}
+      </Button>
+    </form>
+  )
+}

--- a/frontend/src/components/agent/FlowRunList.tsx
+++ b/frontend/src/components/agent/FlowRunList.tsx
@@ -1,0 +1,116 @@
+import { useNavigate } from 'react-router-dom'
+import type { FlowRunListItem } from '@/types/agent'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Eye, Trash2 } from 'lucide-react'
+
+const statusConfig: Record<
+  string,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' }
+> = {
+  pending: { label: 'Pending', variant: 'secondary' },
+  running: { label: 'Running', variant: 'secondary' },
+  waiting_for_input: { label: 'Needs Input', variant: 'default' },
+  completed: { label: 'Completed', variant: 'default' },
+  failed: { label: 'Failed', variant: 'destructive' },
+}
+
+interface FlowRunListProps {
+  runs: FlowRunListItem[]
+  isLoading: boolean
+  onDelete: (runId: string) => Promise<void>
+}
+
+export function FlowRunList({ runs, isLoading, onDelete }: FlowRunListProps) {
+  const navigate = useNavigate()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    )
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+        No runs yet. Use the form above to start one.
+      </div>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Status</TableHead>
+          <TableHead>Current Node</TableHead>
+          <TableHead>Started</TableHead>
+          <TableHead className="w-20" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {runs.map((run) => {
+          const config = statusConfig[run.status] ?? statusConfig.pending
+          return (
+            <TableRow
+              key={run.id}
+              className="cursor-pointer"
+              onClick={() => navigate(`/agent/runs/${run.id}`)}
+            >
+              <TableCell>
+                <Badge variant={config.variant}>{config.label}</Badge>
+              </TableCell>
+              <TableCell className="text-sm font-mono text-muted-foreground">
+                {run.currentNode ?? '—'}
+              </TableCell>
+              <TableCell className="text-sm text-muted-foreground">
+                {new Date(run.createdAt).toLocaleString()}
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      navigate(`/agent/runs/${run.id}`)
+                    }}
+                    title="View run"
+                  >
+                    <Eye className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0 text-muted-foreground hover:text-red-600"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onDelete(run.id)
+                    }}
+                    title="Delete run"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/src/hooks/useFlowRun.ts
+++ b/frontend/src/hooks/useFlowRun.ts
@@ -1,0 +1,105 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type { FlowRun, ResumeFlowRunRequest } from '@/types/agent'
+import * as agentApi from '@/api/agent'
+
+const POLLING_INTERVAL = 3000
+const POLLING_TIMEOUT = 10 * 60 * 1000
+
+interface UseFlowRunReturn {
+  run: FlowRun | null
+  isLoading: boolean
+  isResuming: boolean
+  error: string | null
+  fetchRun: () => Promise<void>
+  resumeRun: (data: ResumeFlowRunRequest) => Promise<void>
+}
+
+export function useFlowRun(
+  runId: string | null
+): UseFlowRunReturn {
+  const [run, setRun] = useState<FlowRun | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isResuming, setIsResuming] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollingStartRef = useRef<number>(0)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }, [])
+
+  const fetchRun = useCallback(async () => {
+    if (!runId) {
+      setRun(null)
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await agentApi.getFlowRun(runId)
+      setRun(data)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch flow run'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [runId])
+
+  const resumeRun = useCallback(
+    async (data: ResumeFlowRunRequest) => {
+      if (!runId) throw new Error('No run ID')
+      setIsResuming(true)
+      setError(null)
+      try {
+        const updated = await agentApi.resumeFlowRun(runId, data)
+        setRun(updated)
+        stopPolling()
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to resume flow run'
+        )
+        throw err
+      } finally {
+        setIsResuming(false)
+      }
+    },
+    [runId, stopPolling]
+  )
+
+  // Poll when run is active
+  useEffect(() => {
+    const isActive =
+      run?.status === 'pending' || run?.status === 'running'
+
+    if (isActive && !pollingRef.current) {
+      pollingStartRef.current = Date.now()
+      pollingRef.current = setInterval(async () => {
+        if (Date.now() - pollingStartRef.current > POLLING_TIMEOUT) {
+          stopPolling()
+          return
+        }
+        await fetchRun()
+      }, POLLING_INTERVAL)
+    } else if (!isActive) {
+      stopPolling()
+    }
+
+    return () => stopPolling()
+  }, [run, fetchRun, stopPolling])
+
+  // Initial fetch
+  useEffect(() => {
+    if (runId) {
+      fetchRun()
+    } else {
+      setRun(null)
+    }
+  }, [runId, fetchRun])
+
+  return { run, isLoading, isResuming, error, fetchRun, resumeRun }
+}

--- a/frontend/src/hooks/useFlowRuns.ts
+++ b/frontend/src/hooks/useFlowRuns.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import type {
   FlowRunListItem,
   StartFlowRunRequest,
+  StartExtractRunRequest,
 } from '@/types/agent'
 import * as agentApi from '@/api/agent'
 
@@ -15,6 +16,8 @@ interface UseFlowRunsReturn {
   error: string | null
   fetchRuns: () => Promise<void>
   startRun: (request: StartFlowRunRequest) => Promise<void>
+  startExtractRun: (request: StartExtractRunRequest) => Promise<void>
+  deleteRun: (runId: string) => Promise<void>
 }
 
 export function useFlowRuns(
@@ -73,6 +76,34 @@ export function useFlowRuns(
     [projectId, fetchRuns]
   )
 
+  const startExtractRun = useCallback(
+    async (request: StartExtractRunRequest) => {
+      if (!projectId) throw new Error('No project selected')
+      setIsStarting(true)
+      setError(null)
+      try {
+        await agentApi.startExtractRun(projectId, request)
+        await fetchRuns()
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to start extract run'
+        )
+        throw err
+      } finally {
+        setIsStarting(false)
+      }
+    },
+    [projectId, fetchRuns]
+  )
+
+  const deleteRun = useCallback(
+    async (runId: string) => {
+      await agentApi.deleteFlowRun(runId)
+      await fetchRuns()
+    },
+    [fetchRuns]
+  )
+
   // Poll when there are active runs
   useEffect(() => {
     const hasActive = runs.some(
@@ -104,5 +135,8 @@ export function useFlowRuns(
     }
   }, [projectId, fetchRuns])
 
-  return { runs, isLoading, isStarting, error, fetchRuns, startRun }
+  return {
+    runs, isLoading, isStarting, error,
+    fetchRuns, startRun, startExtractRun, deleteRun,
+  }
 }

--- a/frontend/src/hooks/useFlowRuns.ts
+++ b/frontend/src/hooks/useFlowRuns.ts
@@ -1,0 +1,108 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type {
+  FlowRunListItem,
+  StartFlowRunRequest,
+} from '@/types/agent'
+import * as agentApi from '@/api/agent'
+
+const POLLING_INTERVAL = 3000
+const POLLING_TIMEOUT = 10 * 60 * 1000
+
+interface UseFlowRunsReturn {
+  runs: FlowRunListItem[]
+  isLoading: boolean
+  isStarting: boolean
+  error: string | null
+  fetchRuns: () => Promise<void>
+  startRun: (request: StartFlowRunRequest) => Promise<void>
+}
+
+export function useFlowRuns(
+  projectId: string | null
+): UseFlowRunsReturn {
+  const [runs, setRuns] = useState<FlowRunListItem[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isStarting, setIsStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollingStartRef = useRef<number>(0)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }, [])
+
+  const fetchRuns = useCallback(async () => {
+    if (!projectId) {
+      setRuns([])
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await agentApi.listFlowRuns(projectId)
+      setRuns(data)
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch flow runs'
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [projectId])
+
+  const startRun = useCallback(
+    async (request: StartFlowRunRequest) => {
+      if (!projectId) throw new Error('No project selected')
+      setIsStarting(true)
+      setError(null)
+      try {
+        await agentApi.startFlowRun(projectId, request)
+        await fetchRuns()
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to start flow run'
+        )
+        throw err
+      } finally {
+        setIsStarting(false)
+      }
+    },
+    [projectId, fetchRuns]
+  )
+
+  // Poll when there are active runs
+  useEffect(() => {
+    const hasActive = runs.some(
+      (r) => r.status === 'pending' || r.status === 'running'
+    )
+
+    if (hasActive && !pollingRef.current) {
+      pollingStartRef.current = Date.now()
+      pollingRef.current = setInterval(async () => {
+        if (Date.now() - pollingStartRef.current > POLLING_TIMEOUT) {
+          stopPolling()
+          return
+        }
+        await fetchRuns()
+      }, POLLING_INTERVAL)
+    } else if (!hasActive) {
+      stopPolling()
+    }
+
+    return () => stopPolling()
+  }, [runs, fetchRuns, stopPolling])
+
+  // Initial fetch
+  useEffect(() => {
+    if (projectId) {
+      fetchRuns()
+    } else {
+      setRuns([])
+    }
+  }, [projectId, fetchRuns])
+
+  return { runs, isLoading, isStarting, error, fetchRuns, startRun }
+}

--- a/frontend/src/pages/FlowRunDetailPage.tsx
+++ b/frontend/src/pages/FlowRunDetailPage.tsx
@@ -1,0 +1,80 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useFlowRun } from '@/hooks/useFlowRun'
+import { FlowRunDetail } from '@/components/agent/FlowRunDetail'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { ArrowLeft } from 'lucide-react'
+import { toast } from 'sonner'
+import type { FlowDefinition, SubmitReviewRequest } from '@/types/agent'
+import * as agentApi from '@/api/agent'
+
+export default function FlowRunDetailPage(): JSX.Element {
+  const { runId } = useParams<{ runId: string }>()
+  const navigate = useNavigate()
+
+  const { run, isLoading, isResuming, error, resumeRun } = useFlowRun(
+    runId ?? null
+  )
+
+  // Load flow definition for graph visualization
+  const [flowDef, setFlowDef] = useState<FlowDefinition | null>(null)
+  useEffect(() => {
+    if (run?.flowDefinitionId) {
+      agentApi
+        .getFlowDefinition(run.flowDefinitionId)
+        .then(setFlowDef)
+        .catch(() => {})
+    }
+  }, [run?.flowDefinitionId])
+
+  const handleResume = async (request: SubmitReviewRequest) => {
+    try {
+      await resumeRun({
+        resumeValue: { action: request.action, data: request.data },
+      })
+      if (request.action === 'reject') {
+        toast.info('Run rejected')
+      } else {
+        toast.success('Review submitted')
+      }
+    } catch (err) {
+      toast.error('Failed to submit review', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
+  }
+
+  if (!runId) {
+    return (
+      <Alert>
+        <AlertDescription>No run ID provided.</AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0"
+          onClick={() => navigate(-1)}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-lg font-semibold">Run Detail</h1>
+      </div>
+
+      <FlowRunDetail
+        run={run}
+        flowDefinition={flowDef}
+        isLoading={isLoading}
+        isResuming={isResuming}
+        error={error}
+        onResume={handleResume}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/FlowRunsPage.tsx
+++ b/frontend/src/pages/FlowRunsPage.tsx
@@ -1,0 +1,143 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useProject } from '@/contexts/ProjectContext'
+import { useDocuments } from '@/hooks/useDocuments'
+import { useExtractionSchemas } from '@/hooks/useExtractionSchemas'
+import { useFlowRuns } from '@/hooks/useFlowRuns'
+import { useFlowComposer } from '@/hooks/useFlowComposer'
+import { FlowRunInputForm } from '@/components/agent/FlowRunInputForm'
+import { FlowRunList } from '@/components/agent/FlowRunList'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ArrowLeft, Workflow } from 'lucide-react'
+import { toast } from 'sonner'
+import type { StartExtractRunRequest } from '@/types/agent'
+
+export default function FlowRunsPage(): JSX.Element {
+  const { flowId } = useParams<{ flowId: string }>()
+  const navigate = useNavigate()
+  const { currentProject } = useProject()
+  const projectId = currentProject?.id ?? null
+
+  // Load the flow definition to get its name and type
+  const composer = useFlowComposer(projectId, flowId)
+
+  const { documents } = useDocuments(projectId)
+  const { schemas } = useExtractionSchemas(projectId)
+  const {
+    runs,
+    isLoading: runsLoading,
+    isStarting,
+    error: runsError,
+    startExtractRun,
+    deleteRun,
+  } = useFlowRuns(projectId)
+
+  // Filter runs to this flow
+  const flowRuns = flowId
+    ? runs.filter((r) => r.flowDefinitionId === flowId)
+    : runs
+
+  const handleStartExtract = async (request: StartExtractRunRequest) => {
+    try {
+      await startExtractRun(request)
+      toast.success('Run started', {
+        description: 'Processing document...',
+      })
+    } catch (err) {
+      toast.error('Failed to start run', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
+  }
+
+  const handleDeleteRun = async (runId: string) => {
+    try {
+      await deleteRun(runId)
+      toast.success('Run deleted')
+    } catch (err) {
+      toast.error('Failed to delete run', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    }
+  }
+
+  if (!currentProject) {
+    return (
+      <Alert>
+        <AlertDescription>Loading project...</AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0"
+          onClick={() => navigate('/agent')}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <Workflow className="h-5 w-5 text-muted-foreground" />
+        <div>
+          <h1 className="text-lg font-semibold">
+            {composer.flowName || 'Flow Runs'}
+          </h1>
+          {composer.flowDescription && (
+            <p className="text-sm text-muted-foreground">
+              {composer.flowDescription}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {runsError && (
+        <Alert variant="destructive">
+          <AlertDescription>{runsError}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Input form */}
+      {flowId && (
+        <div className="rounded-lg border p-4">
+          <h2 className="text-sm font-medium mb-3">Start New Run</h2>
+          {composer.isLoading ? (
+            <Skeleton className="h-20 w-full" />
+          ) : (
+            <FlowRunInputForm
+              flowDefinitionId={flowId}
+              documents={documents}
+              schemas={schemas}
+              isStarting={isStarting}
+              onStart={handleStartExtract}
+            />
+          )}
+        </div>
+      )}
+
+      <Separator />
+
+      {/* Run list */}
+      <div>
+        <h2 className="text-sm font-medium mb-3">
+          Runs
+          {flowRuns.length > 0 && (
+            <span className="text-muted-foreground font-normal ml-1.5">
+              ({flowRuns.length})
+            </span>
+          )}
+        </h2>
+        <FlowRunList
+          runs={flowRuns}
+          isLoading={runsLoading}
+          onDelete={handleDeleteRun}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -167,6 +167,12 @@ export interface StartFlowRunRequest {
   initialState: Record<string, unknown>
 }
 
+export interface StartExtractRunRequest {
+  flowDefinitionId: string
+  documentId: string
+  extractionSchemaId: string
+}
+
 export interface ResumeFlowRunRequest {
   resumeValue: Record<string, unknown>
 }

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -128,3 +128,45 @@ export interface SubmitReviewRequest {
   action: 'approve' | 'edit' | 'reject'
   data?: Record<string, unknown>
 }
+
+// --- Flow Runs ---
+
+export type FlowRunStatus =
+  | 'pending'
+  | 'running'
+  | 'waiting_for_input'
+  | 'completed'
+  | 'failed'
+
+export interface FlowRun {
+  id: string
+  projectId: string
+  flowDefinitionId: string
+  status: FlowRunStatus
+  statusMessage: string | null
+  initialState: Record<string, unknown> | null
+  currentState: Record<string, unknown> | null
+  currentNode: string | null
+  threadId: string | null
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface FlowRunListItem {
+  id: string
+  flowDefinitionId: string
+  status: FlowRunStatus
+  statusMessage: string | null
+  currentNode: string | null
+  createdAt: string
+}
+
+export interface StartFlowRunRequest {
+  flowDefinitionId: string
+  initialState: Record<string, unknown>
+}
+
+export interface ResumeFlowRunRequest {
+  resumeValue: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary

- Adds a generic execution engine that can run any composed `FlowDefinition` with arbitrary initial state, using LangGraph checkpointing and interrupt/resume
- `FlowRunService` builds graphs dynamically via `build_graph_from_definition()`, detects interrupts via `aget_state().next`, and tracks execution in a new `FlowRun` model
- Frontend hooks (`useFlowRuns`, `useFlowRun`) with 3s polling for active runs, and `AgentFlowGraph` updated to visualize generic flow run status

Closes #21

## Changes

### Backend (8 files)
- **`GenericFlowState`** — minimal TypedDict with `total=False` for arbitrary key passthrough
- **`build_graph_from_definition`** — new `state_type` parameter (defaults to `AgentState` for backward compat)
- **`FlowRun` model** — status enum, initial_state/current_state JSON, current_node, thread_id
- **`FlowRunRepository`** — create, get, list, update_status, update_state
- **`FlowRunService`** — `start_run()`, `resume_run()`, `get_run()`, `list_runs()`
- **4 API endpoints**: `POST .../runs`, `GET .../runs`, `GET /runs/{id}`, `POST /runs/{id}/resume`

### Frontend (5 files)
- `FlowRun` types + API functions
- `useFlowRuns` (list + poll) and `useFlowRun` (single + poll + resume) hooks
- `AgentFlowGraph` accepts `flowRunStatus` prop

## Test plan

- [ ] Backend: `uv run python -c "from app.services.agent.flow_run_service import FlowRunService"` imports cleanly
- [ ] Migration: `uv run alembic upgrade head` applies without error
- [ ] Frontend: `npx tsc --noEmit` and `npx vite build` pass
- [ ] Manual: rebuild backend container, POST to `/agent/projects/{id}/runs` with a flow definition ID and initial state, verify run is created and status transitions work
- [ ] Manual: verify existing receipt processing flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)