### PR TITLE
chore(infra): unblock libmagic — swap python-magic for filetype + lazify app.services init

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,13 +1,8 @@
-"""Service layer for business logic."""
-from app.services.auth_service import AuthService
-from app.services.oauth_service import OAuthService
-from app.services.project_service import ProjectService
-from app.services.document_service import DocumentService, process_document_extraction
+"""Service layer for business logic.
 
-__all__ = [
-    "AuthService",
-    "OAuthService",
-    "ProjectService",
-    "DocumentService",
-    "process_document_extraction",
-]
+Import service classes directly from their modules (e.g. ``from
+app.services.auth_service import AuthService``). This package does not
+re-export at the top level — doing so forces eager imports of every
+service and their transitive dependencies whenever any submodule is
+touched.
+"""

--- a/backend/app/utils/file_validation.py
+++ b/backend/app/utils/file_validation.py
@@ -4,7 +4,7 @@ import mimetypes
 from pathlib import Path
 from typing import BinaryIO
 
-import magic
+import filetype
 
 
 class FileValidationError(Exception):
@@ -50,12 +50,9 @@ def validate_mime_type(file_content: bytes, filename: str, allowed_types: list[s
     Raises:
         FileValidationError: If MIME type is not allowed or cannot be detected
     """
-    # Try to detect MIME type from content using python-magic
-    try:
-        mime = magic.Magic(mime=True)
-        detected_mime = mime.from_buffer(file_content[:2048])  # Read first 2KB
-    except Exception:
-        # Fallback to extension-based detection
+    kind = filetype.guess(file_content[:2048])
+    detected_mime = kind.mime if kind is not None else None
+    if detected_mime is None:
         detected_mime, _ = mimetypes.guess_type(filename)
         if not detected_mime:
             raise FileValidationError(f"Could not determine MIME type for file: {filename}")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "llama-index-readers-file>=0.1.0", # File readers for various formats
     "llama-cloud>=1.0.0", # LlamaParse v2 SDK for intelligent document parsing
     "aiofiles>=23.2.0", # Async file operations
-    "python-magic>=0.4.27", # MIME type detection from content
+    "filetype>=1.2.0", # Pure-Python MIME detection from content (no native deps)
     "Pillow>=10.0.0", # Image processing for OCR extraction
     "pytesseract>=0.3.10", # Tesseract OCR wrapper for image text extraction
     # -------------------------------------------------------------------------

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2685,15 +2685,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-magic"
-version = "0.4.27"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -2771,6 +2762,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "filetype" },
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "langchain-text-splitters" },
@@ -2795,7 +2787,6 @@ dependencies = [
     { name = "pytesseract" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-json-logger" },
-    { name = "python-magic" },
     { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "scipy" },
@@ -2825,6 +2816,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
+    { name = "filetype", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "langchain-text-splitters", specifier = ">=0.0.1" },
@@ -2852,7 +2844,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-json-logger", specifier = ">=2.0.7" },
-    { name = "python-magic", specifier = ">=0.4.27" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "scipy", specifier = ">=1.11.0" },


### PR DESCRIPTION
Closes #26

## Summary
- Replace native-C `python-magic` with pure-Python `filetype` for MIME detection — works on Windows, CI, and Alpine Docker with zero system dependencies.
- Lazify `app/services/__init__.py` (docstring only) so importing one service no longer eagerly pulls the entire service layer.

## Why
`python-magic` needs `libmagic` installed at the OS level. On Windows that's a manual install; it also blocked `pytest` collection because the eager re-exports in `app.services.__init__` dragged `document_service` → `file_validation` → `import magic` into every test run. Swapping to `filetype` removes the native dep entirely; lazifying the package init keeps future transitive-import blast radii small.

## Test plan
- [x] `uv sync --extra dev` installs cleanly
- [x] `from app.services.document_service import DocumentService` imports without error
- [x] Task 10 CDM runner tests pass (2/2): `tests/services/parsing/test_llamaparse_runner.py`
- [x] Full backend suite: 421 passed, 4 pre-existing SQLite test-isolation failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)