### PR TITLE
feat(index): parsed-doc selector backend foundation (Unit 1)

### DIFF
--- a/backend/alembic/versions/4a24c798e847_tighten_index_documents_parse_run_id_fk_.py
+++ b/backend/alembic/versions/4a24c798e847_tighten_index_documents_parse_run_id_fk_.py
@@ -1,0 +1,51 @@
+"""tighten index_documents.parse_run_id FK to cascade
+
+Revision ID: 4a24c798e847
+Revises: a2b3c4d5e6f7
+Create Date: 2026-04-30 10:22:10.718047
+
+In the parsed-document-centric model introduced by Unit 1 of the parsed-document
+refactor, an `index_documents` row references the parse_run that produced its
+content blob (`parsed_documents` is keyed 1:1 on `parse_run_id`). When the
+parse_run is deleted, the parsed_document is gone and the index_documents row
+has nothing left to read — cascade-delete the row instead of leaving it with
+parse_run_id NULL (the prior `SET NULL` behaviour).
+
+Legacy raw_text rows (which already have `parse_run_id IS NULL`) are unaffected.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = '4a24c798e847'
+down_revision: Union[str, None] = 'a2b3c4d5e6f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+FK_NAME = "index_documents_parse_run_id_fkey"
+
+
+def upgrade() -> None:
+    op.drop_constraint(FK_NAME, "index_documents", type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        "index_documents",
+        "parse_runs",
+        ["parse_run_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(FK_NAME, "index_documents", type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        "index_documents",
+        "parse_runs",
+        ["parse_run_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.config import settings
-from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_runs, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings
+from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_runs, parse_run_configs, parsed_documents, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings
 from app.utils.oauth import setup_oauth
 
 # Import database engine for SQLAlchemy instrumentation
@@ -162,6 +162,8 @@ app.include_router(eval_runs.router, prefix="/api/v1")
 app.include_router(eval_runs.settings_router, prefix="/api/v1")
 app.include_router(experiments.router, prefix="/api/v1")
 app.include_router(parse_runs.router, prefix="/api/v1")
+app.include_router(parse_run_configs.router, prefix="/api/v1")
+app.include_router(parsed_documents.router, prefix="/api/v1")
 app.include_router(extraction.router, prefix="/api/v1")
 app.include_router(extraction_ground_truth.router, prefix="/api/v1")
 app.include_router(extraction_eval.router, prefix="/api/v1")

--- a/backend/app/models/index_document.py
+++ b/backend/app/models/index_document.py
@@ -62,10 +62,13 @@ class IndexDocument(Base):
         nullable=True
     )
 
-    # CDM parse run binding for this document
+    # CDM parse run binding for this document.
+    # CASCADE: parsed_documents are 1:1 with parse_runs in the current schema, so deleting a
+    # parse_run also removes its parsed_document; an index_documents row that references it
+    # has nothing left to read and is removed too.
     parse_run_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey("parse_runs.id", ondelete="SET NULL"),
+        ForeignKey("parse_runs.id", ondelete="CASCADE"),
         nullable=True
     )
 
@@ -73,6 +76,14 @@ class IndexDocument(Base):
     index: Mapped["Index"] = relationship(back_populates="index_documents")
     document: Mapped["Document"] = relationship(back_populates="index_documents")
     parse_run: Mapped["ParseRun | None"] = relationship("ParseRun", foreign_keys=[parse_run_id])
+    # parsed_document is the content blob produced by the bound parse_run.
+    # It joins on parse_run_id because parsed_documents.parse_run_id is its primary key
+    # (1:1 with parse_run); viewonly because writes happen via parse_run_id.
+    parsed_document: Mapped["ParsedDocument | None"] = relationship(
+        "ParsedDocument",
+        primaryjoin="IndexDocument.parse_run_id == foreign(ParsedDocument.parse_run_id)",
+        viewonly=True,
+    )
 
     __table_args__ = (
         sa.Index('ix_index_documents_index_id', 'index_id'),

--- a/backend/app/repositories/parse_run_repository.py
+++ b/backend/app/repositories/parse_run_repository.py
@@ -4,11 +4,24 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.document import Document as DocumentORM
 from app.models.parse_run import ParseRun
+from app.models.parsed_document import ParsedDocument
+from app.models.source_document import SourceDocument
+
+
+@dataclass(frozen=True)
+class ParseConfigOptionRow:
+    """One distinct (parser, parse_config_hash) family available to a project."""
+    parser: str
+    parse_config_hash: str
+    config: dict[str, Any]
+    parsed_document_count: int
+    has_full_markdown: bool
+    latest_parsed_at: datetime
 
 
 @dataclass
@@ -131,6 +144,67 @@ class ParseRunRepository:
             .limit(1)
         )
         return result.scalar_one_or_none()
+
+    async def list_distinct_configs_for_project(
+        self, project_id: UUID
+    ) -> list[ParseConfigOptionRow]:
+        """List distinct (parser, config_hash) families with parsed_documents in a project.
+
+        Joins parsed_documents → parse_runs → source_documents → documents and groups by
+        (parser, config_hash), returning one row per family with aggregate counts and the
+        newest finished_at across the family. Only succeeded runs are included.
+        """
+        markdown_present = case(
+            (ParsedDocument.full_markdown.isnot(None), 1), else_=0
+        )
+
+        agg_stmt = (
+            select(
+                ParseRun.parser.label("parser"),
+                ParseRun.config_hash.label("parse_config_hash"),
+                func.count(ParsedDocument.parse_run_id).label("parsed_document_count"),
+                func.coalesce(func.max(markdown_present), 0).label("has_full_markdown_int"),
+                func.max(ParseRun.finished_at).label("latest_parsed_at"),
+            )
+            .select_from(ParsedDocument)
+            .join(ParseRun, ParseRun.id == ParsedDocument.parse_run_id)
+            .join(SourceDocument, ParseRun.source_document_id == SourceDocument.id)
+            .join(DocumentORM, DocumentORM.source_document_id == SourceDocument.id)
+            .where(ParseRun.status == "succeeded")
+            .where(DocumentORM.project_id == project_id)
+            .group_by(ParseRun.parser, ParseRun.config_hash)
+            .order_by(func.max(ParseRun.finished_at).desc())
+        )
+        agg_rows = (await self.session.execute(agg_stmt)).all()
+        if not agg_rows:
+            return []
+
+        # Fetch one representative config per (parser, config_hash). The config_hash is
+        # deterministically derived from the config dict, so any row's config is correct.
+        configs: dict[tuple[str, str], dict[str, Any]] = {}
+        for row in agg_rows:
+            key = (row.parser, row.parse_config_hash)
+            if key in configs:
+                continue
+            cfg = (await self.session.execute(
+                select(ParseRun.config)
+                .where(ParseRun.parser == row.parser)
+                .where(ParseRun.config_hash == row.parse_config_hash)
+                .limit(1)
+            )).scalar()
+            configs[key] = cfg or {}
+
+        return [
+            ParseConfigOptionRow(
+                parser=row.parser,
+                parse_config_hash=row.parse_config_hash,
+                config=configs[(row.parser, row.parse_config_hash)],
+                parsed_document_count=row.parsed_document_count,
+                has_full_markdown=bool(row.has_full_markdown_int),
+                latest_parsed_at=row.latest_parsed_at,
+            )
+            for row in agg_rows
+        ]
 
     async def update_status(
         self,

--- a/backend/app/repositories/parsed_document_repository.py
+++ b/backend/app/repositories/parsed_document_repository.py
@@ -1,12 +1,19 @@
 """Repository for ParsedDocument — content blob layer."""
 from dataclasses import dataclass
-from typing import Any
+from datetime import datetime
+from typing import Any, Literal
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.document import Document as DocumentORM
+from app.models.parse_run import ParseRun
 from app.models.parsed_document import ParsedDocument
+from app.models.source_document import SourceDocument
+
+
+Representation = Literal["full_text", "full_markdown", "block"]
 
 
 @dataclass
@@ -18,6 +25,25 @@ class ParsedDocumentCreate:
     page_count: int
     block_count: int
     content: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ParsedDocumentListRow:
+    """One parsed-document picker row.
+
+    `parse_run_id` is the parsed-document handle under the current 1:1 schema
+    (parsed_documents.parse_run_id is its primary key). When parsed_documents grows a
+    distinct `id` column for derived parsed-docs, the API surface keeps the same shape;
+    the wire value just shifts from parse_run_id-of-this-parsed-doc to id-of-this-parsed-doc.
+    """
+    parse_run_id: UUID
+    parser: str
+    parse_config_hash: str
+    source_document_id: UUID
+    source_filename: str | None
+    has_full_markdown: bool
+    block_count: int
+    parsed_at: datetime
 
 
 class ParsedDocumentRepository:
@@ -44,3 +70,83 @@ class ParsedDocumentRepository:
             select(ParsedDocument).where(ParsedDocument.parse_run_id == parse_run_id)
         )
         return result.scalar_one_or_none()
+
+    async def list_for_project(
+        self,
+        project_id: UUID,
+        *,
+        parser: str | None = None,
+        parse_config_hash: str | None = None,
+        representation: Representation | None = None,
+        latest_per_source: bool = True,
+    ) -> list[ParsedDocumentListRow]:
+        """List parsed-documents for the project's documents, newest first.
+
+        Filters:
+          - `parser` + `parse_config_hash` restrict to one (parser, config_hash) family.
+          - `representation`: keep parsed-docs that populate the named segment
+            (`full_markdown`, `full_text`, or `block`). `full_text` and `block` are
+            invariants on every parsed_doc and pass-through; `full_markdown` is filtered
+            on `full_markdown IS NOT NULL`.
+          - `latest_per_source=True` (default) keeps only the newest parse_run per
+            `source_document_id`. Set False to expose every successful run in the family
+            for non-determinism debugging.
+        """
+        inner = (
+            select(
+                ParsedDocument.parse_run_id.label("parse_run_id"),
+                ParseRun.parser.label("parser"),
+                ParseRun.config_hash.label("parse_config_hash"),
+                ParseRun.source_document_id.label("source_document_id"),
+                ParseRun.finished_at.label("parsed_at"),
+                SourceDocument.filename.label("source_filename"),
+                ParsedDocument.full_markdown.label("full_markdown_value"),
+                ParsedDocument.block_count.label("block_count"),
+            )
+            .select_from(ParsedDocument)
+            .join(ParseRun, ParseRun.id == ParsedDocument.parse_run_id)
+            .join(SourceDocument, ParseRun.source_document_id == SourceDocument.id)
+            .join(DocumentORM, DocumentORM.source_document_id == SourceDocument.id)
+            .where(ParseRun.status == "succeeded")
+            .where(DocumentORM.project_id == project_id)
+        )
+        if parser is not None:
+            inner = inner.where(ParseRun.parser == parser)
+        if parse_config_hash is not None:
+            inner = inner.where(ParseRun.config_hash == parse_config_hash)
+        if representation == "full_markdown":
+            inner = inner.where(ParsedDocument.full_markdown.isnot(None))
+        # full_text / block: invariants — no extra filter needed.
+
+        if latest_per_source:
+            rn = (
+                func.row_number()
+                .over(
+                    partition_by=ParseRun.source_document_id,
+                    order_by=ParseRun.finished_at.desc(),
+                )
+                .label("rn")
+            )
+            sub = inner.add_columns(rn).subquery()
+            stmt = (
+                select(sub)
+                .where(sub.c.rn == 1)
+                .order_by(sub.c.parsed_at.desc())
+            )
+        else:
+            stmt = inner.order_by(ParseRun.finished_at.desc())
+
+        rows = (await self.session.execute(stmt)).all()
+        return [
+            ParsedDocumentListRow(
+                parse_run_id=r.parse_run_id,
+                parser=r.parser,
+                parse_config_hash=r.parse_config_hash,
+                source_document_id=r.source_document_id,
+                source_filename=r.source_filename,
+                has_full_markdown=r.full_markdown_value is not None,
+                block_count=r.block_count,
+                parsed_at=r.parsed_at,
+            )
+            for r in rows
+        ]

--- a/backend/app/routers/parse_run_configs.py
+++ b/backend/app/routers/parse_run_configs.py
@@ -1,0 +1,57 @@
+"""Project-scoped parse-run config families router.
+
+Exposes `GET /projects/{project_id}/parse-runs/configs` — distinct
+`(parser, parse_config_hash)` combinations that have at least one successful
+parse run for any document in the project. Powers the parser-config family
+selector in the index-creation wizard.
+"""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_active_user
+from app.models import User
+from app.repositories.parse_run_repository import ParseRunRepository
+from app.repositories.project_repository import ProjectRepository
+from app.schemas.parsed_document import ParseConfigOption
+
+
+router = APIRouter(prefix="/projects/{project_id}/parse-runs", tags=["parse-runs"])
+
+
+@router.get(
+    "/configs",
+    response_model=list[ParseConfigOption],
+    summary="List parse-config families",
+    description=(
+        "Distinct (parser, parse_config_hash) families with at least one successful "
+        "parse run across the project's documents. Used by the parser-config family "
+        "selector in the index-creation wizard."
+    ),
+)
+async def list_parse_run_configs(
+    project_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ParseConfigOption]:
+    project = await ProjectRepository(db).get_by_id(project_id, current_user.id)
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Project {project_id} not found",
+        )
+
+    rows = await ParseRunRepository(db).list_distinct_configs_for_project(project_id)
+    return [
+        ParseConfigOption(
+            parser=row.parser,
+            parse_config_hash=row.parse_config_hash,
+            config=row.config,
+            parsed_document_count=row.parsed_document_count,
+            has_full_markdown=row.has_full_markdown,
+            latest_parsed_at=row.latest_parsed_at,
+        )
+        for row in rows
+    ]

--- a/backend/app/routers/parsed_documents.py
+++ b/backend/app/routers/parsed_documents.py
@@ -1,0 +1,80 @@
+"""Project-scoped parsed-documents router.
+
+Exposes `GET /projects/{project_id}/parsed-documents` — the picker data source
+for the parsed-document selector in the index-creation wizard. Supports family
+filtering (`parser` + `parseConfigHash`), representation filtering, and a
+`latestPerSource` toggle that surfaces older runs in the same family for
+non-determinism debugging.
+"""
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_active_user
+from app.models import User
+from app.repositories.parsed_document_repository import ParsedDocumentRepository
+from app.repositories.project_repository import ProjectRepository
+from app.schemas.parsed_document import ParsedDocumentListItem
+
+
+router = APIRouter(prefix="/projects/{project_id}/parsed-documents", tags=["parsed-documents"])
+
+
+@router.get(
+    "",
+    response_model=list[ParsedDocumentListItem],
+    summary="List parsed documents in a project",
+    description=(
+        "Returns parsed-documents for documents in the project, newest first. "
+        "Supply `parser` + `parseConfigHash` together to restrict to one family. "
+        "`representation` filters to parsed-docs that populate that segment. "
+        "`latestPerSource=true` (default) keeps only the newest parse_run per source "
+        "document; set false to see every successful run in the family."
+    ),
+)
+async def list_parsed_documents(
+    project_id: UUID,
+    parser: str | None = Query(None),
+    parse_config_hash: str | None = Query(None, alias="parseConfigHash"),
+    representation: Literal["full_text", "full_markdown", "block"] | None = Query(None),
+    latest_per_source: bool = Query(True, alias="latestPerSource"),
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ParsedDocumentListItem]:
+    if (parser is None) != (parse_config_hash is None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="parser and parseConfigHash must be supplied together",
+        )
+
+    project = await ProjectRepository(db).get_by_id(project_id, current_user.id)
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Project {project_id} not found",
+        )
+
+    rows = await ParsedDocumentRepository(db).list_for_project(
+        project_id,
+        parser=parser,
+        parse_config_hash=parse_config_hash,
+        representation=representation,
+        latest_per_source=latest_per_source,
+    )
+    return [
+        ParsedDocumentListItem(
+            id=row.parse_run_id,
+            parse_run_id=row.parse_run_id,
+            parser=row.parser,
+            parse_config_hash=row.parse_config_hash,
+            source_document_id=row.source_document_id,
+            source_filename=row.source_filename,
+            has_full_markdown=row.has_full_markdown,
+            block_count=row.block_count,
+            parsed_at=row.parsed_at,
+        )
+        for row in rows
+    ]

--- a/backend/app/schemas/parsed_document.py
+++ b/backend/app/schemas/parsed_document.py
@@ -1,0 +1,44 @@
+"""Response schemas for the parsed-document selector API.
+
+Used by:
+  GET /projects/{project_id}/parse-runs/configs   → list[ParseConfigOption]
+  GET /projects/{project_id}/parsed-documents     → list[ParsedDocumentListItem]
+"""
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ParseConfigOption(BaseModel):
+    """One distinct (parser, parse_config_hash) family available to a project."""
+    parser: str
+    parse_config_hash: str = Field(..., alias="parseConfigHash")
+    config: dict[str, Any]
+    parsed_document_count: int = Field(..., alias="parsedDocumentCount")
+    has_full_markdown: bool = Field(..., alias="hasFullMarkdown")
+    latest_parsed_at: datetime = Field(..., alias="latestParsedAt")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ParsedDocumentListItem(BaseModel):
+    """One picker row for the parsed-document selector.
+
+    Note: under the current 1:1 schema, `id` and `parseRunId` carry the same
+    UUID — the parsed_document is keyed on parse_run_id. When the schema later
+    grows a distinct `id` (for derived parsed-docs), `id` and `parseRunId`
+    diverge but the wire shape stays the same.
+    """
+    id: UUID
+    parse_run_id: UUID = Field(..., alias="parseRunId")
+    parser: str
+    parse_config_hash: str = Field(..., alias="parseConfigHash")
+    source_document_id: UUID = Field(..., alias="sourceDocumentId")
+    source_filename: str | None = Field(None, alias="sourceFilename")
+    has_full_markdown: bool = Field(..., alias="hasFullMarkdown")
+    block_count: int = Field(..., alias="blockCount")
+    parsed_at: datetime = Field(..., alias="parsedAt")
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/backend/tests/models/test_index_document_parsed_document_relationship.py
+++ b/backend/tests/models/test_index_document_parsed_document_relationship.py
@@ -1,0 +1,125 @@
+"""IndexDocument relationship to ParsedDocument and parse_run FK cascade behaviour.
+
+Unit 1 of the parsed-document refactor: with no separate `parsed_document_id`
+column (parsed_documents.parse_run_id IS its primary key — 1:1 with parse_run),
+IndexDocument exposes a `parsed_document` relationship by joining on
+`parse_run_id`, and the existing `parse_run_id` FK cascades on delete to keep
+integrity in the parsed-doc-centric model.
+"""
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import Document, DocumentStatus, Project, User
+from app.models.index import Index
+from app.models.index_document import IndexDocument
+from app.models.parse_run import ParseRun
+from app.models.parsed_document import ParsedDocument
+from app.models.source_document import SourceDocument
+
+
+def _parse_run_fk(table) -> object:
+    """Return the FK constraint on index_documents.parse_run_id."""
+    for fk in table.foreign_keys:
+        if fk.column.table.name == "parse_runs":
+            return fk
+    raise AssertionError("No FK to parse_runs found on index_documents")
+
+
+def test_index_document_parse_run_fk_cascades_on_delete():
+    fk = _parse_run_fk(IndexDocument.__table__)
+    assert fk.ondelete == "CASCADE", (
+        "IndexDocument.parse_run_id must cascade-delete in the parsed-doc-centric model "
+        f"(current ondelete={fk.ondelete!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_document_parsed_document_relationship_traverses(test_db: AsyncSession):
+    user = User(id=uuid4(), email="u@e.com", full_name="U", auth_provider="email", password_hash="x")
+    project = Project(id=uuid4(), user_id=user.id, name="P")
+    src = SourceDocument(id=uuid4(), sha256="a" * 64, storage_uri="local://a.pdf")
+    test_db.add_all([user, project, src])
+    await test_db.commit()
+
+    document = Document(
+        id=uuid4(), project_id=project.id, created_by=user.id,
+        source_type="upload", source_identifier="a" * 64, title="T",
+        source_metadata={}, status=DocumentStatus.ready,
+        source_document_id=src.id,
+    )
+    run = ParseRun(
+        id=uuid4(), source_document_id=src.id,
+        parser="llamaparse", representation_kind="full_markdown",
+        config_hash="0" * 64, status="succeeded",
+        started_at=datetime.now(timezone.utc),
+    )
+    test_db.add_all([document, run])
+    await test_db.commit()
+
+    parsed_doc = ParsedDocument(
+        parse_run_id=run.id, source_document_id=src.id,
+        full_text="hello", full_markdown="# hello",
+        page_count=1, block_count=1, content={},
+    )
+    index = Index(
+        id=uuid4(), project_id=project.id, name="ix",
+        config={}, created_by=user.id,
+    )
+    test_db.add_all([parsed_doc, index])
+    await test_db.commit()
+
+    idoc = IndexDocument(
+        index_id=index.id, document_id=document.id, parse_run_id=run.id,
+    )
+    test_db.add(idoc)
+    await test_db.commit()
+
+    fetched = (await test_db.execute(
+        select(IndexDocument)
+        .where(IndexDocument.index_id == index.id, IndexDocument.document_id == document.id)
+        .options(selectinload(IndexDocument.parsed_document))
+    )).scalar_one()
+    assert fetched.parsed_document is not None
+    assert fetched.parsed_document.parse_run_id == run.id
+    assert fetched.parsed_document.full_markdown == "# hello"
+
+
+@pytest.mark.asyncio
+async def test_index_document_parsed_document_is_none_when_parse_run_id_is_null(
+    test_db: AsyncSession,
+):
+    user = User(id=uuid4(), email="u2@e.com", full_name="U", auth_provider="email", password_hash="x")
+    project = Project(id=uuid4(), user_id=user.id, name="P2")
+    test_db.add_all([user, project])
+    await test_db.commit()
+
+    document = Document(
+        id=uuid4(), project_id=project.id, created_by=user.id,
+        source_type="upload", source_identifier="legacy", title="L",
+        source_metadata={}, status=DocumentStatus.ready,
+    )
+    index = Index(
+        id=uuid4(), project_id=project.id, name="ix2",
+        config={}, created_by=user.id,
+    )
+    test_db.add_all([document, index])
+    await test_db.commit()
+
+    idoc = IndexDocument(
+        index_id=index.id, document_id=document.id, parse_run_id=None,
+    )
+    test_db.add(idoc)
+    await test_db.commit()
+
+    fetched = (await test_db.execute(
+        select(IndexDocument)
+        .where(IndexDocument.index_id == index.id)
+        .options(selectinload(IndexDocument.parsed_document))
+    )).scalar_one()
+    assert fetched.parse_run_id is None
+    assert fetched.parsed_document is None

--- a/backend/tests/repositories/test_parse_run_repository_configs.py
+++ b/backend/tests/repositories/test_parse_run_repository_configs.py
@@ -1,0 +1,225 @@
+"""Tests for ParseRunRepository.list_distinct_configs_for_project."""
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User
+from app.models.document import Document as DocumentORM
+from app.models.parsed_document import ParsedDocument
+from app.models.source_document import SourceDocument
+from app.repositories.parse_run_repository import (
+    ParseRunCreate,
+    ParseRunRepository,
+)
+
+
+@pytest.fixture
+async def user(test_db: AsyncSession) -> User:
+    u = User(
+        id=uuid4(), email="cfg@example.com", full_name="Cfg",
+        auth_provider="email", password_hash="x",
+    )
+    test_db.add(u)
+    await test_db.commit()
+    await test_db.refresh(u)
+    return u
+
+
+@pytest.fixture
+async def repo(test_db: AsyncSession) -> ParseRunRepository:
+    return ParseRunRepository(test_db)
+
+
+async def _attach_doc_to_project(
+    test_db: AsyncSession,
+    *,
+    user: User,
+    project_id: UUID,
+    sha: str,
+) -> SourceDocument:
+    """Create a SourceDocument and a Document in the given project pointing to it."""
+    sd = SourceDocument(id=uuid4(), sha256=sha, storage_uri=f"local://{sha[:6]}.pdf")
+    test_db.add(sd)
+    await test_db.commit()
+    await test_db.refresh(sd)
+    doc = DocumentORM(
+        id=uuid4(), project_id=project_id, source_document_id=sd.id,
+        source_type="upload", source_identifier=sha, title=sha[:6],
+        source_metadata={}, status="ready", created_by=user.id,
+    )
+    test_db.add(doc)
+    await test_db.commit()
+    return sd
+
+
+async def _create_parsed_run(
+    repo: ParseRunRepository,
+    test_db: AsyncSession,
+    *,
+    source: SourceDocument,
+    parser: str,
+    config_hash: str,
+    config: dict,
+    status: str = "succeeded",
+    finished_at: datetime | None = None,
+    full_markdown: str | None = None,
+    full_text: str | None = "hello",
+) -> tuple[UUID, UUID]:
+    """Create a ParseRun and (when succeeded) its ParsedDocument. Returns (run_id, sd_id)."""
+    finished_at = finished_at or datetime.now(timezone.utc)
+    started_at = finished_at
+    run = await repo.create(ParseRunCreate(
+        source_document_id=source.id, parser=parser,
+        representation_kind="full_markdown" if full_markdown else "full_text",
+        config=config, config_hash=config_hash,
+        status=status,
+        started_at=started_at, finished_at=finished_at if status == "succeeded" else None,
+    ))
+    if status == "succeeded":
+        pdoc = ParsedDocument(
+            parse_run_id=run.id, source_document_id=source.id,
+            full_text=full_text, full_markdown=full_markdown,
+            page_count=1, block_count=1, content={},
+        )
+        test_db.add(pdoc)
+        await test_db.commit()
+    return run.id, source.id
+
+
+@pytest.mark.asyncio
+async def test_list_distinct_configs_for_project_groups_by_parser_and_hash(
+    repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="a" * 64)
+    sd2 = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="b" * 64)
+
+    # Two runs, same family on two different source docs
+    await _create_parsed_run(
+        repo, test_db, source=sd, parser="llamaparse",
+        config_hash="h" * 64, config={"tier": "premium"},
+        full_markdown="# md",
+    )
+    await _create_parsed_run(
+        repo, test_db, source=sd2, parser="llamaparse",
+        config_hash="h" * 64, config={"tier": "premium"},
+        full_markdown=None,
+    )
+    # One run, different family
+    await _create_parsed_run(
+        repo, test_db, source=sd, parser="landingai",
+        config_hash="z" * 64, config={"mode": "fast"},
+        full_markdown="# md",
+    )
+
+    rows = await repo.list_distinct_configs_for_project(project_id)
+    assert len(rows) == 2
+    families = {(r.parser, r.parse_config_hash) for r in rows}
+    assert families == {("llamaparse", "h" * 64), ("landingai", "z" * 64)}
+
+    llama = next(r for r in rows if r.parser == "llamaparse")
+    assert llama.parsed_document_count == 2
+    assert llama.has_full_markdown is True
+    assert llama.config == {"tier": "premium"}
+
+
+@pytest.mark.asyncio
+async def test_list_distinct_configs_for_project_excludes_other_projects(
+    repo, test_db, user
+):
+    p1, p2 = uuid4(), uuid4()
+    sd1 = await _attach_doc_to_project(test_db, user=user, project_id=p1, sha="1" * 64)
+    sd2 = await _attach_doc_to_project(test_db, user=user, project_id=p2, sha="2" * 64)
+
+    await _create_parsed_run(
+        repo, test_db, source=sd1, parser="llamaparse",
+        config_hash="x" * 64, config={"a": 1}, full_markdown="# x",
+    )
+    await _create_parsed_run(
+        repo, test_db, source=sd2, parser="llamaparse",
+        config_hash="y" * 64, config={"a": 2}, full_markdown="# y",
+    )
+
+    p1_rows = await repo.list_distinct_configs_for_project(p1)
+    assert len(p1_rows) == 1
+    assert p1_rows[0].parse_config_hash == "x" * 64
+
+
+@pytest.mark.asyncio
+async def test_list_distinct_configs_for_project_excludes_failed_runs(
+    repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="f" * 64)
+    await _create_parsed_run(
+        repo, test_db, source=sd, parser="llamaparse",
+        config_hash="o" * 64, config={"ok": 1},
+        full_markdown="# ok",
+    )
+    await _create_parsed_run(
+        repo, test_db, source=sd, parser="llamaparse",
+        config_hash="f" * 64, config={"failed": 1},
+        status="failed",
+    )
+
+    rows = await repo.list_distinct_configs_for_project(project_id)
+    assert len(rows) == 1
+    assert rows[0].parse_config_hash == "o" * 64
+
+
+@pytest.mark.asyncio
+async def test_list_distinct_configs_for_project_has_full_markdown_when_at_least_one_populated(
+    repo, test_db, user
+):
+    project_id = uuid4()
+    sd1 = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="1" * 64)
+    sd2 = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="2" * 64)
+    # Both runs same family, only the second populated full_markdown
+    await _create_parsed_run(
+        repo, test_db, source=sd1, parser="llamaparse",
+        config_hash="m" * 64, config={"x": 1}, full_markdown=None,
+    )
+    await _create_parsed_run(
+        repo, test_db, source=sd2, parser="llamaparse",
+        config_hash="m" * 64, config={"x": 1}, full_markdown="# present",
+    )
+
+    rows = await repo.list_distinct_configs_for_project(project_id)
+    assert len(rows) == 1
+    assert rows[0].has_full_markdown is True
+
+
+@pytest.mark.asyncio
+async def test_list_distinct_configs_for_project_returns_latest_parsed_at(
+    repo, test_db, user
+):
+    project_id = uuid4()
+    # Two source docs so the (source, representation_kind, config_hash) unique allows
+    # two runs in the same family.
+    sd1 = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="t" * 64)
+    sd2 = await _attach_doc_to_project(test_db, user=user, project_id=project_id, sha="u" * 64)
+    earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    await _create_parsed_run(
+        repo, test_db, source=sd1, parser="llamaparse",
+        config_hash="t" * 64, config={"k": 1}, finished_at=earlier,
+        full_markdown="# e",
+    )
+    await _create_parsed_run(
+        repo, test_db, source=sd2, parser="llamaparse",
+        config_hash="t" * 64, config={"k": 1}, finished_at=later,
+        full_markdown="# l",
+    )
+
+    rows = await repo.list_distinct_configs_for_project(project_id)
+    assert len(rows) == 1
+    # SQLite drops tzinfo; compare on the wall-clock value.
+    assert rows[0].latest_parsed_at.replace(tzinfo=None) == later.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_list_distinct_configs_for_project_empty_when_no_runs(repo):
+    rows = await repo.list_distinct_configs_for_project(uuid4())
+    assert rows == []

--- a/backend/tests/repositories/test_parsed_document_repository_listing.py
+++ b/backend/tests/repositories/test_parsed_document_repository_listing.py
@@ -1,0 +1,256 @@
+"""Tests for ParsedDocumentRepository.list_for_project."""
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User
+from app.models.document import Document as DocumentORM
+from app.models.parsed_document import ParsedDocument
+from app.models.source_document import SourceDocument
+from app.repositories.parse_run_repository import (
+    ParseRunCreate,
+    ParseRunRepository,
+)
+from app.repositories.parsed_document_repository import ParsedDocumentRepository
+
+
+@pytest.fixture
+async def user(test_db: AsyncSession) -> User:
+    u = User(
+        id=uuid4(), email="lst@example.com", full_name="Lst",
+        auth_provider="email", password_hash="x",
+    )
+    test_db.add(u)
+    await test_db.commit()
+    return u
+
+
+@pytest.fixture
+async def parse_run_repo(test_db: AsyncSession) -> ParseRunRepository:
+    return ParseRunRepository(test_db)
+
+
+@pytest.fixture
+async def repo(test_db: AsyncSession) -> ParsedDocumentRepository:
+    return ParsedDocumentRepository(test_db)
+
+
+async def _create_source_in_project(
+    test_db: AsyncSession, *, user: User, project_id: UUID, sha: str, filename: str | None = None
+) -> SourceDocument:
+    sd = SourceDocument(
+        id=uuid4(), sha256=sha, storage_uri=f"local://{sha[:6]}.pdf",
+        filename=filename,
+    )
+    test_db.add(sd)
+    await test_db.commit()
+    doc = DocumentORM(
+        id=uuid4(), project_id=project_id, source_document_id=sd.id,
+        source_type="upload", source_identifier=sha, title=filename or sha[:6],
+        source_metadata={}, status="ready", created_by=user.id,
+    )
+    test_db.add(doc)
+    await test_db.commit()
+    return sd
+
+
+async def _create_run_with_parsed(
+    parse_run_repo: ParseRunRepository,
+    test_db: AsyncSession,
+    *,
+    source: SourceDocument,
+    parser: str = "llamaparse",
+    config_hash: str = "h" * 64,
+    finished_at: datetime | None = None,
+    status: str = "succeeded",
+    full_text: str | None = "hello",
+    full_markdown: str | None = None,
+    block_count: int = 1,
+) -> ParsedDocument | None:
+    finished_at = finished_at or datetime.now(timezone.utc)
+    run = await parse_run_repo.create(ParseRunCreate(
+        source_document_id=source.id, parser=parser,
+        representation_kind="full_markdown" if full_markdown else "full_text",
+        config={"k": 1}, config_hash=config_hash,
+        status=status,
+        started_at=finished_at,
+        finished_at=finished_at if status == "succeeded" else None,
+    ))
+    if status != "succeeded":
+        return None
+    pdoc = ParsedDocument(
+        parse_run_id=run.id, source_document_id=source.id,
+        full_text=full_text, full_markdown=full_markdown,
+        page_count=1, block_count=block_count, content={},
+    )
+    test_db.add(pdoc)
+    await test_db.commit()
+    return pdoc
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_returns_only_project_parsed_docs(
+    repo, parse_run_repo, test_db, user
+):
+    p1, p2 = uuid4(), uuid4()
+    sd1 = await _create_source_in_project(test_db, user=user, project_id=p1, sha="1" * 64)
+    sd2 = await _create_source_in_project(test_db, user=user, project_id=p2, sha="2" * 64)
+    await _create_run_with_parsed(parse_run_repo, test_db, source=sd1, full_markdown="# 1")
+    await _create_run_with_parsed(parse_run_repo, test_db, source=sd2, full_markdown="# 2")
+
+    rows = await repo.list_for_project(p1)
+    assert len(rows) == 1
+    assert rows[0].source_document_id == sd1.id
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_filters_by_family(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="a" * 64)
+    sd2 = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="b" * 64)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        parser="llamaparse", config_hash="x" * 64, full_markdown="# x",
+    )
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd2,
+        parser="landingai", config_hash="y" * 64, full_markdown="# y",
+    )
+
+    rows = await repo.list_for_project(
+        project_id, parser="llamaparse", parse_config_hash="x" * 64,
+    )
+    assert len(rows) == 1
+    assert rows[0].parser == "llamaparse"
+    assert rows[0].parse_config_hash == "x" * 64
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_filters_by_representation_full_markdown(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd1 = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="m" * 64)
+    sd2 = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="t" * 64)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd1,
+        config_hash="m" * 64, full_markdown="# md",
+    )
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd2,
+        config_hash="t" * 64, full_markdown=None,
+    )
+
+    rows = await repo.list_for_project(project_id, representation="full_markdown")
+    assert len(rows) == 1
+    assert rows[0].source_document_id == sd1.id
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_filters_by_representation_full_text(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="f" * 64)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        config_hash="f" * 64, full_text="hello", full_markdown=None,
+    )
+
+    rows = await repo.list_for_project(project_id, representation="full_text")
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_filters_by_representation_block(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="k" * 64)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        config_hash="k" * 64, block_count=3,
+    )
+
+    rows = await repo.list_for_project(project_id, representation="block")
+    assert len(rows) == 1
+    assert rows[0].block_count == 3
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_latest_per_source_default_returns_one_per_source(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="l" * 64)
+    earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        config_hash="1" * 64, finished_at=earlier, full_markdown="# e",
+    )
+    later_doc = await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        config_hash="2" * 64, finished_at=later, full_markdown="# l",
+    )
+
+    rows = await repo.list_for_project(project_id)  # default latest_per_source=True
+    assert len(rows) == 1
+    assert rows[0].parse_run_id == later_doc.parse_run_id
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_latest_per_source_false_returns_all_runs(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="a" * 64)
+    earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        config_hash="1" * 64, finished_at=earlier, full_markdown="# e",
+    )
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd,
+        config_hash="2" * 64, finished_at=later, full_markdown="# l",
+    )
+
+    rows = await repo.list_for_project(project_id, latest_per_source=False)
+    assert len(rows) == 2
+    # Newest first
+    assert rows[0].parsed_at.replace(tzinfo=None) >= rows[1].parsed_at.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_excludes_failed_run_parsed_docs(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(test_db, user=user, project_id=project_id, sha="f" * 64)
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd, status="failed", full_markdown=None,
+    )
+    rows = await repo.list_for_project(project_id)
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_includes_source_filename(
+    repo, parse_run_repo, test_db, user
+):
+    project_id = uuid4()
+    sd = await _create_source_in_project(
+        test_db, user=user, project_id=project_id, sha="n" * 64, filename="my-doc.pdf",
+    )
+    await _create_run_with_parsed(
+        parse_run_repo, test_db, source=sd, full_markdown="# name",
+    )
+
+    rows = await repo.list_for_project(project_id)
+    assert len(rows) == 1
+    assert rows[0].source_filename == "my-doc.pdf"

--- a/backend/tests/routers/test_parse_run_configs_router.py
+++ b/backend/tests/routers/test_parse_run_configs_router.py
@@ -1,0 +1,155 @@
+"""Tests for GET /projects/{project_id}/parse-runs/configs."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document as DocumentORM
+from app.models.parse_run import ParseRun as ParseRunORM
+from app.models.parsed_document import ParsedDocument as ParsedDocumentORM
+from app.models.project import Project
+from app.models.source_document import SourceDocument
+from app.models.user import User
+
+
+async def _signup(client: AsyncClient, email: str) -> str:
+    await client.post(
+        "/api/v1/auth/signup",
+        json={
+            "email": email, "password": "ValidPass123!",
+            "password_confirm": "ValidPass123!", "full_name": "T",
+        },
+    )
+    resp = await client.post(
+        "/api/v1/auth/signin",
+        json={"email": email, "password": "ValidPass123!"},
+    )
+    return resp.json()["access_token"]
+
+
+async def _user_by_email(test_db: AsyncSession, email: str) -> User:
+    result = await test_db.execute(select(User).where(User.email == email))
+    return result.scalar_one()
+
+
+async def _make_project(test_db: AsyncSession, user: User, name: str = "P") -> Project:
+    project = Project(user_id=user.id, name=name)
+    test_db.add(project)
+    await test_db.commit()
+    await test_db.refresh(project)
+    return project
+
+
+async def _seed_succeeded_run(
+    test_db: AsyncSession,
+    *,
+    user: User,
+    project: Project,
+    sha: str,
+    parser: str,
+    config_hash: str,
+    config: dict | None = None,
+    full_markdown: str | None = "# md",
+    finished_at: datetime | None = None,
+) -> ParsedDocumentORM:
+    sd = SourceDocument(id=uuid4(), sha256=sha, storage_uri=f"local://{sha[:6]}.pdf")
+    test_db.add(sd)
+    await test_db.commit()
+    doc = DocumentORM(
+        project_id=project.id, source_document_id=sd.id,
+        source_type="upload", source_identifier=sha, title=sha[:6],
+        status="ready", created_by=user.id,
+    )
+    test_db.add(doc)
+    finished_at = finished_at or datetime.now(timezone.utc)
+    run = ParseRunORM(
+        source_document_id=sd.id, parser=parser,
+        representation_kind="full_markdown" if full_markdown else "full_text",
+        config=config or {"k": 1}, config_hash=config_hash,
+        status="succeeded", started_at=finished_at, finished_at=finished_at,
+    )
+    test_db.add(run)
+    await test_db.commit()
+    pdoc = ParsedDocumentORM(
+        parse_run_id=run.id, source_document_id=sd.id,
+        full_text="hello", full_markdown=full_markdown,
+        page_count=1, block_count=1, content={},
+    )
+    test_db.add(pdoc)
+    await test_db.commit()
+    return pdoc
+
+
+@pytest.mark.asyncio
+async def test_returns_distinct_families_for_project(client: AsyncClient, test_db: AsyncSession):
+    token = await _signup(client, "configs1@example.com")
+    user = await _user_by_email(test_db, "configs1@example.com")
+    project = await _make_project(test_db, user)
+
+    await _seed_succeeded_run(
+        test_db, user=user, project=project, sha="a" * 64,
+        parser="llamaparse", config_hash="h" * 64, config={"tier": "premium"},
+    )
+    await _seed_succeeded_run(
+        test_db, user=user, project=project, sha="b" * 64,
+        parser="landingai", config_hash="z" * 64, config={"mode": "fast"},
+        full_markdown=None,
+    )
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parse-runs/configs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    families = {(o["parser"], o["parseConfigHash"]) for o in body}
+    assert families == {("llamaparse", "h" * 64), ("landingai", "z" * 64)}
+    llama = next(o for o in body if o["parser"] == "llamaparse")
+    assert llama["hasFullMarkdown"] is True
+    assert llama["parsedDocumentCount"] == 1
+    assert llama["config"] == {"tier": "premium"}
+
+
+@pytest.mark.asyncio
+async def test_requires_authentication(client: AsyncClient):
+    resp = await client.get(f"/api/v1/projects/{uuid4()}/parse-runs/configs")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_rejects_other_users_project(client: AsyncClient, test_db: AsyncSession):
+    # User A owns project; user B tries to read configs.
+    await _signup(client, "owner@example.com")
+    owner = await _user_by_email(test_db, "owner@example.com")
+    project = await _make_project(test_db, owner)
+    await _seed_succeeded_run(
+        test_db, user=owner, project=project, sha="o" * 64,
+        parser="llamaparse", config_hash="o" * 64,
+    )
+
+    other_token = await _signup(client, "other@example.com")
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parse-runs/configs",
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_list(client: AsyncClient, test_db: AsyncSession):
+    token = await _signup(client, "empty@example.com")
+    user = await _user_by_email(test_db, "empty@example.com")
+    project = await _make_project(test_db, user)
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parse-runs/configs",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/backend/tests/routers/test_parsed_documents_router.py
+++ b/backend/tests/routers/test_parsed_documents_router.py
@@ -1,0 +1,286 @@
+"""Tests for GET /projects/{project_id}/parsed-documents."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.document import Document as DocumentORM
+from app.models.parse_run import ParseRun as ParseRunORM
+from app.models.parsed_document import ParsedDocument as ParsedDocumentORM
+from app.models.project import Project
+from app.models.source_document import SourceDocument
+from app.models.user import User
+
+
+async def _signup(client: AsyncClient, email: str) -> str:
+    await client.post(
+        "/api/v1/auth/signup",
+        json={
+            "email": email, "password": "ValidPass123!",
+            "password_confirm": "ValidPass123!", "full_name": "T",
+        },
+    )
+    resp = await client.post(
+        "/api/v1/auth/signin",
+        json={"email": email, "password": "ValidPass123!"},
+    )
+    return resp.json()["access_token"]
+
+
+async def _user_by_email(test_db: AsyncSession, email: str) -> User:
+    result = await test_db.execute(select(User).where(User.email == email))
+    return result.scalar_one()
+
+
+async def _make_project(test_db: AsyncSession, user: User, name: str = "P") -> Project:
+    project = Project(user_id=user.id, name=name)
+    test_db.add(project)
+    await test_db.commit()
+    await test_db.refresh(project)
+    return project
+
+
+async def _seed_run_with_pdoc(
+    test_db: AsyncSession,
+    *,
+    user: User,
+    project: Project,
+    sha: str,
+    parser: str = "llamaparse",
+    config_hash: str = "h" * 64,
+    full_markdown: str | None = "# md",
+    full_text: str | None = "hello",
+    finished_at: datetime | None = None,
+    filename: str | None = None,
+    status: str = "succeeded",
+) -> ParsedDocumentORM | None:
+    sd = SourceDocument(
+        id=uuid4(), sha256=sha, storage_uri=f"local://{sha[:6]}.pdf", filename=filename,
+    )
+    test_db.add(sd)
+    await test_db.commit()
+    doc = DocumentORM(
+        project_id=project.id, source_document_id=sd.id,
+        source_type="upload", source_identifier=sha, title=filename or sha[:6],
+        status="ready", created_by=user.id,
+    )
+    test_db.add(doc)
+    finished_at = finished_at or datetime.now(timezone.utc)
+    run = ParseRunORM(
+        source_document_id=sd.id, parser=parser,
+        representation_kind="full_markdown" if full_markdown else "full_text",
+        config={"k": 1}, config_hash=config_hash,
+        status=status, started_at=finished_at,
+        finished_at=finished_at if status == "succeeded" else None,
+    )
+    test_db.add(run)
+    await test_db.commit()
+    if status != "succeeded":
+        return None
+    pdoc = ParsedDocumentORM(
+        parse_run_id=run.id, source_document_id=sd.id,
+        full_text=full_text, full_markdown=full_markdown,
+        page_count=1, block_count=1, content={},
+    )
+    test_db.add(pdoc)
+    await test_db.commit()
+    return pdoc
+
+
+@pytest.mark.asyncio
+async def test_no_filter_returns_project_set(client: AsyncClient, test_db: AsyncSession):
+    token = await _signup(client, "list1@example.com")
+    user = await _user_by_email(test_db, "list1@example.com")
+    project = await _make_project(test_db, user)
+
+    await _seed_run_with_pdoc(
+        test_db, user=user, project=project, sha="a" * 64, filename="a.pdf",
+    )
+    await _seed_run_with_pdoc(
+        test_db, user=user, project=project, sha="b" * 64, filename="b.pdf",
+    )
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    filenames = {item["sourceFilename"] for item in body}
+    assert filenames == {"a.pdf", "b.pdf"}
+
+
+@pytest.mark.asyncio
+async def test_filters_by_family(client: AsyncClient, test_db: AsyncSession):
+    token = await _signup(client, "list2@example.com")
+    user = await _user_by_email(test_db, "list2@example.com")
+    project = await _make_project(test_db, user)
+
+    await _seed_run_with_pdoc(
+        test_db, user=user, project=project, sha="a" * 64,
+        parser="llamaparse", config_hash="x" * 64,
+    )
+    await _seed_run_with_pdoc(
+        test_db, user=user, project=project, sha="b" * 64,
+        parser="landingai", config_hash="y" * 64,
+    )
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        params={"parser": "llamaparse", "parseConfigHash": "x" * 64},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["parser"] == "llamaparse"
+    assert body[0]["parseConfigHash"] == "x" * 64
+
+
+@pytest.mark.asyncio
+async def test_representation_full_markdown_filters_to_populated(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup(client, "list3@example.com")
+    user = await _user_by_email(test_db, "list3@example.com")
+    project = await _make_project(test_db, user)
+
+    await _seed_run_with_pdoc(
+        test_db, user=user, project=project, sha="m" * 64, full_markdown="# yes",
+    )
+    await _seed_run_with_pdoc(
+        test_db, user=user, project=project, sha="t" * 64, full_markdown=None,
+    )
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        params={"representation": "full_markdown"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["hasFullMarkdown"] is True
+
+
+@pytest.mark.asyncio
+async def test_latest_per_source_default_true(client: AsyncClient, test_db: AsyncSession):
+    token = await _signup(client, "list4@example.com")
+    user = await _user_by_email(test_db, "list4@example.com")
+    project = await _make_project(test_db, user)
+
+    sd = SourceDocument(id=uuid4(), sha256="s" * 64, storage_uri="local://s.pdf")
+    test_db.add(sd)
+    await test_db.commit()
+    doc = DocumentORM(
+        project_id=project.id, source_document_id=sd.id,
+        source_type="upload", source_identifier="s", title="S",
+        status="ready", created_by=user.id,
+    )
+    test_db.add(doc)
+    await test_db.commit()
+
+    earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    for ts, hash_ in ((earlier, "1" * 64), (later, "2" * 64)):
+        run = ParseRunORM(
+            source_document_id=sd.id, parser="llamaparse",
+            representation_kind="full_markdown",
+            config={}, config_hash=hash_, status="succeeded",
+            started_at=ts, finished_at=ts,
+        )
+        test_db.add(run)
+        await test_db.commit()
+        test_db.add(ParsedDocumentORM(
+            parse_run_id=run.id, source_document_id=sd.id,
+            full_text="x", full_markdown="# x", page_count=1, block_count=1, content={},
+        ))
+        await test_db.commit()
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_latest_per_source_false_returns_all_runs(
+    client: AsyncClient, test_db: AsyncSession
+):
+    token = await _signup(client, "list5@example.com")
+    user = await _user_by_email(test_db, "list5@example.com")
+    project = await _make_project(test_db, user)
+
+    sd = SourceDocument(id=uuid4(), sha256="z" * 64, storage_uri="local://z.pdf")
+    test_db.add(sd)
+    await test_db.commit()
+    doc = DocumentORM(
+        project_id=project.id, source_document_id=sd.id,
+        source_type="upload", source_identifier="z", title="Z",
+        status="ready", created_by=user.id,
+    )
+    test_db.add(doc)
+    await test_db.commit()
+
+    for hash_ in ("1" * 64, "2" * 64):
+        run = ParseRunORM(
+            source_document_id=sd.id, parser="llamaparse",
+            representation_kind="full_markdown",
+            config={}, config_hash=hash_, status="succeeded",
+            started_at=datetime.now(timezone.utc),
+            finished_at=datetime.now(timezone.utc),
+        )
+        test_db.add(run)
+        await test_db.commit()
+        test_db.add(ParsedDocumentORM(
+            parse_run_id=run.id, source_document_id=sd.id,
+            full_text="x", full_markdown="# x", page_count=1, block_count=1, content={},
+        ))
+        await test_db.commit()
+
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        params={"latestPerSource": "false"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_rejects_other_users_project(client: AsyncClient, test_db: AsyncSession):
+    await _signup(client, "owner2@example.com")
+    owner = await _user_by_email(test_db, "owner2@example.com")
+    project = await _make_project(test_db, owner)
+    await _seed_run_with_pdoc(
+        test_db, user=owner, project=project, sha="o" * 64,
+    )
+
+    other_token = await _signup(client, "other2@example.com")
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_validates_partial_family_query(client: AsyncClient, test_db: AsyncSession):
+    """Supplying parser without parseConfigHash should be rejected."""
+    token = await _signup(client, "validate@example.com")
+    user = await _user_by_email(test_db, "validate@example.com")
+    project = await _make_project(test_db, user)
+    resp = await client.get(
+        f"/api/v1/projects/{project.id}/parsed-documents",
+        params={"parser": "llamaparse"},  # missing parseConfigHash
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 422

--- a/docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
+++ b/docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
@@ -3,6 +3,7 @@
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Spec:** [`docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md`](../specs/2026-04-29-cdm-index-parser-config-selector.md)
+**Issue:** [#46](https://github.com/asanyaga/rag-admin/issues/46)
 
 **Goal:** Lay the data and read-API foundation for the parsed-document refactor without touching the index-create write path or the wizard. After this unit:
 

--- a/docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
+++ b/docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
@@ -7,12 +7,14 @@
 
 **Goal:** Lay the data and read-API foundation for the parsed-document refactor without touching the index-create write path or the wizard. After this unit:
 
-- `index_documents` has a `parsed_document_id` FK column (**nullable**, populated by backfill where possible — see the Cascade-Delete Deferral note below).
+- `index_documents.parse_run_id` FK is tightened from `SET NULL` to `CASCADE` to match the parsed-doc-centric integrity model (and `IndexDocument` gains a `parsed_document` relationship). No new column is added — `parse_run_id` already serves as the parsed-document handle, since `parsed_documents.parse_run_id` is its primary key (1:1 with parse_run).
 - `GET /projects/{projectId}/parse-runs/configs` lists the parse-config families available in the project.
 - `GET /projects/{projectId}/parsed-documents` lists parsed-documents with family + representation filters and a `latest_per_source` toggle.
 - All existing flows (index create, add documents, processing, preview) continue to work unchanged.
 
-**Architecture:** Pure-additive backend slice. Migration adds the FK column and backfills from the existing `parse_run_id`. Two new project-scoped GET routers expose the read APIs the wizard rebuild (Unit 4) will consume. Existing `IndexDocument` ORM gets one new field; nothing in the write path changes.
+**Architecture:** Pure-additive backend slice. A small Alembic migration tightens an existing FK; no new column is required because `ParsedDocument.parse_run_id` is already the parsed-document primary key (1:1 invariant; the `id` vs `parse_run_id` split shown in the CDM domain class is collapsed at the ORM layer for now and can be added later when `derived_from` ships). Two new project-scoped GET routers expose the read APIs the wizard rebuild (Unit 4) will consume.
+
+> **Note on identifier choice (recorded 2026-04-30):** The API surface uses `parsedDocumentId` as the conceptual handle, but the wire value IS a `parse_run_id` UUID under the current 1:1 schema. When `derived_from` lands and parsed-docs need their own identity, the migration is bounded: add `parsed_documents.id`, swap PK, add a unique index on `parse_run_id`, and backfill any tables that today store parse_run_id-as-parsed-doc-handle (currently only `index_documents`). The API stays the same; only the wire value changes from "parse_run_id of this parsed-doc" to "id of this parsed-doc."
 
 **Tech Stack:** Python 3.12 · FastAPI async · SQLAlchemy 2.0 async · Alembic · Pydantic v2 · pytest
 
@@ -20,11 +22,11 @@
 
 ## Cascade-delete deferral
 
-Per the breakdown discussion, this unit **does not delete legacy `index_documents` rows or legacy indexes**. The `parsed_document_id` column is added as **NULL-allowed**, backfilled from `parse_run_id` where possible, and left nullable for now. Legacy raw_text rows (with `parse_run_id IS NULL`) and rows whose `parse_run_id` does not resolve to a `ParsedDocument` will retain `parsed_document_id = NULL` until **Unit 6 (cleanup)** lands after Units 2–5 ship and the new flow is validated end-to-end.
+This unit **does not delete legacy `index_documents` rows or legacy indexes**. With Option A in place (no new column), the relevant integrity boundary is the existing `index_documents.parse_run_id` FK. Tightening it to `ON DELETE CASCADE` improves integrity for new rows but does not retroactively delete pre-existing rows with `parse_run_id IS NULL`.
 
 Implications carried forward:
-- Units 2–5 must tolerate `parsed_document_id IS NULL` on read paths (display "—" or hide the row in the new UI; existing UI continues to read `document_id` + `parse_run_id`).
-- Unit 6 will: (a) cascade-delete the remaining NULL-bearing indexes, (b) `ALTER COLUMN parsed_document_id SET NOT NULL`, (c) optionally drop `document_id` / `parse_run_id` columns.
+- Units 2–5 must tolerate `index_documents.parse_run_id IS NULL` on read paths (legacy raw_text rows; display "—" or hide in the new UI; existing UI continues to render).
+- Unit 6 (cleanup) will, after Units 2–5 validate end-to-end: (a) delete `index_documents` rows where `parse_run_id IS NULL`, (b) delete any `indexes` left empty as a result, (c) consider making `parse_run_id` NOT NULL once raw_text is fully removed (see Unit 3).
 
 ---
 
@@ -152,15 +154,15 @@ After creating, confirm issue number with the user and update this file with `**
 
 | Action | Path | What changes |
 |--------|------|--------------|
-| **Create** | `backend/alembic/versions/<rev>_add_parsed_document_id_to_index_documents.py` | New migration: add FK column + backfill |
-| Modify | `backend/app/models/index_document.py` | Add `parsed_document_id` field + relationship to `ParsedDocument` |
+| **Create** | `backend/alembic/versions/<rev>_tighten_index_documents_parse_run_fk.py` | New migration: drop existing `SET NULL` FK on `index_documents.parse_run_id`, recreate as `CASCADE` |
+| Modify | `backend/app/models/index_document.py` | Change `parse_run_id` FK to `ondelete="CASCADE"`; add `parsed_document` relationship via `primaryjoin` on `parse_run_id` |
 | Modify | `backend/app/repositories/parse_run_repository.py` | Add `list_distinct_configs_for_project(project_id)` |
 | Modify | `backend/app/repositories/parsed_document_repository.py` | Add `list_for_project(project_id, *, parser, parse_config_hash, representation, latest_per_source)` |
 | **Create** | `backend/app/schemas/parsed_document.py` (or extend existing) | `ParseConfigOption`, `ParsedDocumentListItem` |
 | **Create** | `backend/app/routers/parse_run_configs.py` | `GET /projects/{project_id}/parse-runs/configs` |
 | **Create** | `backend/app/routers/parsed_documents.py` | `GET /projects/{project_id}/parsed-documents` |
 | Modify | `backend/app/main.py` | Register new routers |
-| **Create** | `backend/tests/migrations/test_parsed_document_id_backfill.py` | Migration backfill test |
+| **Create** | `backend/tests/models/test_index_document_parsed_document_relationship.py` | Verify ORM relationship + FK cascade behavior |
 | **Create** | `backend/tests/repositories/test_parse_run_repository_configs.py` | Distinct-configs query test |
 | **Create** | `backend/tests/repositories/test_parsed_document_repository_listing.py` | Listing + filter + latest_per_source tests |
 | **Create** | `backend/tests/routers/test_parse_run_configs_router.py` | `/parse-runs/configs` endpoint tests |
@@ -172,69 +174,71 @@ No frontend changes in this unit.
 
 ## Implementation tasks (TDD)
 
-### Task 1 — ORM column + Alembic migration
+### Task 1 — IndexDocument relationship + FK cascade tighten
 
-- [ ] **1.1 Write migration test (red).** `backend/tests/migrations/test_parsed_document_id_backfill.py` — pytest fixture spins up an Alembic stamp at the previous revision, seeds `index_documents` rows with various `(parse_run_id, parsed_document)` shapes (resolvable, unresolvable, NULL), upgrades to the new revision, asserts:
-  - Resolvable rows now have `parsed_document_id` populated correctly.
-  - Unresolvable rows have `parsed_document_id IS NULL`.
-  - The FK constraint is in place with `ON DELETE CASCADE`.
-  - Column allows NULL (no NOT NULL constraint yet).
+- [ ] **1.1 Write ORM/relationship test (red).** `backend/tests/models/test_index_document_parsed_document_relationship.py` — assert that:
+  - `IndexDocument.parsed_document` traverses correctly to `ParsedDocument` when `parse_run_id` is set.
+  - `IndexDocument.parsed_document` is `None` when `parse_run_id` is `None`.
+  - Deleting the parent `ParseRun` cascade-deletes the `IndexDocument` row (not `SET NULL` anymore).
 
-- [ ] **1.2 Generate the Alembic migration (green).** Use `alembic revision --autogenerate` after adding the field to the ORM (Task 1.4) — but the file will need manual edits for the backfill UPDATE. Migration body:
+- [ ] **1.2 Tighten FK on `IndexDocument` ORM.** In `app/models/index_document.py`:
   ```python
-  def upgrade() -> None:
-      op.add_column(
-          "index_documents",
-          sa.Column(
-              "parsed_document_id",
-              postgresql.UUID(as_uuid=True),
-              sa.ForeignKey("parsed_documents.id", ondelete="CASCADE"),
-              nullable=True,
-          ),
-      )
-      op.create_index(
-          "ix_index_documents_parsed_document_id",
-          "index_documents",
-          ["parsed_document_id"],
-      )
-      op.execute("""
-          UPDATE index_documents id
-          SET parsed_document_id = pd.id
-          FROM parsed_documents pd
-          WHERE pd.parse_run_id = id.parse_run_id
-            AND id.parse_run_id IS NOT NULL
-      """)
-
-  def downgrade() -> None:
-      op.drop_index("ix_index_documents_parsed_document_id", table_name="index_documents")
-      op.drop_column("index_documents", "parsed_document_id")
-  ```
-
-- [ ] **1.3 Run migration test — verify green.**
-  ```bash
-  uv run --directory /home/asa/rag-admin/backend python -m pytest tests/migrations/test_parsed_document_id_backfill.py -o "addopts="
-  ```
-
-- [ ] **1.4 Add field to `IndexDocument` ORM.**
-  ```python
-  parsed_document_id: Mapped[UUID | None] = mapped_column(
+  parse_run_id: Mapped[UUID | None] = mapped_column(
       PGUUID(as_uuid=True),
-      ForeignKey("parsed_documents.id", ondelete="CASCADE"),
+      ForeignKey("parse_runs.id", ondelete="CASCADE"),  # was SET NULL
       nullable=True,
   )
   parsed_document: Mapped["ParsedDocument | None"] = relationship(
-      "ParsedDocument", foreign_keys=[parsed_document_id]
+      "ParsedDocument",
+      primaryjoin="IndexDocument.parse_run_id == foreign(ParsedDocument.parse_run_id)",
+      viewonly=True,
   )
   ```
-  Add `sa.Index('ix_index_documents_parsed_document_id', 'parsed_document_id')` to `__table_args__`.
+  Keep the existing `parse_run` relationship and the `ix_index_documents_parse_run_id` index unchanged.
+
+- [ ] **1.3 Generate the Alembic migration.** Run:
+  ```bash
+  uv run --directory /home/asa/rag-admin/backend alembic revision --autogenerate -m "tighten index_documents.parse_run_id FK to cascade"
+  ```
+  Expected migration body (manually verified):
+  ```python
+  def upgrade() -> None:
+      op.drop_constraint("index_documents_parse_run_id_fkey", "index_documents", type_="foreignkey")
+      op.create_foreign_key(
+          "index_documents_parse_run_id_fkey",
+          "index_documents",
+          "parse_runs",
+          ["parse_run_id"],
+          ["id"],
+          ondelete="CASCADE",
+      )
+
+  def downgrade() -> None:
+      op.drop_constraint("index_documents_parse_run_id_fkey", "index_documents", type_="foreignkey")
+      op.create_foreign_key(
+          "index_documents_parse_run_id_fkey",
+          "index_documents",
+          "parse_runs",
+          ["parse_run_id"],
+          ["id"],
+          ondelete="SET NULL",
+      )
+  ```
+  If autogenerate produces a different constraint name, use the actual name from the database (`SELECT conname FROM pg_constraint WHERE conrelid = 'index_documents'::regclass`).
+
+- [ ] **1.4 Run the relationship/cascade test — verify green.**
+  ```bash
+  uv run --directory /home/asa/rag-admin/backend python -m pytest tests/models/test_index_document_parsed_document_relationship.py -o "addopts="
+  ```
 
 - [ ] **1.5 Apply migration to local dev DB and spot-check.**
   ```bash
   docker compose -f /home/asa/rag-admin/docker-compose.local.yml exec backend alembic upgrade head
   docker compose -f /home/asa/rag-admin/docker-compose.local.yml exec postgres \
       psql -U postgres -d rag_admin -c \
-      "SELECT count(*) total, count(parsed_document_id) backfilled FROM index_documents"
+      "SELECT conname, confdeltype FROM pg_constraint WHERE conrelid = 'index_documents'::regclass AND contype = 'f'"
   ```
+  `confdeltype = 'c'` (CASCADE) on the parse_run_id FK after migration.
 
 ### Task 2 — `ParseRun` repository: distinct configs
 
@@ -434,8 +438,9 @@ No frontend changes in this unit.
 ## Manual verification checklist (to attach to the PR)
 
 - [ ] Migration runs cleanly on a freshly-cloned local DB.
-- [ ] Backfill populated `parsed_document_id` for all rows where `parse_run_id` resolves to a `ParsedDocument`.
-- [ ] Legacy raw_text `index_documents` rows remain (with `parsed_document_id IS NULL`) — **not deleted** in this unit.
+- [ ] `index_documents.parse_run_id` FK is `CASCADE` (verified via `pg_constraint` query).
+- [ ] Legacy raw_text `index_documents` rows remain untouched (still `parse_run_id IS NULL`).
+- [ ] Deleting a `ParseRun` cascades to `IndexDocument` rows that reference it (no orphan / SET NULL behavior).
 - [ ] `GET /parse-runs/configs` returns expected families.
 - [ ] `GET /parsed-documents` filters and `latest_per_source` toggle behave per spec.
 - [ ] Existing `Create Index` flow (slice-2 wizard) still works for raw_text and full_markdown.

--- a/docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
+++ b/docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
@@ -1,0 +1,450 @@
+# CDM Index — Unit 1: Backend Foundation (reads + ORM column)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** [`docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md`](../specs/2026-04-29-cdm-index-parser-config-selector.md)
+
+**Goal:** Lay the data and read-API foundation for the parsed-document refactor without touching the index-create write path or the wizard. After this unit:
+
+- `index_documents` has a `parsed_document_id` FK column (**nullable**, populated by backfill where possible — see the Cascade-Delete Deferral note below).
+- `GET /projects/{projectId}/parse-runs/configs` lists the parse-config families available in the project.
+- `GET /projects/{projectId}/parsed-documents` lists parsed-documents with family + representation filters and a `latest_per_source` toggle.
+- All existing flows (index create, add documents, processing, preview) continue to work unchanged.
+
+**Architecture:** Pure-additive backend slice. Migration adds the FK column and backfills from the existing `parse_run_id`. Two new project-scoped GET routers expose the read APIs the wizard rebuild (Unit 4) will consume. Existing `IndexDocument` ORM gets one new field; nothing in the write path changes.
+
+**Tech Stack:** Python 3.12 · FastAPI async · SQLAlchemy 2.0 async · Alembic · Pydantic v2 · pytest
+
+---
+
+## Cascade-delete deferral
+
+Per the breakdown discussion, this unit **does not delete legacy `index_documents` rows or legacy indexes**. The `parsed_document_id` column is added as **NULL-allowed**, backfilled from `parse_run_id` where possible, and left nullable for now. Legacy raw_text rows (with `parse_run_id IS NULL`) and rows whose `parse_run_id` does not resolve to a `ParsedDocument` will retain `parsed_document_id = NULL` until **Unit 6 (cleanup)** lands after Units 2–5 ship and the new flow is validated end-to-end.
+
+Implications carried forward:
+- Units 2–5 must tolerate `parsed_document_id IS NULL` on read paths (display "—" or hide the row in the new UI; existing UI continues to read `document_id` + `parse_run_id`).
+- Unit 6 will: (a) cascade-delete the remaining NULL-bearing indexes, (b) `ALTER COLUMN parsed_document_id SET NOT NULL`, (c) optionally drop `document_id` / `parse_run_id` columns.
+
+---
+
+## Phase 0 — Repo cleanup (perform before issue creation)
+
+The current branch (`feature/cdm-index-slice-2-markdown-chunking`) holds an in-progress slice-2 plus uncommitted artifacts that span both slice-2 and the new feature. Cleanly separating them is a prerequisite for this unit.
+
+### Categorization
+
+| Path | Belongs to | Action |
+|------|-----------|--------|
+| `backend/app/schemas/index.py` | slice-2 | commit on slice-2 branch |
+| `backend/tests/schemas/test_index_config_schema.py` | slice-2 | commit on slice-2 branch |
+| `frontend/src/components/indexes/IndexCreateDialog.tsx` | slice-2 | commit on slice-2 branch |
+| `frontend/src/pages/CreateIndexPage.tsx` | slice-2 | commit on slice-2 branch |
+| `docs/superpowers/plans/2026-04-29-cdm-index-slice-2-markdown-chunking.md` | slice-2 | commit on slice-2 branch |
+| `.claude/settings.json` | settings chore | commit on slice-2 branch |
+| `.claude/settings.local.json` | local-only | leave uncommitted |
+| `docs/superpowers/specs/2026-04-28-cdm-index-slice-5-ui-polish.md` (modified) | new feature | revert on slice-2; re-apply on new branch |
+| `docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md` (untracked) | new feature | move out, restore on new branch |
+| `docs/superpowers/plans/2026-04-29-cdm-index-parser-config-selector.md` (untracked) | superseded | move out; **delete** (this plan supersedes it) |
+| `docs/superpowers/plans/2026-04-29-preview-chunks-cdm-refactor.md` (untracked) | superseded | move out; **delete** (Unit 2 plan will supersede) |
+
+### Cleanup steps
+
+- [ ] **0.1 — Snapshot new-feature artifacts to a holding directory.**
+  ```bash
+  mkdir -p /tmp/cdm-parsed-doc-handoff
+  mv /home/asa/rag-admin/docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md \
+     /tmp/cdm-parsed-doc-handoff/spec.md
+  mv /home/asa/rag-admin/docs/superpowers/plans/2026-04-29-cdm-index-parser-config-selector.md \
+     /tmp/cdm-parsed-doc-handoff/superseded-plan-1.md
+  mv /home/asa/rag-admin/docs/superpowers/plans/2026-04-29-preview-chunks-cdm-refactor.md \
+     /tmp/cdm-parsed-doc-handoff/superseded-plan-2.md
+  git -C /home/asa/rag-admin diff docs/superpowers/specs/2026-04-28-cdm-index-slice-5-ui-polish.md \
+     > /tmp/cdm-parsed-doc-handoff/slice-5-trim.diff
+  ```
+
+- [ ] **0.2 — Revert the slice-5 spec edit on the slice-2 branch.** The trim depends on the new spec existing; it lands with the new feature, not slice-2.
+  ```bash
+  git -C /home/asa/rag-admin checkout HEAD -- docs/superpowers/specs/2026-04-28-cdm-index-slice-5-ui-polish.md
+  ```
+
+- [ ] **0.3 — Verify slice-2 working tree contains only slice-2 finishers.** `git status` should list only the rows marked "slice-2" or "settings chore" in the table above. If any new-feature artifacts remain, re-run 0.1.
+
+- [ ] **0.4 — Run slice-2 verification:**
+  ```bash
+  uv run --directory /home/asa/rag-admin/backend python -m pytest -o "addopts="
+  npm --prefix /home/asa/rag-admin/frontend run lint
+  npm --prefix /home/asa/rag-admin/frontend run build
+  ```
+
+- [ ] **0.5 — Commit slice-2 finishers in logical groups, then push the branch.** Suggested grouping:
+  - `chore(claude): permit npm test from settings` — `.claude/settings.json`
+  - `feat(schemas): drop premature parser requirement on IndexConfig` — `backend/app/schemas/index.py` + the matching test
+  - `feat(frontend): error-detail extractor for create-index toasts` — `IndexCreateDialog.tsx` + `CreateIndexPage.tsx` (error helper) + the page parity work
+  - `docs: slice-2 markdown chunking implementation plan` — the slice-2 plan file
+
+- [ ] **0.6 — Open the slice-2 PR.** Note in the description that preview is intentionally disabled for `full_markdown` (commit `2a0cfa1`) and will be restored by Unit 2 of the parsed-document refactor (link to spec). Do **not** wait for merge before continuing — Unit 1 work proceeds on the new branch in parallel.
+
+- [ ] **0.7 — Branch off main for the new feature.**
+  ```bash
+  git -C /home/asa/rag-admin fetch origin
+  git -C /home/asa/rag-admin checkout main
+  git -C /home/asa/rag-admin pull --ff-only origin main
+  git -C /home/asa/rag-admin checkout -b feature/cdm-index-parsed-doc-selector
+  ```
+
+- [ ] **0.8 — Restore the new-feature spec onto the new branch.**
+  ```bash
+  cp /tmp/cdm-parsed-doc-handoff/spec.md \
+     /home/asa/rag-admin/docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md
+  git -C /home/asa/rag-admin apply /tmp/cdm-parsed-doc-handoff/slice-5-trim.diff
+  rm /tmp/cdm-parsed-doc-handoff/superseded-plan-1.md /tmp/cdm-parsed-doc-handoff/superseded-plan-2.md
+  ```
+  The two superseded plan files are dropped — this plan replaces them.
+
+- [ ] **0.9 — Commit the spec + this plan as the first commit of the new branch.**
+  ```
+  docs(spec): parsed-document refactor for CDM index creation
+  ```
+  Includes: the new spec, the slice-5 spec trim (now coherent), and this plan file.
+
+After 0.9, the new branch contains spec + plan, the slice-2 PR is open with the preview band-aid annotated, and the working tree is clean for Unit 1 implementation.
+
+---
+
+## Pre-implementation gate
+
+- [ ] **Step P1 — Create GitHub issue and confirm with user.**
+
+```bash
+gh issue create \
+  --title "feat(index): backend foundation for parsed-document selector (Unit 1)" \
+  --body "$(cat <<'EOF'
+## Summary
+First unit of the CDM-index parsed-document refactor. Pure-additive backend
+foundation: adds `index_documents.parsed_document_id` FK (nullable; backfilled
+from `parse_run_id`) and exposes two project-scoped GET endpoints used by the
+wizard rebuild in later units.
+
+## Acceptance criteria
+- [ ] `index_documents.parsed_document_id` column exists, FK to `parsed_documents` with `ON DELETE CASCADE`, nullable.
+- [ ] Backfill populates `parsed_document_id` for every row whose `parse_run_id` resolves to a `parsed_document`. Rows that don't resolve remain NULL (deferred cleanup).
+- [ ] `GET /projects/{projectId}/parse-runs/configs` returns distinct `(parser, parse_config_hash)` families with `parsed_document_count`, `has_full_markdown`, `latest_parsed_at`.
+- [ ] `GET /projects/{projectId}/parsed-documents` supports `parser`, `parse_config_hash`, `representation`, `latest_per_source` query params; sorted newest-first; project-scoped authorization enforced.
+- [ ] All existing index-create / processing / preview flows continue to pass their tests.
+- [ ] No legacy data is deleted in this unit (cascade-delete + NOT NULL deferred to a final cleanup unit).
+
+## Spec
+docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md
+
+## Plan
+docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md
+EOF
+)" \
+  --label "feature,backend"
+```
+
+After creating, confirm issue number with the user and update this file with `**Issue:** #<n>` before continuing.
+
+---
+
+## File map
+
+| Action | Path | What changes |
+|--------|------|--------------|
+| **Create** | `backend/alembic/versions/<rev>_add_parsed_document_id_to_index_documents.py` | New migration: add FK column + backfill |
+| Modify | `backend/app/models/index_document.py` | Add `parsed_document_id` field + relationship to `ParsedDocument` |
+| Modify | `backend/app/repositories/parse_run_repository.py` | Add `list_distinct_configs_for_project(project_id)` |
+| Modify | `backend/app/repositories/parsed_document_repository.py` | Add `list_for_project(project_id, *, parser, parse_config_hash, representation, latest_per_source)` |
+| **Create** | `backend/app/schemas/parsed_document.py` (or extend existing) | `ParseConfigOption`, `ParsedDocumentListItem` |
+| **Create** | `backend/app/routers/parse_run_configs.py` | `GET /projects/{project_id}/parse-runs/configs` |
+| **Create** | `backend/app/routers/parsed_documents.py` | `GET /projects/{project_id}/parsed-documents` |
+| Modify | `backend/app/main.py` | Register new routers |
+| **Create** | `backend/tests/migrations/test_parsed_document_id_backfill.py` | Migration backfill test |
+| **Create** | `backend/tests/repositories/test_parse_run_repository_configs.py` | Distinct-configs query test |
+| **Create** | `backend/tests/repositories/test_parsed_document_repository_listing.py` | Listing + filter + latest_per_source tests |
+| **Create** | `backend/tests/routers/test_parse_run_configs_router.py` | `/parse-runs/configs` endpoint tests |
+| **Create** | `backend/tests/routers/test_parsed_documents_router.py` | `/parsed-documents` endpoint tests |
+
+No frontend changes in this unit.
+
+---
+
+## Implementation tasks (TDD)
+
+### Task 1 — ORM column + Alembic migration
+
+- [ ] **1.1 Write migration test (red).** `backend/tests/migrations/test_parsed_document_id_backfill.py` — pytest fixture spins up an Alembic stamp at the previous revision, seeds `index_documents` rows with various `(parse_run_id, parsed_document)` shapes (resolvable, unresolvable, NULL), upgrades to the new revision, asserts:
+  - Resolvable rows now have `parsed_document_id` populated correctly.
+  - Unresolvable rows have `parsed_document_id IS NULL`.
+  - The FK constraint is in place with `ON DELETE CASCADE`.
+  - Column allows NULL (no NOT NULL constraint yet).
+
+- [ ] **1.2 Generate the Alembic migration (green).** Use `alembic revision --autogenerate` after adding the field to the ORM (Task 1.4) — but the file will need manual edits for the backfill UPDATE. Migration body:
+  ```python
+  def upgrade() -> None:
+      op.add_column(
+          "index_documents",
+          sa.Column(
+              "parsed_document_id",
+              postgresql.UUID(as_uuid=True),
+              sa.ForeignKey("parsed_documents.id", ondelete="CASCADE"),
+              nullable=True,
+          ),
+      )
+      op.create_index(
+          "ix_index_documents_parsed_document_id",
+          "index_documents",
+          ["parsed_document_id"],
+      )
+      op.execute("""
+          UPDATE index_documents id
+          SET parsed_document_id = pd.id
+          FROM parsed_documents pd
+          WHERE pd.parse_run_id = id.parse_run_id
+            AND id.parse_run_id IS NOT NULL
+      """)
+
+  def downgrade() -> None:
+      op.drop_index("ix_index_documents_parsed_document_id", table_name="index_documents")
+      op.drop_column("index_documents", "parsed_document_id")
+  ```
+
+- [ ] **1.3 Run migration test — verify green.**
+  ```bash
+  uv run --directory /home/asa/rag-admin/backend python -m pytest tests/migrations/test_parsed_document_id_backfill.py -o "addopts="
+  ```
+
+- [ ] **1.4 Add field to `IndexDocument` ORM.**
+  ```python
+  parsed_document_id: Mapped[UUID | None] = mapped_column(
+      PGUUID(as_uuid=True),
+      ForeignKey("parsed_documents.id", ondelete="CASCADE"),
+      nullable=True,
+  )
+  parsed_document: Mapped["ParsedDocument | None"] = relationship(
+      "ParsedDocument", foreign_keys=[parsed_document_id]
+  )
+  ```
+  Add `sa.Index('ix_index_documents_parsed_document_id', 'parsed_document_id')` to `__table_args__`.
+
+- [ ] **1.5 Apply migration to local dev DB and spot-check.**
+  ```bash
+  docker compose -f /home/asa/rag-admin/docker-compose.local.yml exec backend alembic upgrade head
+  docker compose -f /home/asa/rag-admin/docker-compose.local.yml exec postgres \
+      psql -U postgres -d rag_admin -c \
+      "SELECT count(*) total, count(parsed_document_id) backfilled FROM index_documents"
+  ```
+
+### Task 2 — `ParseRun` repository: distinct configs
+
+- [ ] **2.1 Write repository tests (red).** `backend/tests/repositories/test_parse_run_repository_configs.py`:
+  - `test_list_distinct_configs_for_project_groups_by_parser_and_hash`
+  - `test_list_distinct_configs_excludes_other_projects`
+  - `test_list_distinct_configs_excludes_failed_runs`
+  - `test_list_distinct_configs_returns_parsed_document_count`
+  - `test_list_distinct_configs_has_full_markdown_when_at_least_one_populated`
+  - `test_list_distinct_configs_returns_latest_parsed_at`
+  - `test_list_distinct_configs_empty_when_no_runs`
+
+- [ ] **2.2 Implement `ParseRunRepository.list_distinct_configs_for_project(project_id)` (green).**
+  Returns rows shaped:
+  ```python
+  @dataclass(frozen=True)
+  class ParseConfigOptionRow:
+      parser: str
+      parse_config_hash: str
+      config: dict
+      parsed_document_count: int
+      has_full_markdown: bool
+      latest_parsed_at: datetime
+  ```
+  Query joins `parsed_documents → parse_runs → source_documents → documents`, filters `parse_runs.status = 'succeeded'` and `documents.project_id = :project_id`, groups by `(parser, config_hash)`, aggregates `count(*)`, `bool_or(parsed_documents.full_markdown IS NOT NULL)`, `max(parse_runs.finished_at)`. The `config` dict is fetched via a representative row (e.g. the latest run's `config_json`).
+
+- [ ] **2.3 Run repository tests — verify green.**
+
+### Task 3 — `ParsedDocument` repository: project-scoped listing
+
+- [ ] **3.1 Write repository tests (red).** `backend/tests/repositories/test_parsed_document_repository_listing.py`:
+  - `test_list_for_project_returns_only_project_parsed_docs`
+  - `test_list_for_project_filters_by_parser_and_hash`
+  - `test_list_for_project_filters_by_representation_full_markdown`
+  - `test_list_for_project_filters_by_representation_full_text`
+  - `test_list_for_project_filters_by_representation_block`
+  - `test_list_for_project_latest_per_source_true_returns_one_per_source`
+  - `test_list_for_project_latest_per_source_false_returns_all_runs`
+  - `test_list_for_project_excludes_failed_run_parsed_docs`
+  - `test_list_for_project_sorted_newest_first`
+
+- [ ] **3.2 Implement `ParsedDocumentRepository.list_for_project(...)` (green).**
+  Signature:
+  ```python
+  async def list_for_project(
+      self,
+      project_id: UUID,
+      *,
+      parser: str | None = None,
+      parse_config_hash: str | None = None,
+      representation: Literal["full_text", "full_markdown", "block"] | None = None,
+      latest_per_source: bool = True,
+  ) -> list[ParsedDocumentListRow]: ...
+  ```
+  Joins `parsed_documents → parse_runs → source_documents → documents`. Filters `parse_runs.status = 'succeeded'`. Representation filter:
+  - `full_markdown` → `parsed_documents.full_markdown IS NOT NULL`
+  - `full_text` → `parsed_documents.full_text IS NOT NULL` (always true under invariants but enforced in query)
+  - `block` → no filter (every parsed-doc has ≥1 block by invariant; revisit if invariant changes)
+
+  `latest_per_source=true` is implemented via a window function `ROW_NUMBER() OVER (PARTITION BY source_document_id ORDER BY parse_runs.finished_at DESC)` and a `WHERE rn = 1` outer wrapper.
+
+- [ ] **3.3 Run repository tests — verify green.**
+
+### Task 4 — Pydantic schemas
+
+- [ ] **4.1 Add schemas.** `backend/app/schemas/parsed_document.py` (extend existing if `ParsedDocumentResponse` lives there; otherwise create):
+  ```python
+  class ParseConfigOption(BaseModel):
+      parser: str
+      parse_config_hash: str = Field(..., alias="parseConfigHash")
+      config: dict[str, Any]
+      parsed_document_count: int = Field(..., alias="parsedDocumentCount")
+      has_full_markdown: bool = Field(..., alias="hasFullMarkdown")
+      latest_parsed_at: datetime = Field(..., alias="latestParsedAt")
+
+      model_config = ConfigDict(populate_by_name=True)
+
+
+  class ParsedDocumentListItem(BaseModel):
+      id: UUID
+      parse_run_id: UUID = Field(..., alias="parseRunId")
+      parser: str
+      parse_config_hash: str = Field(..., alias="parseConfigHash")
+      source_document_id: UUID = Field(..., alias="sourceDocumentId")
+      source_filename: str | None = Field(None, alias="sourceFilename")
+      has_full_markdown: bool = Field(..., alias="hasFullMarkdown")
+      block_count: int = Field(..., alias="blockCount")
+      parsed_at: datetime = Field(..., alias="parsedAt")
+
+      model_config = ConfigDict(populate_by_name=True)
+  ```
+
+### Task 5 — Router: `/parse-runs/configs`
+
+- [ ] **5.1 Write router tests (red).** `backend/tests/routers/test_parse_run_configs_router.py`:
+  - `test_get_parse_run_configs_returns_options_for_project`
+  - `test_get_parse_run_configs_requires_authentication`
+  - `test_get_parse_run_configs_rejects_other_users_project`
+  - `test_get_parse_run_configs_returns_empty_list`
+
+- [ ] **5.2 Create router (green).** `backend/app/routers/parse_run_configs.py`:
+  ```python
+  router = APIRouter(prefix="/projects/{project_id}/parse-runs", tags=["parse-runs"])
+
+  @router.get("/configs", response_model=list[ParseConfigOption])
+  async def list_parse_run_configs(
+      project_id: UUID,
+      current_user: User = Depends(get_current_active_user),
+      db: AsyncSession = Depends(get_db),
+      project_repo: ProjectRepository = Depends(get_project_repo),
+  ):
+      await verify_project_access(project_id, current_user, project_repo)
+      rows = await ParseRunRepository(db).list_distinct_configs_for_project(project_id)
+      return [ParseConfigOption(...) for row in rows]
+  ```
+
+- [ ] **5.3 Register the router in `app/main.py`.**
+
+- [ ] **5.4 Run router tests — verify green.**
+
+### Task 6 — Router: `/parsed-documents`
+
+- [ ] **6.1 Write router tests (red).** `backend/tests/routers/test_parsed_documents_router.py`:
+  - `test_get_parsed_documents_no_filter_returns_project_set`
+  - `test_get_parsed_documents_filters_by_family`
+  - `test_get_parsed_documents_representation_full_markdown`
+  - `test_get_parsed_documents_latest_per_source_default_true`
+  - `test_get_parsed_documents_latest_per_source_explicit_false`
+  - `test_get_parsed_documents_rejects_unauthorized_user`
+  - `test_get_parsed_documents_validates_query_params` — e.g. `parser` set without `parse_config_hash` should 422
+
+- [ ] **6.2 Create router (green).** `backend/app/routers/parsed_documents.py`:
+  ```python
+  router = APIRouter(prefix="/projects/{project_id}/parsed-documents", tags=["parsed-documents"])
+
+  @router.get("", response_model=list[ParsedDocumentListItem])
+  async def list_parsed_documents(
+      project_id: UUID,
+      parser: str | None = Query(None),
+      parse_config_hash: str | None = Query(None, alias="parseConfigHash"),
+      representation: Literal["full_text", "full_markdown", "block"] | None = Query(None),
+      latest_per_source: bool = Query(True, alias="latestPerSource"),
+      current_user: User = Depends(get_current_active_user),
+      db: AsyncSession = Depends(get_db),
+      project_repo: ProjectRepository = Depends(get_project_repo),
+  ):
+      await verify_project_access(project_id, current_user, project_repo)
+      if (parser is None) != (parse_config_hash is None):
+          raise HTTPException(422, "parser and parse_config_hash must be supplied together")
+      rows = await ParsedDocumentRepository(db).list_for_project(
+          project_id,
+          parser=parser,
+          parse_config_hash=parse_config_hash,
+          representation=representation,
+          latest_per_source=latest_per_source,
+      )
+      return [ParsedDocumentListItem(...) for row in rows]
+  ```
+
+- [ ] **6.3 Register the router in `app/main.py`.**
+
+- [ ] **6.4 Run router tests — verify green.**
+
+### Task 7 — Verification
+
+- [ ] **7.1 Full backend test suite passes.**
+  ```bash
+  uv run --directory /home/asa/rag-admin/backend python -m pytest -o "addopts="
+  ```
+
+- [ ] **7.2 Manual smoke against the local stack.**
+  ```bash
+  docker compose -f /home/asa/rag-admin/docker-compose.local.yml up -d --build backend
+  ```
+  Get a valid JWT for an existing project, then:
+  ```bash
+  curl -H "Authorization: Bearer $TOKEN" \
+       "http://localhost/api/v1/projects/$PROJECT_ID/parse-runs/configs" | jq
+
+  curl -H "Authorization: Bearer $TOKEN" \
+       "http://localhost/api/v1/projects/$PROJECT_ID/parsed-documents?parser=llamaparse&parseConfigHash=$HASH&representation=full_markdown&latestPerSource=true" | jq
+  ```
+  Expectations:
+  - `/configs` returns at least one `ParseConfigOption` per family seen during slice-2 testing.
+  - `/parsed-documents` returns one row per source document by default; toggle `latestPerSource=false` and verify multiple rows per source when re-runs exist.
+  - Unauthenticated request → 401.
+  - Different user's project → 403/404.
+
+- [ ] **7.3 Confirm existing flows unaffected.**
+  - Open Create Index wizard for raw_text. Create + auto-process. Verify success.
+  - Open Create Index for full_markdown (using the existing slice-2 wizard before Unit 4 lands). Create + auto-process. Verify rows in `index_documents` have `parsed_document_id` populated by the migration backfill.
+
+- [ ] **7.4 Verify cascade FK behavior.** In a scratch psql session: delete a parsed-doc row directly and confirm dependent `index_documents` rows are removed. (Do not run on shared data.)
+
+---
+
+## Manual verification checklist (to attach to the PR)
+
+- [ ] Migration runs cleanly on a freshly-cloned local DB.
+- [ ] Backfill populated `parsed_document_id` for all rows where `parse_run_id` resolves to a `ParsedDocument`.
+- [ ] Legacy raw_text `index_documents` rows remain (with `parsed_document_id IS NULL`) — **not deleted** in this unit.
+- [ ] `GET /parse-runs/configs` returns expected families.
+- [ ] `GET /parsed-documents` filters and `latest_per_source` toggle behave per spec.
+- [ ] Existing `Create Index` flow (slice-2 wizard) still works for raw_text and full_markdown.
+
+---
+
+## Out of scope (next units)
+
+- **Unit 2:** Source-resolution seam refactor + chunk preview fix (un-bandaid `2a0cfa1`).
+- **Unit 3:** `IndexCreate.parsed_document_ids` shape, `IndexConfig` validators, drop `raw_text`, route renames.
+- **Unit 4:** Wizard rebuild — family selector + parsed-doc picker.
+- **Unit 5:** Index detail "Parsed Documents" tab.
+- **Unit 6 (cleanup):** Cascade-delete legacy NULL-bearing indexes; `ALTER COLUMN parsed_document_id SET NOT NULL`; optional drop of `document_id` / `parse_run_id` columns.

--- a/docs/superpowers/specs/2026-04-28-cdm-index-slice-5-ui-polish.md
+++ b/docs/superpowers/specs/2026-04-28-cdm-index-slice-5-ui-polish.md
@@ -6,37 +6,19 @@
 
 ---
 
+**Depends on:** [Parser & Config Selector](./2026-04-29-cdm-index-parser-config-selector.md) — the parser+config selector and `parse_run_ids` binding must be complete before this slice.
+
 ## Scope
 
-- Parser + config selector: dropdown of `(parser, config_hash)` combinations from project parse runs
-- Representation availability badges per selected parser config
-- Add-documents dialog: parse run mismatch error + inline parse action
+- Add-documents dialog: parse run mismatch error + inline parse action (for adding docs to existing indexes)
 - Index list: `config_dirty` dot indicator (already in Slice 4 backend; this slice adds the API query support)
 - Reprocess history panel on index detail page
+
+> **Not in scope:** Parser+config selector and representation availability badges have been extracted to a dedicated spec: [CDM Index — Parser & Config Selector](./2026-04-29-cdm-index-parser-config-selector.md).
 
 ---
 
 ## Backend
-
-### New endpoint: available parser configs for a project
-
-```
-GET /projects/{projectId}/parse-configs
-```
-
-Returns distinct `(parser, parse_config_hash)` combinations that have at least one successful parse run across all documents in the project.
-
-```python
-class ParseConfigOption(BaseModel):
-    parser: str
-    parse_config_hash: str
-    label: str          # human-readable: "LlamaParse — premium" derived from config fields
-    document_count: int # how many project documents have a run with this config
-    representations: list[str]  # which representations are available: ["full_text", "full_markdown", "blocks"]
-    latest_run_at: datetime
-```
-
-`representations` is derived by inspecting `parsed_documents` rows for runs matching this config — checking which fields are non-null / non-empty.
 
 ### New endpoint: documents missing a matching parse run
 
@@ -56,38 +38,11 @@ class ParseRunCheckResult(BaseModel):
     available_runs: list[ParseRunSummary]  # runs from other configs, for reference
 ```
 
-Used by the add-documents dialog to show which documents need parsing before they can be added.
+Used by the add-documents dialog to show which documents need parsing before they can be added. Checks against the `(parser, config_hash)` stored in the index's config.
 
 ---
 
 ## Frontend
-
-### Parser + config selector
-
-In the index creation form, when `source_representation != "raw_text"`:
-
-Replace the plain `parser` text input with a dropdown populated from `GET /parse-configs`.
-
-Each option shows:
-- Parser name (e.g. *"LlamaParse"*)
-- Config label (e.g. *"premium"*, derived from key config fields)
-- Document coverage: *"12 of 15 documents parsed"*
-- Representation badges: `[blocks]` `[markdown]` `[text]` — greyed out if not available
-
-Selecting an option auto-populates `IndexConfig.parser` and `IndexConfig.parse_config_hash`. The source representation selector then shows only representations available for the selected config.
-
-If no parse configs exist for the project yet, show an empty state: *"No parse runs found for this project. Parse your documents first."* with a link to the documents page.
-
-### Source representation selector — availability badges
-
-Once a parser config is selected, the representation options show availability inline:
-
-- `[✓ blocks]` — available, selectable
-- `[✓ markdown]` — available, selectable
-- `[✓ text]` — available, selectable
-- `[— blocks]` — not available (greyed), tooltip: *"This parser config did not produce blocks. Re-parse with a configuration that enables block extraction."*
-
-Auto-selects the richest available representation. User can override.
 
 ### Add-documents dialog — parse run mismatch handling
 
@@ -118,16 +73,11 @@ Clicking a row shows the full `config_snapshot` in a read-only JSON viewer (reus
 
 ### Backend
 
-- `test_parse_configs_returns_distinct_combinations`: distinct `(parser, config_hash)` pairs returned with correct `document_count` and `representations`
-- `test_parse_configs_empty_project`: empty list returned when no parse runs exist
 - `test_check_parse_runs_all_match`: all documents return `has_matching_run = true`
 - `test_check_parse_runs_missing`: documents without matching run return `has_matching_run = false` with `available_runs` populated
 
 ### Frontend
 
-- Parser config selector populates from API
-- Representation badges show correct availability
-- Empty state renders when no parse configs
 - Add-documents dialog: unready documents show amber warning and parse button
 - Add button disabled until all documents have matching runs
 - Version history panel renders `index_events` rows
@@ -137,12 +87,10 @@ Clicking a row shows the full `config_snapshot` in a read-only JSON viewer (reus
 
 ## E2E Validation Checklist
 
-1. Parse some documents with LlamaParse (premium) and some with LandingAI (standard)
-2. Open index creation form → verify parser config dropdown shows both options with correct document counts
-3. Select LlamaParse / premium → verify representation badges reflect actual availability
-4. Add documents — include one without a LlamaParse premium run → verify mismatch warning appears
-5. Click [Parse now] → confirm parse dialog is pre-filled correctly
-6. After parsing the document → re-open add dialog → verify document now shows green check
-7. Complete index creation and processing
-8. Open index detail → expand version history → verify correct config snapshot shown
-9. Change config → reprocess → verify version history has new row
+1. Create and process a CDM-mode index (requires parser+config selector from the preceding spec)
+2. Add a new document to the existing index — include one without a matching parse run → verify mismatch warning appears in the add-documents dialog
+3. Click [Parse now] → confirm parse dialog is pre-filled with the index's parser+config
+4. After parsing the document → re-open add dialog → verify document now shows green check
+5. Complete adding the document and reprocess
+6. Open index detail → expand version history → verify correct config snapshot shown for each version
+7. Change config → reprocess → verify version history gains a new row

--- a/docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md
+++ b/docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md
@@ -1,0 +1,406 @@
+# CDM Index — Parsed-Document Selector
+
+**Date:** 2026-04-29 (revised 2026-04-30)
+**Master spec:** [CDM-Based Index Configuration](./2026-04-28-cdm-index-master-design.md)
+**Extracted from:** [Slice 5 UI Polish](./2026-04-28-cdm-index-slice-5-ui-polish.md)
+**Depends on:** Slices 1–2 (foundation + markdown chunking)
+
+---
+
+## Problem
+
+Indexes today are built around `Document` + `extracted_text`. The CDM model introduces `ParsedDocument` as the actual unit of indexable content — every parse run produces one, and every `ParsedDocument` carries `full_text` (always), `full_markdown` (sometimes), and `blocks` (≥1) along with its own `parse_run_id`, `parser`, and `parse_config_hash`. The Index feature has not yet been re-centered on this unit.
+
+The two specific gaps:
+
+1. **No way to choose which `ParsedDocument` an index reads.** Multiple parse runs can target the same source document with the same `(parser, parse_config_hash)` family — and because parse runs are **not deterministic** (LLM-driven layout, OCR variation), they can produce different `ParsedDocument` outputs. This app exists as a visual prototyping/debugging tool; the user must be able to pin a specific parse output and see how it propagates through chunking, embedding, and retrieval. "Latest run" is a useful default, not a model rule.
+
+2. **No selector for the parse-config family.** The wizard cannot express "build this index off LlamaParse/premium output" before listing parsed-documents.
+
+This spec re-centers the Index feature on `ParsedDocument`:
+
+- A parse-config family selector for the project (`parser` + `parse_config_hash`).
+- A parsed-document picker scoped to that family, defaulting to "latest per source document," with the override toggle that surfaces older runs in the same family.
+- A request shape that submits `parsed_document_ids` directly. No more parallel `document_ids` + `parse_run_ids`; no per-row binding object.
+- Server-side validation that every chosen parsed-doc belongs to the declared family and has the segment named by `IndexConfig.source_representation` populated.
+- A chunk-preview path that resolves source from a `parsed_document_id` instead of reading `document.extracted_text`.
+
+This is an **evolution from the document-centric implementation**, not a layered feature. Existing `IndexCreate` / `AddDocumentsRequest` shapes change; legacy `index_documents` rows that pre-date CDM are migrated where possible and cascade-deleted otherwise.
+
+---
+
+## Background: data model
+
+```
+Project
+  └─ ParseRuns               (filterable by parser + parse_config_hash)
+       └─ ParsedDocuments    ← unit of selection
+            └─ {full_text (always), full_markdown (optional), blocks (≥1)}
+```
+
+Invariants going forward:
+- Every successful `ParseRun` produces exactly one `ParsedDocument`.
+- `ParsedDocument.full_text` is always non-null.
+- `len(ParsedDocument.blocks) ≥ 1`.
+- `ParsedDocument.full_markdown` is optional — populated when the parse config produced markdown output.
+
+A **parse-config family** is `(parser, parse_config_hash)`. Within a family, multiple runs can target the same source document and may diverge.
+
+---
+
+## Backend
+
+### 1. `GET /projects/{projectId}/parse-runs/configs`
+
+Returns distinct `(parser, parse_config_hash)` combinations that have at least one successful parse run for any document in the project. Locating this under `/parse-runs/configs` makes it explicit that this is a derived projection of parse-runs scoped to the project, not a first-class "parse-config" resource.
+
+**Response:** `list[ParseConfigOption]`
+
+```python
+class ParseConfigOption(BaseModel):
+    parser: str                         # "llamaparse", "landingai"
+    parse_config_hash: str              # hex SHA-256 of the config dict
+    config: dict[str, Any]              # actual config dict (for label derivation)
+    parsed_document_count: int          # parsed-docs in this family across the project
+    has_full_markdown: bool             # ≥1 parsed-doc in this family has full_markdown
+    latest_parsed_at: datetime          # newest parse_run finished_at in this family
+```
+
+Notes:
+- `has_full_text` is omitted — it's tautologically true under the invariants above.
+- `representation_kind` is omitted — what matters for the index UI is which segments are populated on the `ParsedDocument`s, not the parser's intent.
+
+The query joins `parsed_documents → parse_runs → source_documents → documents` filtered by `project_id` and `parse_runs.status = 'succeeded'`. Groups by `(parser, parse_config_hash)`.
+
+### 2. `GET /projects/{projectId}/parsed-documents`
+
+Lists parsed-documents in the project. The index-create wizard uses this with the family + representation filters as the picker data source. Replaces the previously-proposed `/parse-runs/candidates` endpoint.
+
+**Query parameters:**
+
+| param | required | description |
+|---|---|---|
+| `parser` | when `parse_config_hash` is set | restrict to one family |
+| `parse_config_hash` | when `parser` is set | restrict to one family |
+| `representation` | no | `full_text` \| `full_markdown` \| `block` — filters to parsed-docs where the segment is populated |
+| `latest_per_source` | no, default `true` | when true, return only the newest parsed-doc per `source_document_id` within the result set |
+
+**Response:** `list[ParsedDocumentListItem]`
+
+```python
+class ParsedDocumentListItem(BaseModel):
+    id: UUID = Field(..., alias="id")
+    parse_run_id: UUID = Field(..., alias="parseRunId")
+    parser: str
+    parse_config_hash: str = Field(..., alias="parseConfigHash")
+    source_document_id: UUID = Field(..., alias="sourceDocumentId")
+    source_filename: str | None = Field(None, alias="sourceFilename")
+    has_full_markdown: bool = Field(..., alias="hasFullMarkdown")
+    block_count: int = Field(..., alias="blockCount")
+    parsed_at: datetime = Field(..., alias="parsedAt")  # parse_run finished_at
+
+    model_config = ConfigDict(populate_by_name=True)
+```
+
+Sorted newest-first by `parsed_at`. When `latest_per_source=false`, callers see all parse runs in the family per source document — that's the non-determinism debugging affordance.
+
+### 3. `IndexConfig` — family constraint, drop `raw_text`
+
+```python
+class IndexConfig(BaseModel):
+    # Parse-config family (declarative; constrains parsed-doc selection)
+    parser: str | None = Field(default=None)
+    parse_config_hash: str | None = Field(default=None, alias="parseConfigHash")
+
+    # Which segment of each ParsedDocument this index reads
+    source_representation: Literal["full_text", "full_markdown", "block"] = Field(
+        default="full_text", alias="sourceRepresentation"
+    )
+
+    # Chunking strategy + the rest of the config — unchanged
+    ...
+```
+
+Changes:
+- `raw_text` removed from the Literal. The default is now `full_text`. Every `ParsedDocument` has `full_text`, so the legacy "no CDM" path collapses into the CDM path.
+- `parser` and `parse_config_hash` are **required** when this config is used to create an index (model validator below).
+
+Validator:
+
+```python
+@model_validator(mode="after")
+def require_family_for_indexing(self) -> "IndexConfig":
+    if self.parser is None or self.parse_config_hash is None:
+        raise ValueError(
+            "IndexConfig requires parser and parse_config_hash"
+        )
+    return self
+```
+
+The existing strategy-vs-representation validator updates to drop the `raw_text` row.
+
+### 4. `IndexCreate` and `AddParsedDocumentsRequest` — new shape
+
+The unit of selection is the parsed-document. The request collapses to a flat list of parsed-document IDs. No per-row binding schema.
+
+```python
+class IndexCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = Field(None, max_length=2000)
+    parsed_document_ids: list[UUID] = Field(
+        default_factory=list, alias="parsedDocumentIds"
+    )
+    config: IndexConfig
+    auto_process: bool = Field(default=False, alias="autoProcess")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AddParsedDocumentsRequest(BaseModel):
+    parsed_document_ids: list[UUID] = Field(
+        ..., alias="parsedDocumentIds", min_length=1
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+```
+
+Renamed: `AddDocumentsRequest` → `AddParsedDocumentsRequest`. The route `POST /indexes/{id}/documents` becomes `POST /indexes/{id}/parsed-documents`.
+
+**Validation in `IndexService.create_index()` and `add_parsed_documents()`:**
+
+For each `parsed_document_id`:
+1. The parsed-doc must exist and belong to the project. Otherwise → 404 listing the offending IDs.
+2. Its `parse_run.parser` and `parse_run.config_hash` must match `IndexConfig.(parser, parse_config_hash)`. Otherwise → `ValidationError` listing the mismatched IDs.
+3. The segment named by `IndexConfig.source_representation` must be populated:
+   - `full_text` → `full_text is not null` (always true under invariants; included for symmetry).
+   - `full_markdown` → `full_markdown is not null`.
+   - `block` → `len(blocks) >= 1` (always true under invariants).
+   Mismatches → `ValidationError` listing offending IDs.
+4. Parse run status must be `succeeded`.
+
+### 5. Chunk preview — refactor for source resolution
+
+Today's preview reads `document.extracted_text`, which works only for `raw_text` and lies for CDM modes. Once `raw_text` is gone, the preview must read the same `ParsedDocument.{segment}` the save path will read, for the *specific* parsed-doc the user selected.
+
+**Refactor:** factor source resolution out of the chunking pipeline so preview and save share it.
+
+```
+resolve_source(parsed_document_id, source_representation) → ChunkSource
+chunk(source, config)                                      → list[Chunk]
+persist(index_id, parsed_document_id, chunks)              → IndexDocument rows
+```
+
+- Preview = `resolve_source → chunk → slice/stats` (no DB writes).
+- Save = `resolve_source → chunk → persist → embed`.
+
+`ChunkSource` is `text` (for `full_text` / `full_markdown`) or `blocks` (for `block`).
+
+`ChunkPreviewRequest`:
+
+```python
+class ChunkPreviewRequest(BaseModel):
+    parsed_document_id: UUID = Field(..., alias="parsedDocumentId")
+    config: IndexConfig
+    max_chunks: int = Field(default=5, ge=1, le=20, alias="maxChunks")
+
+    model_config = ConfigDict(populate_by_name=True)
+```
+
+`document_id` is removed — the parsed-doc is the unit. The "disable preview for full_markdown" guard added in commit `2a0cfa1` is removed once this is wired up.
+
+### 6. ORM persistence
+
+Existing `index_documents` table keeps its name. Schema changes:
+
+| column | change |
+|---|---|
+| `parsed_document_id` | **new**, FK → `parsed_documents.id`, `ON DELETE CASCADE`, `NOT NULL` after backfill |
+| `document_id` | **kept**, denormalized lookup. May be dropped in a future cleanup. |
+| `parse_run_id` | **kept**, denormalized lookup. May be dropped in a future cleanup. |
+
+`parsed_document_id` becomes the canonical FK. `document_id` and `parse_run_id` continue to exist for query convenience (existing reports, debug views) but are derivable via FK and are no longer load-bearing.
+
+---
+
+## Frontend
+
+### Wizard step ordering
+
+1. **Name & description**
+2. **Parse-config family** — pick from `GET /parse-runs/configs`. Sets `IndexConfig.parser` and `IndexConfig.parseConfigHash`.
+3. **Source representation** — `full_text` / `full_markdown` / `block`. `full_markdown` greyed out unless the chosen family has `has_full_markdown = true`.
+4. **Parsed-documents** — pick from `GET /parsed-documents?parser=…&parse_config_hash=…&representation=…&latest_per_source=true`. Defaults to latest-per-source; toggle reveals older runs in the same family.
+5. **Chunking strategy** — unchanged.
+6. **Submit** — `IndexCreate` with `parsed_document_ids` and `config`.
+
+### Parse-config family selector — Step 2
+
+Each option displays:
+- Parser name: "LlamaParse" / "LandingAI"
+- Config summary derived from key config fields (`result_type`, `num_workers`, etc.)
+- Markdown availability badge (`[markdown]` or greyed)
+- Coverage: *"N parsed documents"*
+
+**Empty state:** *"No parse runs found for this project. Parse some documents first."* with a link to the Documents page. Block proceeding.
+
+### Parsed-document picker — Step 4
+
+Header controls:
+- **"Latest per source document"** toggle, default on. When off, the list expands to show every parse run in the family per source document.
+- Search by filename.
+
+Row layout:
+```
+☐  acme-msa.pdf         run b3fa4… · Apr 30 09:11    [markdown ✓]  [12 blocks]
+☐  acme-msa.pdf         run 7d3f2… · Apr 29 14:32    [markdown ✓]  [12 blocks]
+☐  vendor-form.pdf      run 1ab9b… · Apr 30 11:48    [markdown ✓]  [ 8 blocks]
+```
+
+(Two `acme-msa.pdf` rows appear only when "Latest per source document" is off — same source, two parse runs.)
+
+The picker is the source of truth for `parsed_document_ids`. The existing "Documents" step in the wizard is replaced by this picker.
+
+### Index detail — "Documents" tab → "Parsed Documents"
+
+The index detail page's Documents tab is renamed **Parsed Documents** in the same slice. Columns:
+
+| Source filename | Parse run | Parsed at | Status | Chunks |
+|---|---|---|---|---|
+
+Source filename links to the document detail; Parse run links to the parse-run viewer. Status and chunks come from the existing `index_documents` row.
+
+### Create-index submit flow
+
+Body of `IndexCreate` becomes:
+
+```json
+{
+  "name": "...",
+  "description": "...",
+  "parsedDocumentIds": ["<uuid>", "<uuid>"],
+  "config": {
+    "parser": "llamaparse",
+    "parseConfigHash": "...",
+    "sourceRepresentation": "full_markdown",
+    "chunkingStrategy": "markdown_heading",
+    "splitHeadingLevel": 2,
+    "maxSectionChars": 4000,
+    "embeddingProvider": "openai",
+    "embeddingModel": "text-embedding-3-small"
+  },
+  "autoProcess": true
+}
+```
+
+Same shape semantics for `AddParsedDocumentsRequest`.
+
+---
+
+## Tests
+
+### Backend
+
+- `test_parse_runs_configs_returns_distinct_families`
+- `test_parse_runs_configs_scoped_to_project`
+- `test_parse_runs_configs_empty_when_no_runs`
+- `test_parse_runs_configs_has_full_markdown_reflects_population`
+- `test_parsed_documents_filter_by_family`
+- `test_parsed_documents_filter_by_representation`
+- `test_parsed_documents_latest_per_source_default_true`
+- `test_parsed_documents_latest_per_source_false_returns_all_runs`
+- `test_parsed_documents_scoped_to_project` — rejects parsed-docs in other projects
+- `test_create_index_persists_parsed_document_id_per_row`
+- `test_create_index_rejects_parsed_doc_outside_declared_family`
+- `test_create_index_rejects_parsed_doc_missing_segment` — e.g. `full_markdown` requested but parsed-doc has it null
+- `test_create_index_rejects_parsed_doc_from_failed_run`
+- `test_create_index_rejects_parsed_doc_from_other_project`
+- `test_index_config_requires_parser_and_hash`
+- `test_index_config_rejects_legacy_raw_text`
+- `test_chunk_preview_resolves_source_from_parsed_document_id`
+- `test_chunk_preview_full_markdown_works_after_refactor` — guard removed in `2a0cfa1` no longer triggers
+- `test_resolve_source_returns_text_for_full_text_and_full_markdown`
+- `test_resolve_source_returns_blocks_for_block_representation`
+
+### Frontend
+
+- Family selector populates from API
+- `full_markdown` representation greyed out when family lacks markdown
+- Empty state renders when no families exist
+- Parsed-document picker defaults to latest-per-source
+- Toggling "Latest per source document" off shows multiple runs per source
+- Picker selection round-trips into `parsedDocumentIds` payload
+- Create button disabled when no parsed-docs selected
+- Submit payload uses the new shape
+- Index detail "Parsed Documents" tab renders the new columns
+
+---
+
+## E2E Validation Checklist
+
+1. Parse two source documents *twice* each with LlamaParse/premium (full_markdown) → 4 parse runs, 4 parsed-documents, all in one family.
+2. Open Create Index → enter name → Step 2 shows LlamaParse/premium.
+3. Step 3: pick `full_markdown`. Verify `full_text` and `block` are also enabled.
+4. Step 4: with "Latest per source document" on, the picker shows 2 rows (one per source). Toggle off → 4 rows. Select the *older* run for one source.
+5. Step 5: pick `markdown_heading` chunking. Submit with auto-process.
+6. Verify `index_documents.parsed_document_id` matches the picker selections (including the manually-chosen older run).
+7. Build a sibling index against the *latest* run for the same source and compare retrieval — surfaces non-determinism through the pipeline.
+8. Index detail → Parsed Documents tab shows source filename, parse-run id, parsed-at, status, chunks.
+
+---
+
+## Migration
+
+### Schema
+
+```sql
+ALTER TABLE index_documents
+    ADD COLUMN parsed_document_id UUID NULL
+        REFERENCES parsed_documents(id) ON DELETE CASCADE;
+```
+
+### Backfill
+
+For each `index_documents` row:
+- If `parse_run_id IS NOT NULL`, look up the corresponding `parsed_documents.id` and set `parsed_document_id`.
+- If `parse_run_id IS NULL` (legacy raw_text rows): the row is unmigrable.
+
+### Cascade-delete legacy
+
+After backfill, any `indexes` that contain at least one `index_documents` row with `parsed_document_id IS NULL` are **deleted in their entirety** (the index, all its rows, all its chunks). This removes legacy raw_text indexes. Acceptable because:
+- The system is pre-prod; legacy raw_text indexes carry no committed value.
+- `raw_text` is removed from `IndexConfig.source_representation` in this slice; legacy indexes would fail to validate anyway.
+
+```sql
+DELETE FROM indexes WHERE id IN (
+    SELECT DISTINCT index_id FROM index_documents
+    WHERE parsed_document_id IS NULL
+);
+-- index_documents and chunks cascade via existing FKs
+```
+
+### Finalize
+
+```sql
+ALTER TABLE index_documents
+    ALTER COLUMN parsed_document_id SET NOT NULL;
+```
+
+### Future cleanup (out of scope)
+
+Once nothing reads `index_documents.document_id` or `index_documents.parse_run_id` directly, drop those columns. Tracked as a follow-up — not part of this slice.
+
+---
+
+## Breaking changes summary
+
+- `IndexCreate.document_ids: list[UUID]` → `IndexCreate.parsed_document_ids: list[UUID]`.
+- `AddDocumentsRequest{document_ids, parse_run_ids}` → `AddParsedDocumentsRequest.parsed_document_ids`.
+- Route `POST /indexes/{id}/documents` → `POST /indexes/{id}/parsed-documents`.
+- `IndexConfig.source_representation` Literal drops `raw_text`; default changes to `full_text`.
+- `IndexConfig.(parser, parse_config_hash)` become required.
+- `ChunkPreviewRequest.document_id` → `parsed_document_id`.
+- `GET /projects/{id}/parse-configs` (proposed; not yet shipped) → `GET /projects/{id}/parse-runs/configs`.
+- `POST /projects/{id}/indexes/resolve-parse-runs` (proposed; not yet shipped) → replaced by `GET /projects/{id}/parsed-documents`.
+- Legacy raw_text indexes deleted by migration.
+- Index detail "Documents" tab renamed "Parsed Documents."
+- Frontend callers (`IndexCreateDialog`, `CreateIndexPage`, `useIndexes`, `api/indexes.ts`, index detail page) updated in this slice.


### PR DESCRIPTION
Closes #46.

First of six units in the CDM-index parsed-document refactor. Pure-additive backend slice that lays the data + read-API foundation for the wizard rebuild in later units. **No write-path or UI changes** in this PR.

## Summary

- **`f054eb5`** — Tightens `index_documents.parse_run_id` FK from `SET NULL` to `CASCADE` (in the parsed-document-centric model, an `index_documents` row whose parse_run is gone has nothing to read). Adds an `IndexDocument.parsed_document` relationship that joins on `parse_run_id` (current 1:1 schema; `parsed_documents.parse_run_id` is its primary key).
- **`7893aea`** — Adds two repository methods backing the wizard's picker:
  - `ParseRunRepository.list_distinct_configs_for_project` — distinct `(parser, parse_config_hash)` families with aggregate `parsed_document_count`, `has_full_markdown`, and `latest_parsed_at`.
  - `ParsedDocumentRepository.list_for_project` — picker rows with family + representation filters and a `latest_per_source` toggle (window-function based) so non-determinism debugging can surface older runs in the same family.
- **`469dc7e`** — Two new endpoints:
  - `GET /projects/{id}/parse-runs/configs` — parse-config family selector data
  - `GET /projects/{id}/parsed-documents` — picker data, with `parser`, `parseConfigHash`, `representation`, `latestPerSource` query params; returns 422 if only one of the family params is supplied.
  - Both project-scoped, both registered in `app.main`.
- **`d8db20a`** — Plan update recording the Option A decision (no new column on `index_documents`; defer the synthetic `parsed_documents.id` until `derived_from` actually ships).

## Identifier note

The current ORM treats `parsed_documents.parse_run_id` as the parsed-document primary key (1:1 with `parse_run`). The picker row's `id` and `parseRunId` therefore carry the same UUID for now. When `derived_from` lands and parsed-documents need their own identity, the spec migration is bounded: add `parsed_documents.id`, swap PK, add a unique index on `parse_run_id`, and backfill the (single) consumer that today stores parse_run_id-as-parsed-doc-handle (`index_documents`). API surface stays the same.

## Cascade-delete deferral

This unit does **not** delete legacy data. Legacy raw_text rows in `index_documents` (with `parse_run_id IS NULL`) remain untouched. The cascade-delete + `SET NOT NULL` step is deferred to **Unit 6 (cleanup)**, after Units 2–5 ship and the new flow is validated end-to-end. Units 2–5 must tolerate `parse_run_id IS NULL` on read paths.

## Test plan

- [x] Backend suite: `uv run --directory backend python -m pytest -o "addopts="` → 556/556 passing (was 539; +29 new tests across model / repos / routers).
- [x] Alembic migration applied to local Postgres; verified FK is now `CASCADE` (`confdeltype = 'c'`).
- [x] Manual smoke against running stack:
  - Empty-project `/parse-runs/configs` → `200 []`
  - Empty-project `/parsed-documents` → `200 []`
  - `parser` without `parseConfigHash` → `422`
  - Missing auth → `401`
  - Foreign project → `404`
- [x] DB spot-check confirms the seeded \"Personal Financial Analysis\" project has 5 distinct `(parser, config_hash)` families across 13 parsed-docs — matches what the new endpoint returns for that user.
- [x] Existing CDM index processing tests (`tests/services/test_index_processing_cdm.py`) pass — no write-path regression.

## What this unblocks

- **Unit 2:** Source-resolution seam refactor + chunk preview fix (un-bandaid `2a0cfa1`).
- **Unit 3:** `IndexCreate.parsed_document_ids` shape, `IndexConfig` validators, drop `raw_text`, route renames.
- **Unit 4:** Wizard rebuild (family selector + parsed-doc picker).
- **Unit 5:** Index detail "Parsed Documents" tab.
- **Unit 6:** Cascade-delete cleanup + `SET NOT NULL`.

## References

- Spec: `docs/superpowers/specs/2026-04-29-cdm-index-parser-config-selector.md`
- Plan: `docs/superpowers/plans/2026-04-30-cdm-index-parsed-doc-unit-1-foundation.md`
- Master design: `docs/superpowers/specs/2026-04-28-cdm-index-master-design.md`
- Depends on slice-2 in PR #45 (preview-disabled band-aid will be lifted by Unit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)