### PR TITLE
feat(cdm): persist raw LlamaParse payload on ParseRun

### DIFF
--- a/backend/alembic/versions/adec07f4ba7c_add_raw_payload_to_parse_runs.py
+++ b/backend/alembic/versions/adec07f4ba7c_add_raw_payload_to_parse_runs.py
@@ -1,0 +1,33 @@
+"""add raw_payload to parse_runs
+
+Revision ID: adec07f4ba7c
+Revises: 011ace2ca7ef
+Create Date: 2026-04-25 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "adec07f4ba7c"
+down_revision: Union[str, None] = "011ace2ca7ef"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "parse_runs",
+        sa.Column(
+            "raw_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("parse_runs", "raw_payload")

--- a/backend/app/cdm/source.py
+++ b/backend/app/cdm/source.py
@@ -55,4 +55,5 @@ class ParseRun(_Frozen):
     warnings: List[str] = []
     failed_pages: List[int] = []
     provider_refs: Dict[str, Any] = {}
+    raw_payload: Optional[Dict[str, Any]] = None
     error: Optional[str] = None

--- a/backend/app/models/parse_run.py
+++ b/backend/app/models/parse_run.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from sqlalchemy import DateTime, ForeignKey, Integer, JSON, Text
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -46,6 +46,9 @@ class ParseRun(Base):
     )
     provider_refs: Mapped[dict] = mapped_column(
         JSON, nullable=False, default=dict, server_default=sa.text("'{}'")
+    )
+    raw_payload: Mapped[dict | None] = mapped_column(
+        JSONB, nullable=True, default=None
     )
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/parse_run.py
+++ b/backend/app/models/parse_run.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from sqlalchemy import DateTime, ForeignKey, Integer, JSON, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -48,7 +48,7 @@ class ParseRun(Base):
         JSON, nullable=False, default=dict, server_default=sa.text("'{}'")
     )
     raw_payload: Mapped[dict | None] = mapped_column(
-        JSONB, nullable=True, default=None
+        JSON, nullable=True, default=None
     )
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/repositories/parse_run_repository.py
+++ b/backend/app/repositories/parse_run_repository.py
@@ -30,6 +30,7 @@ class ParseRunCreate:
     warnings: list[str] = field(default_factory=list)
     failed_pages: list[int] = field(default_factory=list)
     provider_refs: dict[str, Any] = field(default_factory=dict)
+    raw_payload: dict[str, Any] | None = None
     error: str | None = None
 
 
@@ -55,6 +56,7 @@ class ParseRunRepository:
             warnings=dto.warnings,
             failed_pages=dto.failed_pages,
             provider_refs=dto.provider_refs,
+            raw_payload=dto.raw_payload,
             error=dto.error,
         )
         if dto.id is not None:

--- a/backend/app/routers/parse_runs.py
+++ b/backend/app/routers/parse_runs.py
@@ -12,7 +12,7 @@ from app.models.document import Document as DocumentORM
 from app.models.project import Project
 from app.repositories.parse_run_repository import ParseRunRepository
 from app.repositories.parsed_document_repository import ParsedDocumentRepository
-from app.schemas.parse_run import ParsedDocumentResponse
+from app.schemas.parse_run import ParsedDocumentResponse, RawPayloadResponse
 
 router = APIRouter(prefix="/parse-runs", tags=["parse-runs"])
 
@@ -71,3 +71,35 @@ async def get_parsed_document_for_run(
             detail=f"No ParsedDocument for ParseRun {parse_run_id}",
         )
     return ParsedDocumentResponse.from_orm_row(parsed)
+
+
+@router.get(
+    "/{parse_run_id}/raw-payload",
+    response_model=RawPayloadResponse,
+    summary="Get the verbatim parser SDK payload for a ParseRun",
+    description=(
+        "Return the raw parser-SDK response that produced this ParseRun, as "
+        "captured at run time. Returns rawPayload: null for legacy runs or "
+        "runs where no payload was captured (e.g. the parser SDK call failed)."
+    ),
+)
+async def get_raw_payload_for_run(
+    parse_run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    run = await ParseRunRepository(db).get(parse_run_id)
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ParseRun {parse_run_id} not found",
+        )
+    owns = await _user_owns_source(
+        db, source_document_id=run.source_document_id, user_id=current_user.id
+    )
+    if not owns:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to view this ParseRun",
+        )
+    return RawPayloadResponse(raw_payload=run.raw_payload)

--- a/backend/app/schemas/parse_run.py
+++ b/backend/app/schemas/parse_run.py
@@ -54,3 +54,11 @@ class ParsedDocumentResponse(BaseModel):
     @classmethod
     def from_orm_row(cls, row: ParsedDocumentORM) -> "ParsedDocumentResponse":
         return cls.model_validate(row)
+
+
+class RawPayloadResponse(BaseModel):
+    """Verbatim parser SDK payload captured at run time. Null for legacy runs."""
+
+    raw_payload: dict[str, Any] | None = Field(None, alias="rawPayload")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/backend/app/services/parsing/llamaparse_runner.py
+++ b/backend/app/services/parsing/llamaparse_runner.py
@@ -74,6 +74,7 @@ async def run_llamaparse(
         input_tokens=jm.get("pdf-inputTokens"),
         output_tokens=jm.get("pdf-outputTokens"),
         provider_refs={"llamaparse_job_id": jm.get("job_id")} if jm.get("job_id") else {},
+        raw_payload=raw,
     )
 
     adapter = LlamaParseAdapter()

--- a/backend/app/services/parsing/parsing_service.py
+++ b/backend/app/services/parsing/parsing_service.py
@@ -185,5 +185,6 @@ class ParsingService:
             warnings=list(cdm_run.warnings),
             failed_pages=list(cdm_run.failed_pages),
             provider_refs=dict(cdm_run.provider_refs),
+            raw_payload=cdm_run.raw_payload,
             error=cdm_run.error,
         ))

--- a/backend/tests/repositories/test_parse_run_repository.py
+++ b/backend/tests/repositories/test_parse_run_repository.py
@@ -226,3 +226,23 @@ async def test_create_with_explicit_id(repo, source_doc):
     explicit_id = uuid4()
     run = await repo.create(make_dto(source_doc, id=explicit_id))
     assert run.id == explicit_id
+
+
+@pytest.mark.asyncio
+async def test_create_persists_raw_payload(repo, source_doc):
+    payload = {
+        "job_metadata": {"job_id": "abc", "pdf-inputTokens": 10},
+        "pages": [{"text": "hello", "markdown": "# hello"}],
+    }
+    run = await repo.create(make_dto(source_doc, raw_payload=payload))
+    fetched = await repo.get(run.id)
+    assert fetched is not None
+    assert fetched.raw_payload == payload
+
+
+@pytest.mark.asyncio
+async def test_create_defaults_raw_payload_to_none(repo, source_doc):
+    run = await repo.create(make_dto(source_doc))
+    fetched = await repo.get(run.id)
+    assert fetched is not None
+    assert fetched.raw_payload is None

--- a/backend/tests/routers/test_parse_runs_router.py
+++ b/backend/tests/routers/test_parse_runs_router.py
@@ -158,3 +158,78 @@ async def test_403_when_user_does_not_own_source(
         headers={"Authorization": f"Bearer {token_b}"},
     )
     assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raw_payload_200_returns_dict(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup_and_login(client, "rp1@example.com")
+    user = await _user_by_email(test_db, "rp1@example.com")
+    run = await _seed(test_db, user)
+    run.raw_payload = {"job_metadata": {"job_id": "j1"}, "pages": []}
+    await test_db.commit()
+
+    resp = await client.get(
+        f"/api/v1/parse-runs/{run.id}/raw-payload",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["rawPayload"] == {"job_metadata": {"job_id": "j1"}, "pages": []}
+
+
+@pytest.mark.asyncio
+async def test_raw_payload_200_returns_null_when_absent(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup_and_login(client, "rp2@example.com")
+    user = await _user_by_email(test_db, "rp2@example.com")
+    run = await _seed(test_db, user)  # raw_payload defaults to NULL
+
+    resp = await client.get(
+        f"/api/v1/parse-runs/{run.id}/raw-payload",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["rawPayload"] is None
+
+
+@pytest.mark.asyncio
+async def test_raw_payload_404_when_run_does_not_exist(
+    client: AsyncClient,
+):
+    token = await _signup_and_login(client, "rp3@example.com")
+    resp = await client.get(
+        f"/api/v1/parse-runs/{uuid4()}/raw-payload",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_raw_payload_403_when_user_does_not_own_source(
+    client: AsyncClient, test_db: AsyncSession
+):
+    await _signup_and_login(client, "rpA@example.com")
+    user_a = await _user_by_email(test_db, "rpA@example.com")
+    run = await _seed(test_db, user_a)
+
+    token_b = await _signup_and_login(client, "rpB@example.com")
+    resp = await client.get(
+        f"/api/v1/parse-runs/{run.id}/raw-payload",
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_raw_payload_401_when_unauthenticated(
+    client: AsyncClient, test_db: AsyncSession
+):
+    await _signup_and_login(client, "rpC@example.com")
+    user = await _user_by_email(test_db, "rpC@example.com")
+    run = await _seed(test_db, user)
+
+    resp = await client.get(f"/api/v1/parse-runs/{run.id}/raw-payload")
+    assert resp.status_code == 401

--- a/backend/tests/services/parsing/test_llamaparse_runner.py
+++ b/backend/tests/services/parsing/test_llamaparse_runner.py
@@ -61,6 +61,28 @@ async def test_runner_returns_run_and_doc_on_success(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_runner_sets_raw_payload_on_success(tmp_path):
+    src = SourceDocument(
+        id="src-1", sha256="a" * 64,
+        filename="hello.pdf",
+        created_at=datetime.now(timezone.utc),
+    )
+    file_path = tmp_path / "hello.pdf"
+    file_path.write_bytes(b"%PDF-1.4\n")
+
+    client = _FakeClient(MINIMAL_RAW)
+
+    run, doc = await run_llamaparse(
+        source=src,
+        file_path=str(file_path),
+        representation_kind="extract_rich",
+        config={"tier": "agentic"},
+        client=client,
+    )
+    assert run.raw_payload == MINIMAL_RAW
+
+
+@pytest.mark.asyncio
 async def test_runner_raises_llama_parse_run_error_on_failure(tmp_path):
     src = SourceDocument(
         id="src-1", sha256="a" * 64,

--- a/backend/tests/services/parsing/test_llamaparse_runner.py
+++ b/backend/tests/services/parsing/test_llamaparse_runner.py
@@ -111,3 +111,4 @@ async def test_runner_raises_llama_parse_run_error_on_failure(tmp_path):
     assert "boom" in err.run.error
     assert err.run.finished_at is not None
     assert err.run.duration_ms is not None and err.run.duration_ms >= 0
+    assert err.run.raw_payload is None

--- a/backend/tests/services/parsing/test_parsing_service.py
+++ b/backend/tests/services/parsing/test_parsing_service.py
@@ -239,6 +239,7 @@ async def test_parse_and_persist_failure_path(repos, source_cdm, source_orm, tes
     db_run = result.scalar_one_or_none()
     assert db_run is not None
     assert "SDK exploded" in (db_run.error or "")
+    assert db_run.raw_payload is None
 
     db_doc = await doc_repo.get_by_run(db_run.id)
     assert db_doc is None

--- a/backend/tests/services/parsing/test_parsing_service.py
+++ b/backend/tests/services/parsing/test_parsing_service.py
@@ -181,6 +181,34 @@ async def test_parse_and_persist_happy_path(repos, source_cdm, source_orm, test_
 
 
 @pytest.mark.asyncio
+async def test_parse_and_persist_persists_raw_payload(repos, source_cdm, source_orm, test_db, tmp_path):
+    project_id = uuid4()
+    await _link_source_to_project(test_db, source_orm, project_id)
+
+    file_path = tmp_path / "c.pdf"
+    file_path.write_bytes(b"%PDF-1.4\n")
+
+    service = _make_service(repos, _fake_client(MINIMAL_RAW))
+    config = {"tier": "agentic"}
+
+    run, doc = await service.parse_and_persist(
+        source=source_cdm,
+        file_path=str(file_path),
+        representation_kind="extract_rich",
+        config=config,
+        project_id=project_id,
+    )
+
+    assert run.status == ParseRunStatus.SUCCEEDED
+
+    _, run_repo, _ = repos
+    persisted = await run_repo.get(UUID(run.id))
+    assert persisted is not None
+    assert persisted.raw_payload is not None
+    assert persisted.raw_payload == MINIMAL_RAW
+
+
+@pytest.mark.asyncio
 async def test_parse_and_persist_failure_path(repos, source_cdm, source_orm, test_db, tmp_path):
     project_id = uuid4()
     await _link_source_to_project(test_db, source_orm, project_id)


### PR DESCRIPTION
## Summary
- Add `raw_payload JSONB` column to `parse_runs` (Alembic migration `adec07f4ba7c`).
- Thread the verbatim `result.model_dump()` from LlamaParse through the CDM `ParseRun` Pydantic model, the `ParseRunCreate` DTO, and the repository `create()`.
- New endpoint `GET /api/v1/parse-runs/{id}/raw-payload` (auth-gated identical to the rest of the parse-runs router).

Unblocks the ParseRun Viewer UI (Phase 2).

Closes #35

## Test plan
- `uv run --directory backend python -m pytest -o "addopts=" tests/repositories/ tests/services/parsing/ tests/routers/test_parse_runs_router.py`
- `uv run --directory backend alembic upgrade head` on a fresh DB
- Manual: upload a document, confirm `parse_runs.raw_payload` is non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)