### PR TITLE
feat(cdm): read endpoints for ParseRun + ParsedDocument

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.config import settings
-from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_results, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings
+from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_results, parse_runs, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings
 from app.utils.oauth import setup_oauth
 
 # Import database engine for SQLAlchemy instrumentation
@@ -162,6 +162,7 @@ app.include_router(eval_runs.router, prefix="/api/v1")
 app.include_router(eval_runs.settings_router, prefix="/api/v1")
 app.include_router(experiments.router, prefix="/api/v1")
 app.include_router(parse_results.router, prefix="/api/v1")
+app.include_router(parse_runs.router, prefix="/api/v1")
 app.include_router(extraction.router, prefix="/api/v1")
 app.include_router(extraction_ground_truth.router, prefix="/api/v1")
 app.include_router(extraction_eval.router, prefix="/api/v1")

--- a/backend/app/repositories/parse_run_repository.py
+++ b/backend/app/repositories/parse_run_repository.py
@@ -71,6 +71,17 @@ class ParseRunRepository:
         )
         return result.scalar_one_or_none()
 
+    async def list_for_source_document(
+        self, source_document_id: UUID
+    ) -> list[ParseRun]:
+        """Return all runs for a source, newest first."""
+        result = await self.session.execute(
+            select(ParseRun)
+            .where(ParseRun.source_document_id == source_document_id)
+            .order_by(ParseRun.created_at.desc())
+        )
+        return list(result.scalars().all())
+
     async def get_latest_for_content(
         self,
         *,

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -22,6 +22,7 @@ from app.dependencies.documents import get_storage_service, get_document_extract
 from app.models import User, DocumentStatus
 from app.ports import StorageService, DocumentExtractor
 from app.repositories.document_repository import DocumentRepository
+from app.repositories.parse_run_repository import ParseRunRepository
 from app.repositories.project_repository import ProjectRepository
 from app.repositories.parse_result_repository import ParseResultRepository
 from app.schemas.document import (
@@ -33,6 +34,7 @@ from app.schemas.document import (
     BulkMoveRequest,
     BulkMoveResponse,
 )
+from app.schemas.parse_run import ParseRunResponse
 from app.services.document_service import DocumentService, process_document_extraction, BulkUploadItemResult
 from app.services.parse_service import ParseService, process_document_parsing
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
@@ -434,6 +436,36 @@ async def download_document_file(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e)
         )
+
+
+@router.get(
+    "/{document_id}/parse-runs",
+    response_model=list[ParseRunResponse],
+    summary="List CDM ParseRuns for a document",
+    description=(
+        "Return every CDM ParseRun associated with this document's source, "
+        "newest first. Returns [] if the document has no CDM runs."
+    ),
+)
+async def list_document_parse_runs(
+    document_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List CDM ParseRuns for a document."""
+    document_repo = DocumentRepository(db)
+    document = await document_repo.get_by_id(document_id, current_user.id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found",
+        )
+    if document.source_document_id is None:
+        return []
+    runs = await ParseRunRepository(db).list_for_source_document(
+        document.source_document_id
+    )
+    return [ParseRunResponse.from_orm_row(r) for r in runs]
 
 
 @router.get(

--- a/backend/app/routers/parse_runs.py
+++ b/backend/app/routers/parse_runs.py
@@ -1,0 +1,73 @@
+"""Parse-runs API router — CDM read endpoints."""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_active_user
+from app.models import User
+from app.models.document import Document as DocumentORM
+from app.models.project import Project
+from app.repositories.parse_run_repository import ParseRunRepository
+from app.repositories.parsed_document_repository import ParsedDocumentRepository
+from app.schemas.parse_run import ParsedDocumentResponse
+
+router = APIRouter(prefix="/parse-runs", tags=["parse-runs"])
+
+
+async def _user_owns_source(
+    db: AsyncSession, *, source_document_id: UUID, user_id: UUID
+) -> bool:
+    """True iff the user owns any Document pointing at this source_document_id."""
+    result = await db.execute(
+        select(DocumentORM.id)
+        .join(DocumentORM.project)
+        .where(
+            and_(
+                DocumentORM.source_document_id == source_document_id,
+                Project.user_id == user_id,
+            )
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+@router.get(
+    "/{parse_run_id}/parsed-document",
+    response_model=ParsedDocumentResponse,
+    summary="Get the ParsedDocument content for a ParseRun",
+    description=(
+        "Return the full CDM content blob produced by a ParseRun. "
+        "Returns 404 if the run has no associated ParsedDocument "
+        "(e.g. the run failed)."
+    ),
+)
+async def get_parsed_document_for_run(
+    parse_run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    run = await ParseRunRepository(db).get(parse_run_id)
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ParseRun {parse_run_id} not found",
+        )
+    owns = await _user_owns_source(
+        db, source_document_id=run.source_document_id, user_id=current_user.id
+    )
+    if not owns:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to view this ParseRun",
+        )
+    parsed = await ParsedDocumentRepository(db).get_by_run(parse_run_id)
+    if parsed is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No ParsedDocument for ParseRun {parse_run_id}",
+        )
+    return ParsedDocumentResponse.from_orm_row(parsed)

--- a/backend/app/schemas/parse_run.py
+++ b/backend/app/schemas/parse_run.py
@@ -1,0 +1,56 @@
+"""Response schemas for CDM ParseRun + ParsedDocument viewer endpoints."""
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.parse_run import ParseRun as ParseRunORM
+from app.models.parsed_document import ParsedDocument as ParsedDocumentORM
+
+
+class ParseRunResponse(BaseModel):
+    """Execution row for a parser invocation."""
+
+    id: UUID
+    source_document_id: UUID = Field(..., alias="sourceDocumentId")
+    parser: str
+    parser_version: str | None = Field(None, alias="parserVersion")
+    representation_kind: str = Field(..., alias="representationKind")
+    status: str
+    started_at: datetime = Field(..., alias="startedAt")
+    finished_at: datetime | None = Field(None, alias="finishedAt")
+    duration_ms: int | None = Field(None, alias="durationMs")
+    input_tokens: int | None = Field(None, alias="inputTokens")
+    output_tokens: int | None = Field(None, alias="outputTokens")
+    cost: dict[str, Any]
+    warnings: list[str]
+    failed_pages: list[int] = Field(..., alias="failedPages")
+    provider_refs: dict[str, Any] = Field(..., alias="providerRefs")
+    error: str | None
+    config: dict[str, Any]
+    created_at: datetime = Field(..., alias="createdAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_row(cls, row: ParseRunORM) -> "ParseRunResponse":
+        return cls.model_validate(row)
+
+
+class ParsedDocumentResponse(BaseModel):
+    """Content blob for a successful (or partial) ParseRun."""
+
+    parse_run_id: UUID = Field(..., alias="parseRunId")
+    source_document_id: UUID = Field(..., alias="sourceDocumentId")
+    page_count: int = Field(..., alias="pageCount")
+    block_count: int = Field(..., alias="blockCount")
+    full_text: str | None = Field(None, alias="fullText")
+    full_markdown: str | None = Field(None, alias="fullMarkdown")
+    content: dict[str, Any]
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_row(cls, row: ParsedDocumentORM) -> "ParsedDocumentResponse":
+        return cls.model_validate(row)

--- a/backend/tests/repositories/test_parse_run_repository.py
+++ b/backend/tests/repositories/test_parse_run_repository.py
@@ -184,6 +184,44 @@ async def test_get_latest_for_project_returns_none_for_config_mismatch(repo, sou
 
 
 @pytest.mark.asyncio
+async def test_list_for_source_document_empty(repo):
+    assert await repo.list_for_source_document(uuid4()) == []
+
+
+@pytest.mark.asyncio
+async def test_list_for_source_document_orders_newest_first(
+    repo, source_doc, test_db
+):
+    r1 = await repo.create(make_dto(source_doc, config_hash="1" * 64))
+    r2 = await repo.create(make_dto(source_doc, config_hash="2" * 64))
+    r3 = await repo.create(make_dto(source_doc, config_hash="3" * 64))
+
+    # Bump created_at deterministically: r2 newest, r3 middle, r1 oldest.
+    r1.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    r3.created_at = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    r2.created_at = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    await test_db.commit()
+
+    rows = await repo.list_for_source_document(source_doc.id)
+    assert [r.id for r in rows] == [r2.id, r3.id, r1.id]
+
+
+@pytest.mark.asyncio
+async def test_list_for_source_document_excludes_other_sources(
+    repo, source_doc, test_db
+):
+    await repo.create(make_dto(source_doc, config_hash="1" * 64))
+    other = SourceDocument(id=uuid4(), sha256="c" * 64, storage_uri="local://c.pdf")
+    test_db.add(other)
+    await test_db.commit()
+    await test_db.refresh(other)
+    other_run = await repo.create(make_dto(other, config_hash="2" * 64))
+
+    rows = await repo.list_for_source_document(other.id)
+    assert [r.id for r in rows] == [other_run.id]
+
+
+@pytest.mark.asyncio
 async def test_create_with_explicit_id(repo, source_doc):
     explicit_id = uuid4()
     run = await repo.create(make_dto(source_doc, id=explicit_id))

--- a/backend/tests/routers/test_documents_parse_runs_router.py
+++ b/backend/tests/routers/test_documents_parse_runs_router.py
@@ -1,0 +1,184 @@
+"""Tests for GET /documents/{id}/parse-runs."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document as DocumentORM
+from app.models.parse_run import ParseRun as ParseRunORM
+from app.models.project import Project
+from app.models.source_document import SourceDocument
+from app.models.user import User
+
+
+async def _signup_and_login(client: AsyncClient, email: str = "u1@example.com") -> str:
+    await client.post(
+        "/api/v1/auth/signup",
+        json={
+            "email": email,
+            "password": "ValidPass123!",
+            "password_confirm": "ValidPass123!",
+            "full_name": "Test User",
+        },
+    )
+    resp = await client.post(
+        "/api/v1/auth/signin",
+        json={"email": email, "password": "ValidPass123!"},
+    )
+    return resp.json()["access_token"]
+
+
+async def _get_user_by_email(test_db: AsyncSession, email: str) -> User:
+    from sqlalchemy import select
+
+    result = await test_db.execute(select(User).where(User.email == email))
+    return result.scalar_one()
+
+
+def _make_run(source_id, *, config_hash: str, started_at=None) -> ParseRunORM:
+    return ParseRunORM(
+        source_document_id=source_id,
+        parser="llamaparse",
+        representation_kind="vector_light",
+        config={"k": "v"},
+        config_hash=config_hash,
+        status="succeeded",
+        started_at=started_at or datetime.now(timezone.utc),
+    )
+
+
+async def _seed_doc_with_runs(
+    test_db: AsyncSession,
+    user: User,
+    *,
+    with_source: bool = True,
+    n_runs: int = 0,
+) -> tuple[DocumentORM, list[ParseRunORM]]:
+    project = Project(user_id=user.id, name="P")
+    test_db.add(project)
+    await test_db.commit()
+    await test_db.refresh(project)
+
+    source_id = None
+    if with_source:
+        sd = SourceDocument(
+            id=uuid4(), sha256="a" * 64, storage_uri="local://a.pdf"
+        )
+        test_db.add(sd)
+        await test_db.commit()
+        await test_db.refresh(sd)
+        source_id = sd.id
+
+    doc = DocumentORM(
+        project_id=project.id,
+        source_document_id=source_id,
+        source_type="upload",
+        source_identifier="a.pdf",
+        title="A",
+        status="ready",
+        created_by=user.id,
+    )
+    test_db.add(doc)
+    await test_db.commit()
+    await test_db.refresh(doc)
+
+    runs: list[ParseRunORM] = []
+    if source_id is not None:
+        for i in range(n_runs):
+            run = _make_run(source_id, config_hash=str(i) * 64)
+            test_db.add(run)
+            runs.append(run)
+        if runs:
+            await test_db.commit()
+            for r in runs:
+                await test_db.refresh(r)
+            # Deterministic ordering: index 0 = oldest, last = newest
+            for i, r in enumerate(runs):
+                r.created_at = datetime(2026, 1, i + 1, tzinfo=timezone.utc)
+            await test_db.commit()
+    return doc, runs
+
+
+@pytest.mark.asyncio
+async def test_404_for_unknown_document(client: AsyncClient):
+    token = await _signup_and_login(client)
+    resp = await client.get(
+        f"/api/v1/documents/{uuid4()}/parse-runs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_404_for_other_users_document(
+    client: AsyncClient, test_db: AsyncSession
+):
+    # User A owns the doc, User B tries to access it.
+    token_a = await _signup_and_login(client, "a@example.com")
+    user_a = await _get_user_by_email(test_db, "a@example.com")
+    doc, _ = await _seed_doc_with_runs(test_db, user_a, n_runs=1)
+
+    token_b = await _signup_and_login(client, "b@example.com")
+    resp = await client.get(
+        f"/api/v1/documents/{doc.id}/parse-runs",
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert resp.status_code == 404
+    # Owner can see it
+    resp = await client.get(
+        f"/api/v1/documents/{doc.id}/parse-runs",
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_empty_list_when_no_source_document(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup_and_login(client)
+    user = await _get_user_by_email(test_db, "u1@example.com")
+    doc, _ = await _seed_doc_with_runs(test_db, user, with_source=False)
+
+    resp = await client.get(
+        f"/api/v1/documents/{doc.id}/parse-runs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_returns_runs_newest_first_with_camel_case(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup_and_login(client)
+    user = await _get_user_by_email(test_db, "u1@example.com")
+    doc, runs = await _seed_doc_with_runs(test_db, user, n_runs=3)
+
+    resp = await client.get(
+        f"/api/v1/documents/{doc.id}/parse-runs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload) == 3
+    # Newest first: runs created in order 0,1,2 with created_at jan 1,2,3 → order 2,1,0
+    expected_ids = [str(runs[2].id), str(runs[1].id), str(runs[0].id)]
+    assert [r["id"] for r in payload] == expected_ids
+
+    first = payload[0]
+    for key in (
+        "sourceDocumentId",
+        "representationKind",
+        "startedAt",
+        "failedPages",
+        "providerRefs",
+        "createdAt",
+    ):
+        assert key in first, f"missing camelCase key {key}"
+    assert first["parser"] == "llamaparse"

--- a/backend/tests/routers/test_parse_runs_router.py
+++ b/backend/tests/routers/test_parse_runs_router.py
@@ -1,0 +1,160 @@
+"""Tests for GET /parse-runs/{id}/parsed-document."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document as DocumentORM
+from app.models.parse_run import ParseRun as ParseRunORM
+from app.models.parsed_document import ParsedDocument as ParsedDocumentORM
+from app.models.project import Project
+from app.models.source_document import SourceDocument
+from app.models.user import User
+
+
+async def _signup_and_login(client: AsyncClient, email: str) -> str:
+    await client.post(
+        "/api/v1/auth/signup",
+        json={
+            "email": email,
+            "password": "ValidPass123!",
+            "password_confirm": "ValidPass123!",
+            "full_name": "Test User",
+        },
+    )
+    resp = await client.post(
+        "/api/v1/auth/signin",
+        json={"email": email, "password": "ValidPass123!"},
+    )
+    return resp.json()["access_token"]
+
+
+async def _user_by_email(test_db: AsyncSession, email: str) -> User:
+    result = await test_db.execute(select(User).where(User.email == email))
+    return result.scalar_one()
+
+
+async def _seed(
+    test_db: AsyncSession,
+    user: User,
+    *,
+    with_parsed_doc: bool = True,
+) -> ParseRunORM:
+    project = Project(user_id=user.id, name="P")
+    test_db.add(project)
+    await test_db.commit()
+    await test_db.refresh(project)
+
+    sd = SourceDocument(id=uuid4(), sha256="a" * 64, storage_uri="local://a.pdf")
+    test_db.add(sd)
+    await test_db.commit()
+    await test_db.refresh(sd)
+
+    doc = DocumentORM(
+        project_id=project.id,
+        source_document_id=sd.id,
+        source_type="upload",
+        source_identifier="a.pdf",
+        title="A",
+        status="ready",
+        created_by=user.id,
+    )
+    test_db.add(doc)
+
+    run = ParseRunORM(
+        source_document_id=sd.id,
+        parser="llamaparse",
+        representation_kind="vector_light",
+        config={},
+        config_hash="c" * 64,
+        status="succeeded",
+        started_at=datetime.now(timezone.utc),
+    )
+    test_db.add(run)
+    await test_db.commit()
+    await test_db.refresh(run)
+
+    if with_parsed_doc:
+        parsed = ParsedDocumentORM(
+            parse_run_id=run.id,
+            source_document_id=sd.id,
+            full_text="hello",
+            full_markdown="# hello",
+            page_count=1,
+            block_count=2,
+            content={"schema_version": "1", "pages": [], "blocks": []},
+        )
+        test_db.add(parsed)
+        await test_db.commit()
+
+    return run
+
+
+@pytest.mark.asyncio
+async def test_200_returns_parsed_document_with_camel_case(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup_and_login(client, "u1@example.com")
+    user = await _user_by_email(test_db, "u1@example.com")
+    run = await _seed(test_db, user)
+
+    resp = await client.get(
+        f"/api/v1/parse-runs/{run.id}/parsed-document",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["parseRunId"] == str(run.id)
+    assert body["sourceDocumentId"] == str(run.source_document_id)
+    assert body["pageCount"] == 1
+    assert body["blockCount"] == 2
+    assert body["fullText"] == "hello"
+    assert body["fullMarkdown"] == "# hello"
+    assert body["content"]["schema_version"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_404_when_run_does_not_exist(client: AsyncClient):
+    token = await _signup_and_login(client, "u1@example.com")
+    resp = await client.get(
+        f"/api/v1/parse-runs/{uuid4()}/parsed-document",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_404_when_run_has_no_parsed_document(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup_and_login(client, "u1@example.com")
+    user = await _user_by_email(test_db, "u1@example.com")
+    run = await _seed(test_db, user, with_parsed_doc=False)
+
+    resp = await client.get(
+        f"/api/v1/parse-runs/{run.id}/parsed-document",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_403_when_user_does_not_own_source(
+    client: AsyncClient, test_db: AsyncSession
+):
+    # User A seeds a run; User B calls the endpoint.
+    await _signup_and_login(client, "a@example.com")
+    user_a = await _user_by_email(test_db, "a@example.com")
+    run = await _seed(test_db, user_a)
+
+    token_b = await _signup_and_login(client, "b@example.com")
+    resp = await client.get(
+        f"/api/v1/parse-runs/{run.id}/parsed-document",
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert resp.status_code == 403

--- a/docs/planning/2026-04-24-cdm-viewer-backend.md
+++ b/docs/planning/2026-04-24-cdm-viewer-backend.md
@@ -1,0 +1,146 @@
+# CDM Viewer Backend — Read Endpoints for ParseRun + ParsedDocument
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose two read-only HTTP endpoints so a frontend viewer can browse persisted CDM records: `GET /documents/{id}/parse-runs` and `GET /parse-runs/{id}/parsed-document`. Persistence already landed in PR #29; the viewer UI is a sibling PR.
+
+**Architecture:** Thin projections of existing ORM rows. New schemas, a new `list_for_source_document` repository method, two route handlers, authorization via the owning `Document`. No migrations.
+
+**Tech Stack:** Python 3.12, FastAPI (async), SQLAlchemy 2.0, pytest-asyncio, `pytest -o "addopts="`.
+
+**Spec:** [docs/specs/cdm_viewer_backend.md](../specs/cdm_viewer_backend.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/app/schemas/parse_run.py` — `ParseRunResponse`, `ParsedDocumentResponse`
+- `backend/app/routers/parse_runs.py` — `/parse-runs/{id}/parsed-document` handler
+- `backend/tests/routers/test_parse_runs_router.py`
+- `backend/tests/routers/test_documents_parse_runs_router.py`
+
+**Modify:**
+- `backend/app/repositories/parse_run_repository.py` — add `list_for_source_document`
+- `backend/app/routers/documents.py` — add `GET /documents/{id}/parse-runs`
+- `backend/app/main.py` (or wherever routers are registered) — register `parse_runs.py`
+- `backend/tests/repositories/test_parse_run_repository.py` — cover new method
+
+---
+
+## Preflight
+
+- [ ] **Preflight 1: Branch from main**
+
+```bash
+git -C /c/Repos/rag-admin checkout -b feat/cdm-viewer-backend main
+git -C /c/Repos/rag-admin status
+```
+
+Expected: `On branch feat/cdm-viewer-backend`, clean tree.
+
+- [ ] **Preflight 2: Baseline test suite passes**
+
+```bash
+uv run --directory /c/Repos/rag-admin/backend python -m pytest -o "addopts=" -x
+```
+
+Expected: all tests green.
+
+---
+
+## Task 1 — Response schemas
+
+- [ ] Create `backend/app/schemas/parse_run.py` with two Pydantic v2 `BaseModel`s using camelCase aliases (`populate_by_name=True`):
+  - `ParseRunResponse` — all fields listed in spec §2.1. Include `createdAt`.
+  - `ParsedDocumentResponse` — fields in spec §2.2 (`parseRunId`, `sourceDocumentId`, `pageCount`, `blockCount`, `fullText`, `fullMarkdown`, `content`).
+- [ ] Add `from_orm_row` classmethod on each that accepts the ORM row and returns the schema.
+
+No tests yet (schemas are covered via router tests).
+
+---
+
+## Task 2 — Repository: `list_for_source_document`
+
+- [ ] Add to `ParseRunRepository`:
+
+```python
+async def list_for_source_document(self, source_document_id: UUID) -> list[ParseRun]:
+    result = await self.session.execute(
+        select(ParseRun)
+        .where(ParseRun.source_document_id == source_document_id)
+        .order_by(ParseRun.created_at.desc())
+    )
+    return list(result.scalars().all())
+```
+
+- [ ] Add a test in `backend/tests/repositories/test_parse_run_repository.py` covering:
+  - Returns `[]` for an unknown source_document_id
+  - Returns rows in `created_at DESC` order when ≥2 runs exist
+  - Does not return rows from other source_documents
+
+Run:
+
+```bash
+uv run --directory /c/Repos/rag-admin/backend python -m pytest -o "addopts=" backend/tests/repositories/test_parse_run_repository.py -x
+```
+
+Expected: new test passes, no regressions.
+
+---
+
+## Task 3 — Route: `GET /documents/{id}/parse-runs`
+
+- [ ] In `backend/app/routers/documents.py`, add a new route handler:
+  - Path: `/{document_id}/parse-runs`
+  - Deps: `get_current_active_user`, `AsyncSession`
+  - Load the `Document` (404 if missing). Authorize via existing project/user check pattern used by `GET /documents/{id}`.
+  - If `document.source_document_id is None`, return `[]`.
+  - Else call `ParseRunRepository(db).list_for_source_document(document.source_document_id)`, map to `ParseRunResponse[]`, return.
+
+- [ ] Write `backend/tests/routers/test_documents_parse_runs_router.py`:
+  - `404` for unknown document
+  - `403` for doc belonging to another user's project
+  - `[]` for doc with `source_document_id=None`
+  - Ordered list for doc with ≥2 runs
+  - Fields serialize as camelCase
+
+Run the new test file; verify green.
+
+---
+
+## Task 4 — Route: `GET /parse-runs/{id}/parsed-document`
+
+- [ ] Create `backend/app/routers/parse_runs.py` with router `APIRouter(prefix="/parse-runs", tags=["parse-runs"])`.
+- [ ] Handler `GET /{parse_run_id}/parsed-document`:
+  - Load `ParseRun` (404 if missing).
+  - Authorize: fetch all `Document` rows with `source_document_id == run.source_document_id`; 403 unless one is visible to the current user (reuse existing project-visibility helper; if none exists, inline the check).
+  - Call `ParsedDocumentRepository(db).get_by_run(run_id)`; 404 if missing (covers failed runs).
+  - Return `ParsedDocumentResponse`.
+- [ ] Register the router in `backend/app/main.py` alongside the others.
+- [ ] Write `backend/tests/routers/test_parse_runs_router.py` covering all 4 status codes (200 / 403 / 404-run / 404-no-parsed-doc) and camelCase output shape.
+
+Run the new test file; verify green.
+
+---
+
+## Task 5 — Full regression
+
+- [ ] Run the full backend suite:
+
+```bash
+uv run --directory /c/Repos/rag-admin/backend python -m pytest -o "addopts="
+```
+
+Expected: all green, including the new files.
+
+- [ ] Start the backend locally and hit both endpoints with `curl` against a real CDM-parsed document from a dev database to confirm the wire shape matches the spec.
+
+---
+
+## Task 6 — PR
+
+- [ ] Commit on `feat/cdm-viewer-backend`.
+- [ ] Open PR titled `feat(cdm): read endpoints for ParseRun + ParsedDocument`, linked to the GitHub issue.
+- [ ] In the PR body: link to `docs/specs/cdm_viewer_backend.md`, list endpoints, list files touched, confirm test run output.
+- [ ] Do not merge. Wait for user to review.

--- a/docs/planning/2026-04-24-cdm-viewer-frontend.md
+++ b/docs/planning/2026-04-24-cdm-viewer-frontend.md
@@ -1,0 +1,176 @@
+# CDM Viewer Frontend — ParsedDocument Viewer in Documents Sheet
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the two CDM backend endpoints inside the existing documents-page Sheet drawer: run selector + metrics strip + tabs for Markdown / Text / Pages / Metrics / Raw JSON. Depends on the backend PR (sibling plan). Re-parse is already wired via the existing upload flow and is out of scope.
+
+**Architecture:** One API module, one hook, one component. Reuses `Tabs`, `Badge`, `Select`, `Card`, `Skeleton`, `react-markdown`. No new dependencies. Mirrors the shape and pattern of `useParseResults` + `ParseResultViewer`.
+
+**Tech Stack:** React 18, TypeScript, Vite, shadcn/ui, Tailwind CSS, Vitest.
+
+**Spec:** [docs/specs/cdm_viewer_frontend.md](../specs/cdm_viewer_frontend.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `frontend/src/types/cdm.ts` — `ParseRunListItem`, `ParsedDocumentDetail`
+- `frontend/src/api/parseRuns.ts` — `listParseRuns`, `getParsedDocument`
+- `frontend/src/hooks/useParseRuns.ts`
+- `frontend/src/components/documents/ParsedDocumentViewer.tsx`
+- `frontend/src/components/documents/ParsedDocumentViewer.test.tsx`
+- `frontend/src/hooks/useParseRuns.test.ts`
+
+**Modify:**
+- `frontend/src/pages/DocumentsPage.tsx` — render `ParsedDocumentViewer` in Sheet drawer
+- `frontend/src/pages/ProjectDocumentsPage.tsx` — same
+
+---
+
+## Preflight
+
+- [ ] **Preflight 1: Backend PR merged (or available on a branch)**
+
+Confirm `GET /documents/{id}/parse-runs` and `GET /parse-runs/{id}/parsed-document` return the shapes in the backend spec. If developing in parallel, stub the API locally via MSW.
+
+- [ ] **Preflight 2: Branch from main**
+
+```bash
+git -C /c/Repos/rag-admin checkout -b feat/cdm-viewer-frontend main
+```
+
+- [ ] **Preflight 3: Baseline frontend checks**
+
+```bash
+npm --prefix /c/Repos/rag-admin/frontend run lint
+npm --prefix /c/Repos/rag-admin/frontend run build
+npx --prefix /c/Repos/rag-admin/frontend vitest run
+```
+
+Expected: all green.
+
+---
+
+## Task 1 — Types + API module
+
+- [ ] Create `frontend/src/types/cdm.ts` with:
+
+```ts
+export interface ParseRunListItem {
+  id: string
+  sourceDocumentId: string
+  parser: string
+  parserVersion: string | null
+  representationKind: string
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'partial'
+  startedAt: string
+  finishedAt: string | null
+  durationMs: number | null
+  inputTokens: number | null
+  outputTokens: number | null
+  cost: Record<string, unknown>
+  warnings: string[]
+  failedPages: number[]
+  providerRefs: Record<string, unknown>
+  error: string | null
+  config: Record<string, unknown>
+  createdAt: string
+}
+
+export interface ParsedDocumentDetail {
+  parseRunId: string
+  sourceDocumentId: string
+  pageCount: number
+  blockCount: number
+  fullText: string | null
+  fullMarkdown: string | null
+  content: Record<string, unknown>   // full ParsedDocument JSON
+}
+```
+
+- [ ] Create `frontend/src/api/parseRuns.ts` with `listParseRuns(documentId)` and `getParsedDocument(parseRunId)` using `apiClient` (mirror `frontend/src/api/parsing.ts`).
+
+---
+
+## Task 2 — `useParseRuns` hook
+
+- [ ] Create `frontend/src/hooks/useParseRuns.ts`.
+- [ ] Local state: `parseRuns`, `selectedRunId`, `parsedDocument`, loading flags, error.
+- [ ] Effect 1: on `documentId` change, call `listParseRuns`; on success, auto-select newest `succeeded` or `partial`; if none, newest run of any status.
+- [ ] Effect 2: on `selectedRunId` change, if the selected run's `status` is not `failed`, call `getParsedDocument`. For `failed`, clear `parsedDocument`.
+- [ ] Poll: while any run has `status in ("pending","running")`, refresh the list every 5000 ms via `setInterval`; clear when terminal. Clean up on unmount.
+- [ ] Return the shape in spec §5.
+
+- [ ] Create `frontend/src/hooks/useParseRuns.test.ts` covering:
+  - auto-selects newest succeeded run
+  - clears `parsedDocument` and does not fetch when selecting a failed run
+  - stops polling when all runs are terminal
+
+---
+
+## Task 3 — `ParsedDocumentViewer` component
+
+- [ ] Create `frontend/src/components/documents/ParsedDocumentViewer.tsx`.
+- [ ] Props: `{ documentId: string }`.
+- [ ] Uses `useParseRuns(documentId)`.
+- [ ] Early returns:
+  - loading → `<Skeleton>` card
+  - error → destructive `<Card>` with error
+  - `parseRuns.length === 0` → `return null` (parent handles absence)
+
+- [ ] Render the layout described in spec §3:
+  1. Header row: `<h3>CDM Parse</h3>` + `<Select>` of runs (if ≥2).
+  2. Metrics strip (status badge, duration, tokens, cost, warnings, failed_pages).
+  3. If `selectedRun.status in ("pending","running")`: spinner + "Parse in progress…" and stop here.
+  4. If `selectedRun.status === "failed"`: show `error` and stop.
+  5. Otherwise: `<Tabs defaultValue="markdown">` with five tabs per spec §3.3.
+  6. Pages tab: map `(content.pages as Page[])` to a list of collapsible cards; each card lists `content.blocks` filtered by `page_index`.
+
+- [ ] Extract helpers where clean: `RunMetricsStrip`, `PageBlockList`.
+
+- [ ] Create `ParsedDocumentViewer.test.tsx`:
+  - renders run selector when 2 runs
+  - switches tabs
+  - renders markdown via react-markdown
+  - shows failed-run error state (no content fetch)
+  - shows pending spinner
+
+Run `npx vitest run` in the frontend directory; fix until green.
+
+---
+
+## Task 4 — Wire into pages
+
+- [ ] In `frontend/src/pages/DocumentsPage.tsx`, locate the Sheet body where `<ParseResultViewer documentId=... />` is rendered. Add `<ParsedDocumentViewer documentId=... />` immediately above it. The component itself returns `null` when no CDM runs exist, so no extra guard is needed.
+- [ ] Repeat in `frontend/src/pages/ProjectDocumentsPage.tsx`.
+
+---
+
+## Task 5 — Full regression
+
+- [ ] Run all frontend checks:
+
+```bash
+npm --prefix /c/Repos/rag-admin/frontend run lint
+npm --prefix /c/Repos/rag-admin/frontend run build
+npx --prefix /c/Repos/rag-admin/frontend vitest run
+```
+
+Expected: all green.
+
+- [ ] Manual smoke test via Docker local stack (see CLAUDE.md "Local Testing"): upload a PDF with `USE_CDM_PARSER=true`, open the documents Sheet, verify:
+  - viewer appears above legacy viewer
+  - run selector visible once ≥2 runs exist (re-parse to create one)
+  - all five tabs render
+  - metrics strip shows duration + tokens
+  - failed runs show error state without crashing
+
+---
+
+## Task 6 — PR
+
+- [ ] Commit on `feat/cdm-viewer-frontend`.
+- [ ] Open PR titled `feat(cdm): ParsedDocument viewer in documents sheet`, linked to the GitHub issue.
+- [ ] Body: link spec, screenshots of the five tabs, confirm lint/build/test output.
+- [ ] Do not merge. Wait for user to review.

--- a/docs/specs/cdm_viewer_backend.md
+++ b/docs/specs/cdm_viewer_backend.md
@@ -1,0 +1,136 @@
+# CDM Viewer — Backend Spec
+
+> **Status**: Spec for implementation.
+> **Scope**: Read-only HTTP surface for browsing `ParseRun` + `ParsedDocument` records that were persisted by the CDM path in [cdm_persistence.md](cdm_persistence.md).
+> **Out of scope**: Re-parse trigger (already wired via existing upload/re-parse path), PDF rendering, bbox overlays, UI.
+> **Reference**: [cdm_v1.md §11.4](cdm_v1.md), [cdm_persistence.md](cdm_persistence.md).
+
+---
+
+## 1. Goals
+
+1. Expose the two CDM records a viewer needs: the list of `ParseRun`s for a document, and the full `ParsedDocument` content for a run.
+2. Do not duplicate the legacy `/parse-results` surface — this is the CDM-native path. Both coexist until the legacy adapter is retired.
+3. Keep the wire shape a thin, obvious projection of the ORM rows. No invented fields.
+
+Non-goals: pagination (page counts are small, O(10) runs per doc), filtering, mutation.
+
+---
+
+## 2. Endpoints
+
+### 2.1 `GET /documents/{document_id}/parse-runs`
+
+List all `ParseRun` rows associated with a document, newest first.
+
+**Resolution:** `Document.source_document_id → ParseRun.source_document_id`. If the document has no `source_document_id` (legacy row pre-CDM), return `[]`.
+
+**Response** (`200 OK`):
+
+```json
+[
+  {
+    "id": "uuid",
+    "source_document_id": "uuid",
+    "parser": "llamaparse",
+    "parser_version": null,
+    "representation_kind": "vector_light",
+    "status": "succeeded",
+    "started_at": "2026-04-24T10:00:00Z",
+    "finished_at": "2026-04-24T10:00:12Z",
+    "duration_ms": 12340,
+    "input_tokens": 1200,
+    "output_tokens": 450,
+    "cost": {"credits": 1.2},
+    "warnings": [],
+    "failed_pages": [],
+    "provider_refs": {"llamaparse_job_id": "..."},
+    "error": null,
+    "config": {"parser_mode": "parse_page_with_agent"},
+    "created_at": "2026-04-24T10:00:00Z"
+  }
+]
+```
+
+**Errors:** `404` if document not found or not accessible to the current user.
+
+### 2.2 `GET /parse-runs/{parse_run_id}/parsed-document`
+
+Return the `ParsedDocument` content blob associated with a run.
+
+**Response** (`200 OK`):
+
+```json
+{
+  "parse_run_id": "uuid",
+  "source_document_id": "uuid",
+  "page_count": 3,
+  "block_count": 47,
+  "full_text": "…",
+  "full_markdown": "…",
+  "content": { "…raw ParsedDocument Pydantic JSON…" }
+}
+```
+
+`content` is the full round-trippable CDM payload (pages, blocks, tables, bboxes). The top-level scalar fields (`page_count`, `full_text`, etc.) are duplicated for clients that only need summaries.
+
+**Errors:**
+- `404` if the run doesn't exist, or exists but has no `ParsedDocument` (e.g. status=`failed`).
+- `403` if the user doesn't own any `Document` pointing at the run's `source_document_id`.
+
+---
+
+## 3. Authorization
+
+Both endpoints require an authenticated user. A user can read a `ParseRun` / `ParsedDocument` iff they own a `Document` whose `source_document_id` matches the run's `source_document_id`. Cross-project reuse (same bytes, different project) is deferred — the auth check scopes to "any Document visible to this user".
+
+Rationale: `source_documents` is content-addressed and project-agnostic, but access is gated through `documents`. This keeps us consistent with the existing `GET /documents/{id}` authorization model.
+
+---
+
+## 4. Schemas
+
+Add to `backend/app/schemas/parse_run.py` (new file):
+
+- `ParseRunResponse` — list item shape from §2.1.
+- `ParsedDocumentResponse` — detail shape from §2.2.
+
+Use camelCase aliases on response models (matches existing `DocumentResponse` convention — see [frontend/src/types/parsing.ts](../../frontend/src/types/parsing.ts) for consumer expectation).
+
+---
+
+## 5. Repository additions
+
+Add to `ParseRunRepository`:
+
+- `list_for_source_document(source_document_id: UUID) -> list[ParseRun]` — ordered by `created_at DESC`.
+
+`ParsedDocumentRepository.get_by_run` already exists.
+
+No changes to `SourceDocumentRepository`.
+
+---
+
+## 6. Router wiring
+
+New router module `backend/app/routers/parse_runs.py` for the `/parse-runs/{id}/…` routes. The `/documents/{id}/parse-runs` route lives on the existing `documents.py` router next to `/documents/{id}/parse-results`.
+
+Both routers share a small dependency `get_parse_run_service` in `app/dependencies/parsing.py` (or extend the existing `get_parsing_service`).
+
+---
+
+## 7. Testing
+
+- `backend/tests/routers/test_parse_runs_router.py` — 404 for missing doc, empty list for pre-CDM doc, populated list for doc with ≥1 run, ordering is newest-first, 403 for cross-user access.
+- `backend/tests/routers/test_parsed_document_router.py` — 200 for existing succeeded run, 404 for non-existent run, 404 for failed run (no ParsedDocument row), 403 for cross-user access.
+- `backend/tests/repositories/test_parse_run_repository.py` — add a test for `list_for_source_document` ordering and empty case.
+
+---
+
+## 8. Acceptance Criteria
+
+1. Both endpoints implemented, returning the shapes in §2.
+2. Authorization enforces the user-owns-a-Document-pointing-at-this-source rule.
+3. Tests in §7 pass. Existing backend tests continue to pass.
+4. No schema migrations required (reads only against existing tables).
+5. `/parse-results` legacy endpoints remain untouched.

--- a/docs/specs/cdm_viewer_frontend.md
+++ b/docs/specs/cdm_viewer_frontend.md
@@ -1,0 +1,132 @@
+# CDM Viewer — Frontend Spec
+
+> **Status**: Spec for implementation.
+> **Scope**: Read-only UI for browsing a document's `ParseRun`s and the resulting `ParsedDocument` content, inside the existing documents-page Sheet drawer.
+> **Depends on**: [cdm_viewer_backend.md](cdm_viewer_backend.md) endpoints.
+> **Out of scope**: PDF rendering, bbox overlays, block→PDF click-through, re-run-with-different-config (already wired via existing re-parse flow), reading-order tree.
+> **Reference**: [cdm_v1.md §11.4](cdm_v1.md).
+
+---
+
+## 1. Goals
+
+1. Let a user open any document and inspect what the CDM parser produced: run metrics, full markdown, full text, per-page block breakdown.
+2. Fit into the existing `DocumentsPage` Sheet drawer next to the legacy `ParseResultViewer` — do not redesign the page.
+3. Reuse existing components (`Tabs`, `Badge`, `Select`, `Card`, `Skeleton`, `react-markdown`). No new dependencies.
+
+Non-goals: pagination, virtualization for huge docs (v1 assumes ≤100 pages), editing.
+
+---
+
+## 2. Placement
+
+In the documents-page Sheet drawer (see [DocumentsPage.tsx](../../frontend/src/pages/DocumentsPage.tsx)):
+
+- If the document has **≥1 CDM ParseRun**, render the new `<ParsedDocumentViewer documentId={id} />` **above** the legacy `<ParseResultViewer />`.
+- If the document has **0 CDM ParseRuns**, render nothing (the legacy viewer handles the pre-CDM case).
+- Apply the same logic in [ProjectDocumentsPage.tsx](../../frontend/src/pages/ProjectDocumentsPage.tsx).
+
+No feature flag — presence of CDM runs in the response determines visibility. The legacy viewer stays until the legacy adapter is retired (separate follow-up).
+
+---
+
+## 3. Component: `ParsedDocumentViewer`
+
+File: `frontend/src/components/documents/ParsedDocumentViewer.tsx`.
+
+### 3.1 Header
+
+- Title: "CDM Parse" (distinguishes from legacy "Parse Results").
+- Right side: `<Select>` of ParseRuns (if ≥2) — label format `{parser} / {representation_kind} / {startedAt relative time} · {status badge}`. Disabled when only one run exists; the single run is auto-selected.
+
+### 3.2 Run-level metrics strip
+
+Below header, before tabs. Compact horizontal row of labeled values:
+
+- Status badge (success/pending/failed/partial/running — reuse `StatusBadge` styling from `ParseResultViewer`).
+- Duration (`1.2s`, `12.4s`).
+- Tokens (`1,200 in / 450 out`) — hide if both null.
+- Cost (render key/value pairs from `cost` object, e.g. `1.2 credits`) — hide if empty.
+- Warning count — clickable; opens a popover listing warnings. Hide if empty.
+- Failed pages — small badge `failed: p3, p7`. Hide if empty.
+
+### 3.3 Tabs
+
+Five tabs, `markdown` default:
+
+1. **Markdown** — `full_markdown` rendered with `react-markdown` + `remark-gfm` + `rehype-raw` (match existing viewer styling).
+2. **Text** — `full_text` in a `<pre>` with `whitespace-pre-wrap`, monospace.
+3. **Pages** — vertical list of pages. Each page is a collapsible card:
+   - Header: `Page {index+1}` · `{block_count} blocks` · confidence badge (if present).
+   - Body (expanded): list of blocks for that page. Each block shows: role badge, one-line text preview (truncated), optional confidence chip. Click a block to expand its full markdown / text / bbox / native_type.
+4. **Metrics** — full dump of ParseRun fields in a key-value list (reuse `DiagnosticsView` pattern). Includes `provider_refs`, `config`, `parser_version`, `error`, raw `warnings`.
+5. **Raw JSON** — collapsible `<pre>` of the full `ParsedDocument.content` payload for debugging.
+
+Tab labels get count badges where useful (e.g. `Pages (3)`).
+
+### 3.4 States
+
+- **Loading list**: `<Skeleton>` placeholders matching `ParseResultViewer`.
+- **Empty list**: component returns `null` (handled at placement level — see §2).
+- **Loading detail** (ParsedDocument fetch): `<Skeleton>` tab body.
+- **Run selected but status=failed**: show metrics strip + error message, hide content tabs. `content` endpoint returns 404 for failed runs — don't call it.
+- **Run selected but status=running/pending**: spinner + "Parse in progress…". Re-poll every 5 s until `succeeded`/`failed`/`partial`.
+
+---
+
+## 4. API module
+
+File: `frontend/src/api/parseRuns.ts`.
+
+```ts
+export async function listParseRuns(documentId: string): Promise<ParseRunListItem[]>
+export async function getParsedDocument(parseRunId: string): Promise<ParsedDocumentDetail>
+```
+
+Shapes mirror the backend response (§2 of backend spec). Put types in `frontend/src/types/cdm.ts`.
+
+---
+
+## 5. Hook: `useParseRuns`
+
+File: `frontend/src/hooks/useParseRuns.ts`. One hook per feature (project convention).
+
+```ts
+useParseRuns(documentId: string): {
+  parseRuns: ParseRunListItem[]
+  selectedRun: ParseRunListItem | undefined
+  parsedDocument: ParsedDocumentDetail | undefined
+  isLoading: boolean            // list
+  isLoadingContent: boolean     // detail
+  error: string | null
+  selectRun: (id: string) => void
+}
+```
+
+Internal behaviour:
+- Fetch the list on mount + on `documentId` change.
+- Auto-select the newest `succeeded`/`partial` run; fall back to the newest run if none succeeded.
+- Fetch `parsedDocument` when a non-failed run is selected.
+- Poll the list every 5 s while any run has `status in ("pending","running")`; stop polling otherwise.
+
+No global state manager needed — local state + `useEffect` mirrors `useParseResults`.
+
+---
+
+## 6. Testing
+
+- `ParsedDocumentViewer.test.tsx` — renders metrics strip from ParseRun fields, switches tabs, renders markdown, renders page list, shows failure state for `status=failed`, shows spinner for `status=running`.
+- `useParseRuns.test.ts` — auto-selects newest succeeded run, swaps content on selection change, stops polling when all terminal.
+
+Use existing MSW / Vitest setup (mirror `ParseResultViewer.test.tsx`).
+
+---
+
+## 7. Acceptance Criteria
+
+1. Opening a document with ≥1 CDM ParseRun shows the new viewer above the legacy one.
+2. All five tabs render and switch correctly against a real `succeeded` run.
+3. Failed / running / pending runs render the correct placeholder state; no content fetch is issued for failed runs.
+4. Multi-run documents show the run selector; switching runs swaps the content.
+5. `npm run lint`, `npm run build`, `npx vitest run` all pass.
+6. Existing documents-page behaviour unchanged.


### PR DESCRIPTION
## Summary

Exposes two read-only endpoints so a frontend viewer can browse CDM records persisted in #29:

- `GET /documents/{id}/parse-runs` — list ParseRuns for a document, newest first
- `GET /parse-runs/{id}/parsed-document` — full ParsedDocument content blob

Authorization gated through the owning `Document`. No migrations.

Also adds the frontend sibling spec + plan under `docs/` — implementation ships in #32.

Closes #31

## Files

**Created:**
- `backend/app/schemas/parse_run.py` — `ParseRunResponse`, `ParsedDocumentResponse` (camelCase aliases)
- `backend/app/routers/parse_runs.py` — `/parse-runs/{id}/parsed-document` handler + owner check
- `backend/tests/routers/test_parse_runs_router.py` — 200/404/404/403 coverage
- `backend/tests/routers/test_documents_parse_runs_router.py` — 404, empty, ordering, camelCase
- `docs/specs/cdm_viewer_backend.md`, `docs/specs/cdm_viewer_frontend.md`
- `docs/planning/2026-04-24-cdm-viewer-backend.md`, `docs/planning/2026-04-24-cdm-viewer-frontend.md`

**Modified:**
- `backend/app/repositories/parse_run_repository.py` — add `list_for_source_document`
- `backend/app/routers/documents.py` — add `GET /{id}/parse-runs`
- `backend/app/main.py` — register `parse_runs` router
- `backend/tests/repositories/test_parse_run_repository.py` — 3 new tests for the list method

## Test Plan

Backend suite: `uv run --directory backend python -m pytest -o \"addopts=\"` → **475 passed**. One pre-existing failure (`test_project_repository.py::test_list_all_sorted_by_created_at`) is also failing on `main` — unrelated to this change.

- [x] `ParseRunRepository.list_for_source_document` returns `[]` / newest-first / scoped-to-source
- [x] `GET /documents/{id}/parse-runs` — 404 unknown doc, 404 for other user's doc, `[]` for doc with no source, newest-first with camelCase keys
- [x] `GET /parse-runs/{id}/parsed-document` — 200 with camelCase payload, 404 unknown run, 404 run-with-no-ParsedDocument (covers failed runs), 403 for cross-user
- [ ] Manual smoke (deferred — wire shape verified by tests; curl smoke requires running stack + real CDM doc, will happen during frontend PR integration)

## Spec

[docs/specs/cdm_viewer_backend.md](docs/specs/cdm_viewer_backend.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)