### PR TITLE
feat(cdm): ParsedDocument viewer in documents sheet

### DIFF
--- a/frontend/src/api/parseRuns.ts
+++ b/frontend/src/api/parseRuns.ts
@@ -1,0 +1,20 @@
+import apiClient from './client'
+import type { ParseRunListItem, ParsedDocumentDetail } from '@/types/cdm'
+
+export async function listParseRuns(
+  documentId: string
+): Promise<ParseRunListItem[]> {
+  const response = await apiClient.get<ParseRunListItem[]>(
+    `/documents/${documentId}/parse-runs`
+  )
+  return response.data
+}
+
+export async function getParsedDocument(
+  parseRunId: string
+): Promise<ParsedDocumentDetail> {
+  const response = await apiClient.get<ParsedDocumentDetail>(
+    `/parse-runs/${parseRunId}/parsed-document`
+  )
+  return response.data
+}

--- a/frontend/src/components/documents/ParsedDocumentViewer.tsx
+++ b/frontend/src/components/documents/ParsedDocumentViewer.tsx
@@ -1,0 +1,409 @@
+import { useMemo, useState } from 'react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useParseRuns } from '@/hooks/useParseRuns'
+import type { Block, ParseRunListItem, ParseRunStatus } from '@/types/cdm'
+
+interface ParsedDocumentViewerProps {
+  documentId: string
+}
+
+function StatusBadge({ status }: { status: ParseRunStatus }) {
+  switch (status) {
+    case 'succeeded':
+      return <Badge variant="success">Succeeded</Badge>
+    case 'partial':
+      return <Badge variant="warning">Partial</Badge>
+    case 'pending':
+    case 'running':
+      return <Badge variant="warning">{status === 'pending' ? 'Pending' : 'Running'}</Badge>
+    case 'failed':
+      return <Badge variant="destructive">Failed</Badge>
+    default:
+      return <Badge variant="secondary">{status}</Badge>
+  }
+}
+
+function formatDuration(ms: number | null): string | null {
+  if (ms === null) return null
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatRelative(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+function RunMetricsStrip({ run }: { run: ParseRunListItem }) {
+  const duration = formatDuration(run.durationMs)
+  const tokens =
+    run.inputTokens !== null || run.outputTokens !== null
+      ? `${run.inputTokens ?? 0} in / ${run.outputTokens ?? 0} out`
+      : null
+  const costEntries = Object.entries(run.cost)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+      <StatusBadge status={run.status} />
+      {duration && (
+        <span>
+          <span className="font-medium text-foreground">{duration}</span> elapsed
+        </span>
+      )}
+      {tokens && (
+        <span>
+          <span className="font-medium text-foreground">{tokens}</span> tokens
+        </span>
+      )}
+      {costEntries.length > 0 && (
+        <span>
+          {costEntries.map(([k, v]) => (
+            <span key={k} className="mr-2">
+              <span className="font-medium text-foreground">{String(v)}</span> {k}
+            </span>
+          ))}
+        </span>
+      )}
+      {run.warnings.length > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button className="underline decoration-dotted">
+              {run.warnings.length} warning{run.warnings.length === 1 ? '' : 's'}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="text-xs space-y-1 max-w-sm">
+            {run.warnings.map((w, i) => (
+              <div key={i}>{w}</div>
+            ))}
+          </PopoverContent>
+        </Popover>
+      )}
+      {run.failedPages.length > 0 && (
+        <Badge variant="destructive" className="text-xs">
+          failed: {run.failedPages.map((p) => `p${p}`).join(', ')}
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+function PageBlockList({ blocks }: { blocks: Block[] }) {
+  if (blocks.length === 0) {
+    return <p className="text-xs text-muted-foreground">No blocks on this page.</p>
+  }
+  return (
+    <div className="space-y-2">
+      {blocks.map((b) => {
+        const preview = (b.text ?? b.markdown ?? '').slice(0, 140)
+        const confidence = b.quality?.confidence
+        return (
+          <Collapsible key={b.id}>
+            <CollapsibleTrigger asChild>
+              <button className="w-full text-left border rounded-md px-2 py-1 hover:bg-muted/50">
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-xs">
+                    {b.role}
+                  </Badge>
+                  {typeof confidence === 'number' && (
+                    <Badge variant="outline" className="text-xs">
+                      {confidence.toFixed(2)}
+                    </Badge>
+                  )}
+                  <span className="text-xs text-muted-foreground truncate flex-1">
+                    {preview || <em>empty</em>}
+                  </span>
+                </div>
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="border border-t-0 rounded-b-md px-3 py-2 space-y-2 -mt-px">
+              {b.markdown ? (
+                <div className="prose prose-sm dark:prose-invert max-w-none">
+                  <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+                    {b.markdown}
+                  </Markdown>
+                </div>
+              ) : b.text ? (
+                <pre className="whitespace-pre-wrap font-mono text-xs">{b.text}</pre>
+              ) : (
+                <p className="text-xs text-muted-foreground">No text/markdown.</p>
+              )}
+              <div className="text-xs text-muted-foreground space-y-0.5">
+                {b.native_type && <div>native_type: {b.native_type}</div>}
+                {b.bbox && (
+                  <div>
+                    bbox: ({b.bbox.x0.toFixed(3)}, {b.bbox.y0.toFixed(3)}) →
+                    ({b.bbox.x1.toFixed(3)}, {b.bbox.y1.toFixed(3)})
+                  </div>
+                )}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        )
+      })}
+    </div>
+  )
+}
+
+function MetricsTab({ run }: { run: ParseRunListItem }) {
+  const rows: Array<[string, unknown]> = [
+    ['Status', run.status],
+    ['Parser', run.parser],
+    ['Parser version', run.parserVersion ?? '—'],
+    ['Representation', run.representationKind],
+    ['Started at', formatRelative(run.startedAt)],
+    ['Finished at', run.finishedAt ? formatRelative(run.finishedAt) : '—'],
+    ['Duration', formatDuration(run.durationMs) ?? '—'],
+    ['Input tokens', run.inputTokens ?? '—'],
+    ['Output tokens', run.outputTokens ?? '—'],
+    ['Cost', JSON.stringify(run.cost)],
+    ['Warnings', run.warnings.length > 0 ? run.warnings.join('; ') : '—'],
+    [
+      'Failed pages',
+      run.failedPages.length > 0 ? run.failedPages.join(', ') : '—',
+    ],
+    ['Provider refs', JSON.stringify(run.providerRefs)],
+    ['Config', JSON.stringify(run.config)],
+    ['Error', run.error ?? '—'],
+  ]
+  return (
+    <div className="space-y-1 text-sm">
+      {rows.map(([label, value]) => (
+        <div
+          key={label}
+          className="flex justify-between gap-3 py-1 border-b border-muted last:border-0"
+        >
+          <span className="font-medium">{label}</span>
+          <span className="text-muted-foreground font-mono text-xs text-right break-all">
+            {String(value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ParsedDocumentViewer({
+  documentId,
+}: ParsedDocumentViewerProps) {
+  const {
+    parseRuns,
+    selectedRun,
+    parsedDocument,
+    isLoading,
+    isLoadingContent,
+    error,
+    selectRun,
+  } = useParseRuns(documentId)
+
+  const blocksByPage = useMemo<Map<number, Block[]>>(() => {
+    const map = new Map<number, Block[]>()
+    const blocks = parsedDocument?.content?.blocks ?? []
+    for (const b of blocks) {
+      const arr = map.get(b.page_index) ?? []
+      arr.push(b)
+      map.set(b.page_index, arr)
+    }
+    return map
+  }, [parsedDocument])
+
+  const [tab, setTab] = useState('markdown')
+
+  if (isLoading) {
+    return (
+      <Card className="p-6">
+        <div className="space-y-4">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card className="p-6">
+        <p className="text-sm text-destructive">{error}</p>
+      </Card>
+    )
+  }
+
+  if (parseRuns.length === 0) return null
+
+  const isPending =
+    selectedRun?.status === 'pending' || selectedRun?.status === 'running'
+  const isFailed = selectedRun?.status === 'failed'
+  const pages = parsedDocument?.content?.pages ?? []
+
+  return (
+    <Card className="p-6">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-lg font-medium">CDM Parse</h3>
+          {parseRuns.length > 1 && selectedRun && (
+            <Select value={selectedRun.id} onValueChange={selectRun}>
+              <SelectTrigger className="w-[360px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {parseRuns.map((r) => (
+                  <SelectItem key={r.id} value={r.id}>
+                    <div className="flex items-center gap-2 text-xs">
+                      <StatusBadge status={r.status} />
+                      <span>
+                        {r.parser} / {r.representationKind} ·{' '}
+                        {formatRelative(r.startedAt)}
+                      </span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        {selectedRun && <RunMetricsStrip run={selectedRun} />}
+
+        {isPending && (
+          <div className="flex items-center gap-3 py-8 justify-center">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <span className="text-sm text-muted-foreground">
+              Parse in progress…
+            </span>
+          </div>
+        )}
+
+        {isFailed && selectedRun && (
+          <div className="text-sm text-destructive">
+            {selectedRun.error || 'Parse failed.'}
+          </div>
+        )}
+
+        {!isPending && !isFailed && selectedRun && (
+          <>
+            {isLoadingContent && (
+              <div className="space-y-3">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-64 w-full" />
+              </div>
+            )}
+            {parsedDocument && (
+              <Tabs value={tab} onValueChange={setTab}>
+                <TabsList>
+                  <TabsTrigger value="markdown">Markdown</TabsTrigger>
+                  <TabsTrigger value="text">Text</TabsTrigger>
+                  <TabsTrigger value="pages">
+                    Pages ({parsedDocument.pageCount})
+                  </TabsTrigger>
+                  <TabsTrigger value="metrics">Metrics</TabsTrigger>
+                  <TabsTrigger value="raw">Raw JSON</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="markdown" className="mt-4">
+                  <div className="prose prose-sm dark:prose-invert max-w-none bg-muted/30 p-4 rounded-lg max-h-[500px] overflow-y-auto">
+                    {parsedDocument.fullMarkdown ? (
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                      >
+                        {parsedDocument.fullMarkdown}
+                      </Markdown>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No markdown produced.
+                      </p>
+                    )}
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="text" className="mt-4">
+                  <div className="whitespace-pre-wrap font-mono text-sm leading-relaxed bg-muted/30 p-4 rounded-lg max-h-[500px] overflow-y-auto">
+                    {parsedDocument.fullText || 'No text content.'}
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="pages" className="mt-4">
+                  <div className="space-y-3 max-h-[500px] overflow-y-auto">
+                    {pages.length === 0 && (
+                      <p className="text-sm text-muted-foreground">
+                        No pages.
+                      </p>
+                    )}
+                    {pages.map((p) => {
+                      const blocks = blocksByPage.get(p.index) ?? []
+                      const confidence = p.quality?.confidence
+                      return (
+                        <Collapsible key={p.index} defaultOpen>
+                          <CollapsibleTrigger asChild>
+                            <button className="w-full text-left border rounded-md px-3 py-2 hover:bg-muted/50">
+                              <div className="flex items-center gap-3 text-sm">
+                                <span className="font-medium">
+                                  Page {p.index + 1}
+                                </span>
+                                <span className="text-muted-foreground text-xs">
+                                  {blocks.length} block
+                                  {blocks.length === 1 ? '' : 's'}
+                                </span>
+                                {typeof confidence === 'number' && (
+                                  <Badge
+                                    variant="outline"
+                                    className="text-xs ml-auto"
+                                  >
+                                    confidence {confidence.toFixed(2)}
+                                  </Badge>
+                                )}
+                              </div>
+                            </button>
+                          </CollapsibleTrigger>
+                          <CollapsibleContent className="border border-t-0 rounded-b-md p-3 -mt-px">
+                            <PageBlockList blocks={blocks} />
+                          </CollapsibleContent>
+                        </Collapsible>
+                      )
+                    })}
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="metrics" className="mt-4">
+                  <MetricsTab run={selectedRun} />
+                </TabsContent>
+
+                <TabsContent value="raw" className="mt-4">
+                  <pre className="font-mono text-xs bg-muted/30 p-4 rounded-lg overflow-auto max-h-[500px]">
+                    {JSON.stringify(parsedDocument.content, null, 2)}
+                  </pre>
+                </TabsContent>
+              </Tabs>
+            )}
+          </>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/hooks/useParseRuns.test.ts
+++ b/frontend/src/hooks/useParseRuns.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useParseRuns } from './useParseRuns'
+import type {
+  ParsedDocumentDetail,
+  ParseRunListItem,
+  ParseRunStatus,
+} from '@/types/cdm'
+
+vi.mock('@/api/parseRuns', () => ({
+  listParseRuns: vi.fn(),
+  getParsedDocument: vi.fn(),
+}))
+
+import * as api from '@/api/parseRuns'
+
+const mockListParseRuns = vi.mocked(api.listParseRuns)
+const mockGetParsedDocument = vi.mocked(api.getParsedDocument)
+
+function buildRun(overrides: Partial<ParseRunListItem> = {}): ParseRunListItem {
+  return {
+    id: overrides.id ?? 'run-1',
+    sourceDocumentId: 'src-1',
+    parser: 'llamaparse',
+    parserVersion: null,
+    representationKind: 'vector_light',
+    status: (overrides.status as ParseRunStatus) ?? 'succeeded',
+    startedAt: '2026-04-24T10:00:00Z',
+    finishedAt: '2026-04-24T10:00:12Z',
+    durationMs: 12000,
+    inputTokens: 100,
+    outputTokens: 50,
+    cost: {},
+    warnings: [],
+    failedPages: [],
+    providerRefs: {},
+    error: null,
+    config: {},
+    createdAt: '2026-04-24T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function buildDetail(
+  overrides: Partial<ParsedDocumentDetail> = {}
+): ParsedDocumentDetail {
+  return {
+    parseRunId: 'run-1',
+    sourceDocumentId: 'src-1',
+    pageCount: 1,
+    blockCount: 1,
+    fullText: 'hello',
+    fullMarkdown: '# hello',
+    content: { pages: [], blocks: [] },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useParseRuns', () => {
+  it('does not call the API when documentId is null', async () => {
+    const { result } = renderHook(() => useParseRuns(null))
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(mockListParseRuns).not.toHaveBeenCalled()
+  })
+
+  it('auto-selects newest succeeded run and fetches its parsed document', async () => {
+    // Backend returns newest-first. r-newest is failed, r-mid is succeeded.
+    const runs = [
+      buildRun({ id: 'r-newest', status: 'failed' }),
+      buildRun({ id: 'r-mid', status: 'succeeded' }),
+      buildRun({ id: 'r-oldest', status: 'succeeded' }),
+    ]
+    mockListParseRuns.mockResolvedValue(runs)
+    mockGetParsedDocument.mockResolvedValue(
+      buildDetail({ parseRunId: 'r-mid' })
+    )
+
+    const { result } = renderHook(() => useParseRuns('doc-1'))
+    await waitFor(() => {
+      expect(result.current.parseRuns).toHaveLength(3)
+    })
+    await waitFor(() => {
+      expect(result.current.parsedDocument?.parseRunId).toBe('r-mid')
+    })
+    expect(result.current.selectedRun?.id).toBe('r-mid')
+    expect(mockGetParsedDocument).toHaveBeenCalledWith('r-mid')
+  })
+
+  it('does not fetch parsed document for failed runs', async () => {
+    const runs = [
+      buildRun({ id: 'r1', status: 'succeeded' }),
+      buildRun({ id: 'r2', status: 'failed' }),
+    ]
+    mockListParseRuns.mockResolvedValue(runs)
+    mockGetParsedDocument.mockResolvedValue(buildDetail())
+
+    const { result } = renderHook(() => useParseRuns('doc-1'))
+    await waitFor(() => {
+      expect(result.current.selectedRun?.id).toBe('r1')
+    })
+    expect(mockGetParsedDocument).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.selectRun('r2')
+    })
+    await waitFor(() => {
+      expect(result.current.selectedRun?.id).toBe('r2')
+    })
+    expect(result.current.parsedDocument).toBeUndefined()
+    expect(mockGetParsedDocument).toHaveBeenCalledTimes(1) // no extra call
+  })
+
+  it('polls while a run is non-terminal and stops once all terminal', async () => {
+    mockListParseRuns
+      .mockResolvedValueOnce([buildRun({ id: 'r1', status: 'running' })])
+      .mockResolvedValueOnce([buildRun({ id: 'r1', status: 'running' })])
+      .mockResolvedValueOnce([buildRun({ id: 'r1', status: 'succeeded' })])
+    mockGetParsedDocument.mockResolvedValue(buildDetail({ parseRunId: 'r1' }))
+
+    const { result } = renderHook(() => useParseRuns('doc-1'))
+    await waitFor(() => {
+      expect(result.current.parseRuns[0]?.status).toBe('running')
+    })
+
+    // First poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(mockListParseRuns).toHaveBeenCalledTimes(2)
+
+    // Second poll → run flips to succeeded
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(mockListParseRuns).toHaveBeenCalledTimes(3)
+    await waitFor(() => {
+      expect(result.current.parseRuns[0]?.status).toBe('succeeded')
+    })
+
+    // Polling should have stopped: another tick should NOT call again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15000)
+    })
+    expect(mockListParseRuns).toHaveBeenCalledTimes(3)
+  })
+})

--- a/frontend/src/hooks/useParseRuns.ts
+++ b/frontend/src/hooks/useParseRuns.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as parseRunsApi from '@/api/parseRuns'
+import type {
+  ParsedDocumentDetail,
+  ParseRunListItem,
+  ParseRunStatus,
+} from '@/types/cdm'
+
+const POLLING_INTERVAL_MS = 5000
+
+const TERMINAL: ReadonlyArray<ParseRunStatus> = [
+  'succeeded',
+  'failed',
+  'partial',
+]
+
+function isTerminal(status: ParseRunStatus): boolean {
+  return TERMINAL.includes(status)
+}
+
+interface UseParseRunsReturn {
+  parseRuns: ParseRunListItem[]
+  selectedRun: ParseRunListItem | undefined
+  parsedDocument: ParsedDocumentDetail | undefined
+  isLoading: boolean
+  isLoadingContent: boolean
+  error: string | null
+  selectRun: (id: string) => void
+}
+
+function pickInitialRun(
+  runs: ParseRunListItem[]
+): ParseRunListItem | undefined {
+  if (runs.length === 0) return undefined
+  // Backend returns newest-first. Prefer succeeded/partial, else newest of any.
+  return (
+    runs.find((r) => r.status === 'succeeded' || r.status === 'partial') ??
+    runs[0]
+  )
+}
+
+export function useParseRuns(
+  documentId: string | null
+): UseParseRunsReturn {
+  const [parseRuns, setParseRuns] = useState<ParseRunListItem[]>([])
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+  const [parsedDocument, setParsedDocument] = useState<
+    ParsedDocumentDetail | undefined
+  >(undefined)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingContent, setIsLoadingContent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current !== null) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }, [])
+
+  const fetchList = useCallback(
+    async (
+      docId: string,
+      { silent = false }: { silent?: boolean } = {}
+    ): Promise<ParseRunListItem[]> => {
+      if (!silent) {
+        setIsLoading(true)
+        setError(null)
+      }
+      try {
+        const runs = await parseRunsApi.listParseRuns(docId)
+        setParseRuns(runs)
+        return runs
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to fetch parse runs'
+        )
+        return []
+      } finally {
+        if (!silent) setIsLoading(false)
+      }
+    },
+    []
+  )
+
+  // Initial fetch + auto-select on documentId change.
+  useEffect(() => {
+    let cancelled = false
+    if (!documentId) {
+      setParseRuns([])
+      setSelectedRunId(null)
+      setParsedDocument(undefined)
+      stopPolling()
+      return
+    }
+    void fetchList(documentId).then((runs) => {
+      if (cancelled) return
+      const initial = pickInitialRun(runs)
+      setSelectedRunId(initial?.id ?? null)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [documentId, fetchList, stopPolling])
+
+  // Poll while any run is non-terminal.
+  useEffect(() => {
+    if (!documentId) return
+    const hasActive = parseRuns.some((r) => !isTerminal(r.status))
+    if (!hasActive) {
+      stopPolling()
+      return
+    }
+    if (pollingRef.current !== null) return
+    pollingRef.current = setInterval(() => {
+      void fetchList(documentId, { silent: true })
+    }, POLLING_INTERVAL_MS)
+    return () => {
+      stopPolling()
+    }
+  }, [documentId, parseRuns, fetchList, stopPolling])
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => stopPolling()
+  }, [stopPolling])
+
+  // Fetch ParsedDocument when selection changes (skip for failed runs).
+  useEffect(() => {
+    let cancelled = false
+    if (selectedRunId === null) {
+      setParsedDocument(undefined)
+      return
+    }
+    const run = parseRuns.find((r) => r.id === selectedRunId)
+    if (!run) {
+      setParsedDocument(undefined)
+      return
+    }
+    if (run.status === 'failed' || run.status === 'pending' || run.status === 'running') {
+      setParsedDocument(undefined)
+      return
+    }
+    setIsLoadingContent(true)
+    void parseRunsApi
+      .getParsedDocument(selectedRunId)
+      .then((doc) => {
+        if (!cancelled) setParsedDocument(doc)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'Failed to fetch parsed document'
+          )
+          setParsedDocument(undefined)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingContent(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedRunId, parseRuns])
+
+  const selectRun = useCallback((id: string) => {
+    setSelectedRunId(id)
+  }, [])
+
+  const selectedRun = useMemo(
+    () => parseRuns.find((r) => r.id === selectedRunId),
+    [parseRuns, selectedRunId]
+  )
+
+  return {
+    parseRuns,
+    selectedRun,
+    parsedDocument,
+    isLoading,
+    isLoadingContent,
+    error,
+    selectRun,
+  }
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -16,6 +16,7 @@ import { DocumentEditDialog } from '@/components/documents/DocumentEditDialog'
 import { DocumentDeleteDialog } from '@/components/documents/DocumentDeleteDialog'
 import { DocumentUploadDialog } from '@/components/documents/DocumentUploadDialog'
 import { ParseResultViewer } from '@/components/documents/ParseResultViewer'
+import { ParsedDocumentViewer } from '@/components/documents/ParsedDocumentViewer'
 import { ReParseDialog } from '@/components/documents/ReParseDialog'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Plus, RotateCw, Files } from 'lucide-react'
@@ -364,6 +365,9 @@ export default function DocumentsPage(): JSX.Element {
             </div>
           </SheetHeader>
           <div className="mt-6 space-y-6">
+            {viewDocumentId && (
+              <ParsedDocumentViewer documentId={viewDocumentId} />
+            )}
             {viewDocumentId && parseResults.length > 0 && (
               <ParseResultViewer documentId={viewDocumentId} />
             )}

--- a/frontend/src/pages/ProjectDocumentsPage.tsx
+++ b/frontend/src/pages/ProjectDocumentsPage.tsx
@@ -13,6 +13,7 @@ import { DocumentTextViewer } from '@/components/documents/DocumentTextViewer'
 import { DocumentEditDialog } from '@/components/documents/DocumentEditDialog'
 import { DocumentDeleteDialog } from '@/components/documents/DocumentDeleteDialog'
 import { ParseResultViewer } from '@/components/documents/ParseResultViewer'
+import { ParsedDocumentViewer } from '@/components/documents/ParsedDocumentViewer'
 import { ReParseDialog } from '@/components/documents/ReParseDialog'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { RotateCw } from 'lucide-react'
@@ -249,6 +250,11 @@ export default function ProjectDocumentsPage(): JSX.Element {
             </div>
           </SheetHeader>
           <div className="mt-6 space-y-6">
+            {/* CDM Parse (renders nothing if no CDM runs exist) */}
+            {viewDocumentId && (
+              <ParsedDocumentViewer documentId={viewDocumentId} />
+            )}
+
             {/* Parse Results (if any) */}
             {viewDocumentId && parseResults.length > 0 && (
               <ParseResultViewer documentId={viewDocumentId} />

--- a/frontend/src/types/cdm.ts
+++ b/frontend/src/types/cdm.ts
@@ -1,0 +1,86 @@
+/**
+ * CDM viewer types — wire shape of the read endpoints in
+ * docs/specs/cdm_viewer_backend.md.
+ */
+
+export type ParseRunStatus =
+  | 'pending'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'partial'
+
+export interface ParseRunListItem {
+  id: string
+  sourceDocumentId: string
+  parser: string
+  parserVersion: string | null
+  representationKind: string
+  status: ParseRunStatus
+  startedAt: string
+  finishedAt: string | null
+  durationMs: number | null
+  inputTokens: number | null
+  outputTokens: number | null
+  cost: Record<string, unknown>
+  warnings: string[]
+  failedPages: number[]
+  providerRefs: Record<string, unknown>
+  error: string | null
+  config: Record<string, unknown>
+  createdAt: string
+}
+
+export interface ParsedDocumentDetail {
+  parseRunId: string
+  sourceDocumentId: string
+  pageCount: number
+  blockCount: number
+  fullText: string | null
+  fullMarkdown: string | null
+  /** Full ParsedDocument round-trippable JSON. */
+  content: ParsedDocumentContent
+}
+
+/**
+ * Subset of fields the viewer reads from the content blob.
+ * Kept loose because new parser_extras may appear over time.
+ */
+export interface ParsedDocumentContent {
+  pages?: Page[]
+  blocks?: Block[]
+  [key: string]: unknown
+}
+
+export interface Page {
+  index: number
+  width?: number
+  height?: number
+  block_ids?: string[]
+  quality?: { confidence?: number | null } | null
+  parser_extras?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface Block {
+  id: string
+  page_index: number
+  role: string
+  native_type?: string | null
+  native_label?: string | null
+  text?: string | null
+  markdown?: string | null
+  bbox?: Bbox | null
+  quality?: { confidence?: number | null } | null
+  parser_extras?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface Bbox {
+  x0: number
+  y0: number
+  x1: number
+  y1: number
+  source_space?: string | null
+  source_coords?: Record<string, unknown> | null
+}


### PR DESCRIPTION
## Summary
- Adds a read-only CDM ParsedDocument viewer rendered in the document detail sheet on both `DocumentsPage` and `ProjectDocumentsPage`.
- New `useParseRuns` hook fetches `/documents/{id}/parse-runs`, auto-selects newest succeeded/partial run, lazily fetches `/parse-runs/{id}/parsed-document`, and polls every 5s while any run is non-terminal.
- New `ParsedDocumentViewer` component: run selector + status badge, run-metrics strip (duration, tokens, cost, warnings, failed pages), and 5 tabs — Markdown, Text, Pages (per-page block list), Metrics, Raw JSON.

Depends on #33 (backend read endpoints).
Closes #32.

Refs spec: `docs/specs/cdm_viewer_frontend.md` (lives on main via #33).

## Files
- `frontend/src/types/cdm.ts` — wire types matching backend camelCase
- `frontend/src/api/parseRuns.ts` — `listParseRuns`, `getParsedDocument`
- `frontend/src/hooks/useParseRuns.ts` — list + selection + polling
- `frontend/src/hooks/useParseRuns.test.ts` — 4 unit tests (see note)
- `frontend/src/components/documents/ParsedDocumentViewer.tsx` — viewer UI
- `frontend/src/pages/DocumentsPage.tsx`, `frontend/src/pages/ProjectDocumentsPage.tsx` — wire viewer into the existing detail sheet, above the legacy `ParseResultViewer`

## Scope deferred (per request)
- PDF rendering and bbox overlays — explicitly out of scope; deferred to next slice.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] `npx vitest run useParseRuns` — **not runnable** locally due to a pre-existing `ERR_REQUIRE_ESM` from `html-encoding-sniffer/encoding-lite.js` that affects all hook tests on `main` (e.g. `useParseResults.test.ts`). Test file kept in repo for when infra is fixed.
- [ ] Manual: upload a doc with `USE_CDM_PARSER=true`, open the sheet, verify run list, status badge, polling stops on terminal, tabs render markdown/text/pages/metrics/raw JSON.
- [ ] Manual: failed run → no content fetch, error state shown.
- [ ] Manual: doc with no CDM runs → viewer renders nothing (legacy `ParseResultViewer` still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)