### PR TITLE
feat(indexes): Block chunking backend — Slice 3 (Tasks 1–9)

### DIFF
--- a/backend/app/schemas/citation.py
+++ b/backend/app/schemas/citation.py
@@ -1,0 +1,39 @@
+"""Uniform citation schema returned with every search result.
+
+Fields are populated based on the chunk's `source_type`:
+- text-based (`raw_text`, `full_text`): start_char, end_char, page_numbers
+- markdown-based (`full_markdown`): start_char, end_char, heading_path
+- block-based (`block`): block_ids, page_indices, block_roles, bboxes, confidence
+
+Block fields are resolved at query time by re-fetching the parsed document.
+If the parse run has been deleted, block fields stay null — the caller can
+detect resolution failure rather than render stale references.
+"""
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ChunkCitation(BaseModel):
+    chunk_id: UUID = Field(..., alias="chunkId")
+    document_id: UUID = Field(..., alias="documentId")
+    document_title: str = Field(..., alias="documentTitle")
+    index_id: UUID = Field(..., alias="indexId")
+    index_version: int = Field(..., alias="indexVersion")
+    parse_run_id: UUID | None = Field(None, alias="parseRunId")
+    source_type: str = Field(..., alias="sourceType")
+
+    # Text-based
+    start_char: int | None = Field(None, alias="startChar")
+    end_char: int | None = Field(None, alias="endChar")
+    page_numbers: list[int] = Field(default_factory=list, alias="pageNumbers")
+    heading_path: list[str] | None = Field(None, alias="headingPath")
+
+    # Block-based
+    block_ids: list[str] | None = Field(None, alias="blockIds")
+    page_indices: list[int] | None = Field(None, alias="pageIndices")
+    block_roles: list[str] | None = Field(None, alias="blockRoles")
+    bboxes: list[dict | None] | None = None
+    confidence: float | None = None
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/backend/app/schemas/index.py
+++ b/backend/app/schemas/index.py
@@ -49,6 +49,15 @@ class IndexConfig(BaseModel):
     split_heading_level: int = Field(default=2, ge=1, le=3, alias="splitHeadingLevel")
     max_section_chars: int = Field(default=4000, ge=500, le=16000, alias="maxSectionChars")
 
+    # Block-based config (block, classified_block)
+    group_by_heading: bool = Field(default=True, alias="groupByHeading")
+    max_blocks_per_chunk: int = Field(
+        default=10, ge=1, le=50, alias="maxBlocksPerChunk"
+    )
+    block_role_filter: list[str] | None = Field(
+        default=None, alias="blockRoleFilter"
+    )
+
     # Embedding config (unchanged)
     embedding_provider: str = Field(default="openai", alias="embeddingProvider")
     embedding_model: str = Field(default="text-embedding-3-small", alias="embeddingModel")

--- a/backend/app/schemas/query.py
+++ b/backend/app/schemas/query.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from app.schemas.citation import ChunkCitation
+
 
 class QueryRequest(BaseModel):
     """Query request matching the frontend contract."""
@@ -41,6 +43,7 @@ class RetrievalResult(BaseModel):
     score: float
     content: str
     metadata: RetrievalResultMetadata
+    citation: ChunkCitation | None = None
 
     model_config = {"populate_by_name": True}
 

--- a/backend/app/services/block_chunking_service.py
+++ b/backend/app/services/block_chunking_service.py
@@ -1,0 +1,191 @@
+"""Service for chunking a CDM ParsedDocument's blocks by semantic role.
+
+Grouping algorithm (per spec slice 3):
+
+1. Sort blocks by (page_index, bbox.y0). Blocks without a bbox sort to the
+   top of their page (y0 treated as -infinity for ordering only).
+2. Apply block_role_filter (whitelist) if set.
+3. Iterate:
+   - HEADER/FOOTER/MARGINALIA: skip entirely (layout, never content).
+   - TITLE/HEADING: closes any open group, opens a new one with this block.
+   - TABLE/FIGURE: never split. If group_by_heading and a group is open,
+     append; else close the current group and emit a single-block group.
+   - Other content roles (PARAGRAPH/LIST/CAPTION/CODE/FORMULA): append to
+     the open group; if no group is open, start one without a heading.
+4. If appending would push current group over max_blocks_per_chunk and the
+   incoming block is NOT a TABLE/FIGURE, close the group and start a new one.
+   The new group is a "continuation": its metadata records `context_heading`
+   from the most recently seen TITLE/HEADING and the chunk content is
+   prefixed with `[context: <heading>]`.
+5. Close any open group at end.
+"""
+from __future__ import annotations
+
+import tiktoken
+
+from app.cdm.models import Block, BlockRole
+from app.schemas.index import IndexConfig
+from app.services.chunking_service import ChunkResult
+
+
+_HEADING_OPENERS = {BlockRole.TITLE, BlockRole.HEADING}
+_NEVER_SPLIT = {BlockRole.TABLE, BlockRole.FIGURE}
+_LAYOUT_SKIP = {BlockRole.HEADER, BlockRole.FOOTER, BlockRole.MARGINALIA}
+
+
+class BlockChunkingService:
+    """Groups CDM blocks into chunks per the block-chunking spec."""
+
+    def __init__(self) -> None:
+        self._tokenizer = tiktoken.get_encoding("cl100k_base")
+
+    def count_tokens(self, text: str) -> int:
+        return len(self._tokenizer.encode(text))
+
+    def chunk_blocks(
+        self,
+        *,
+        blocks: list[dict],
+        config: IndexConfig,
+        source_document_id: str | None = None,
+        source_filename: str | None = None,
+    ) -> list[ChunkResult]:
+        if not blocks:
+            return []
+
+        # 1. Validate dicts → Block. Skip rows that fail validation defensively.
+        validated: list[Block] = []
+        for raw in blocks:
+            try:
+                validated.append(Block.model_validate(raw))
+            except Exception:
+                continue
+        if not validated:
+            return []
+
+        # 2. Sort by (page_index, bbox.y0). y0 missing → -inf within its page.
+        validated.sort(
+            key=lambda b: (b.page_index, b.bbox.y0 if b.bbox else float("-inf"))
+        )
+
+        # 3. Apply role filter (whitelist).
+        role_filter = (
+            {r for r in (config.block_role_filter or [])} or None
+        )
+        if role_filter is not None:
+            validated = [b for b in validated if b.role.value in role_filter]
+        if not validated:
+            return []
+
+        # 4. Iterate.
+        chunks: list[ChunkResult] = []
+        current: list[Block] = []
+        current_is_continuation = False
+        last_heading_text: str | None = None
+        chunk_index_counter = 0
+
+        def emit_current() -> None:
+            nonlocal chunk_index_counter, current, current_is_continuation
+            if not current:
+                return
+            chunks.append(
+                self._build_chunk(
+                    blocks=current,
+                    chunk_index=chunk_index_counter,
+                    context_heading=last_heading_text if current_is_continuation else None,
+                    source_document_id=source_document_id,
+                    source_filename=source_filename,
+                )
+            )
+            chunk_index_counter += 1
+            current = []
+            current_is_continuation = False
+
+        for block in validated:
+            if block.role in _LAYOUT_SKIP:
+                continue
+
+            # Heading opens a new group.
+            if block.role in _HEADING_OPENERS:
+                emit_current()
+                last_heading_text = block.text or last_heading_text
+                current.append(block)
+                continue
+
+            # Table / Figure: never split.
+            if block.role in _NEVER_SPLIT:
+                if config.group_by_heading and current:
+                    current.append(block)
+                else:
+                    emit_current()
+                    current.append(block)
+                    emit_current()
+                continue
+
+            # Generic content block.
+            if current and len(current) >= config.max_blocks_per_chunk:
+                emit_current()
+                current_is_continuation = True
+            current.append(block)
+
+        emit_current()
+        return chunks
+
+    def _build_chunk(
+        self,
+        *,
+        blocks: list[Block],
+        chunk_index: int,
+        context_heading: str | None,
+        source_document_id: str | None,
+        source_filename: str | None,
+    ) -> ChunkResult:
+        body = "\n\n".join(b.text for b in blocks if b.text)
+        if context_heading:
+            content = f"[context: {context_heading}]\n\n{body}"
+        else:
+            content = body
+
+        page_indices = sorted({b.page_index for b in blocks})
+        bboxes = [
+            (
+                {"x0": b.bbox.x0, "y0": b.bbox.y0, "x1": b.bbox.x1, "y1": b.bbox.y1}
+                if b.bbox
+                else None
+            )
+            for b in blocks
+        ]
+
+        metadata: dict = {
+            "chunk_index": chunk_index,
+            "block_ids": [b.id for b in blocks],
+            "page_indices": page_indices,
+            "block_roles": [b.role.value for b in blocks],
+            "bboxes": bboxes,
+        }
+        if context_heading:
+            metadata["context_heading"] = context_heading
+        if source_document_id:
+            metadata["source_document_id"] = source_document_id
+        if source_filename:
+            metadata["source_filename"] = source_filename
+
+        return ChunkResult(
+            content=content,
+            chunk_index=chunk_index,
+            token_count=self.count_tokens(content),
+            char_count=len(content),
+            start_char=0,
+            end_char=len(content),
+            metadata=metadata,
+        )
+
+
+_block_chunking_service: BlockChunkingService | None = None
+
+
+def get_block_chunking_service() -> BlockChunkingService:
+    global _block_chunking_service
+    if _block_chunking_service is None:
+        _block_chunking_service = BlockChunkingService()
+    return _block_chunking_service

--- a/backend/app/services/chunking_dispatcher.py
+++ b/backend/app/services/chunking_dispatcher.py
@@ -1,5 +1,9 @@
 """Dispatch a resolved ChunkSource + IndexConfig to the right chunker."""
 from app.schemas.index import IndexConfig
+from app.services.block_chunking_service import (
+    BlockChunkingService,
+    get_block_chunking_service,
+)
 from app.services.chunking_service import (
     ChunkResult,
     ChunkingService,
@@ -23,10 +27,14 @@ class ChunkingDispatcher:
         self,
         chunking_service: ChunkingService | None = None,
         markdown_chunking_service: MarkdownChunkingService | None = None,
+        block_chunking_service: BlockChunkingService | None = None,
     ) -> None:
         self.chunking_service = chunking_service or get_chunking_service()
         self.markdown_chunking_service = (
             markdown_chunking_service or get_markdown_chunking_service()
+        )
+        self.block_chunking_service = (
+            block_chunking_service or get_block_chunking_service()
         )
 
     def dispatch(
@@ -51,11 +59,18 @@ class ChunkingDispatcher:
                 config=config,
                 source_document_id=source_document_id,
                 source_filename=source_filename,
-                page_boundaries=None,  # CDM page boundaries: see Unit 6 notes
+                page_boundaries=None,
             )
         if isinstance(source, BlocksSource):
-            raise NotImplementedError(
-                "block-based chunking is not yet implemented"
+            if config.chunking_strategy == "classified_block":
+                raise NotImplementedError(
+                    "classified_block chunking requires a classification run "
+                    "and is not yet implemented"
+                )
+            return self.block_chunking_service.chunk_blocks(
+                blocks=source.blocks,
+                config=config,
+                source_document_id=source_document_id,
+                source_filename=source_filename,
             )
-        # Defensive: ChunkSource is Union[TextSource, BlocksSource]; future variant would fall here.
         raise TypeError(f"Unsupported ChunkSource type: {type(source).__name__}")

--- a/backend/app/services/query_service.py
+++ b/backend/app/services/query_service.py
@@ -6,7 +6,9 @@ from uuid import UUID
 from app.models import Chunk, IndexStatus
 from app.repositories.index_repository import IndexRepository
 from app.repositories.chunk_repository import ChunkRepository
+from app.repositories.parsed_document_repository import ParsedDocumentRepository
 from app.repositories.provider_key_repository import ProviderKeyRepository
+from app.schemas.citation import ChunkCitation
 from app.schemas.query import (
     QueryRequest,
     QueryResponse,
@@ -180,10 +182,10 @@ class QueryService:
                 similarity_threshold=request.similarity_threshold,
             )
 
-        return [
-            self._to_result(chunk, score, rank)
-            for rank, (chunk, score) in enumerate(scored_chunks, 1)
-        ]
+        results: list[RetrievalResult] = []
+        for rank, (chunk, score) in enumerate(scored_chunks, 1):
+            results.append(await self._to_result(chunk, score, rank))
+        return results
 
     async def _keyword_search(
         self, index, request: QueryRequest,
@@ -244,10 +246,10 @@ class QueryService:
                 if score >= request.similarity_threshold
             ][:request.top_k]
 
-        return [
-            self._to_result(chunk, score, rank)
-            for rank, (chunk, score) in enumerate(filtered, 1)
-        ]
+        results: list[RetrievalResult] = []
+        for rank, (chunk, score) in enumerate(filtered, 1):
+            results.append(await self._to_result(chunk, score, rank))
+        return results
 
     async def _hybrid_search(
         self, index, user_id: UUID, project_id: UUID, request: QueryRequest,
@@ -327,10 +329,10 @@ class QueryService:
                 vector_results, keyword_results, request, pool_k
             )
 
-        return [
-            self._to_result(chunk, score, rank)
-            for rank, (chunk, score) in enumerate(results, 1)
-        ]
+        out: list[RetrievalResult] = []
+        for rank, (chunk, score) in enumerate(results, 1):
+            out.append(await self._to_result(chunk, score, rank))
+        return out
 
     def _rrf_merge(
         self,
@@ -376,8 +378,7 @@ class QueryService:
     # Helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _to_result(chunk: Chunk, score: float, rank: int) -> RetrievalResult:
+    async def _to_result(self, chunk: Chunk, score: float, rank: int) -> RetrievalResult:
         """Convert a Chunk ORM object to a RetrievalResult schema."""
         doc = chunk.document
         if doc:
@@ -392,6 +393,8 @@ class QueryService:
 
         page_numbers = (chunk.chunk_metadata or {}).get("page_numbers")
         page = page_numbers[0] if page_numbers else None
+
+        citation = await self._build_citation(chunk, doc_name)
 
         return RetrievalResult(
             chunk_id=str(chunk.id),
@@ -408,4 +411,67 @@ class QueryService:
                 char_count=chunk.char_count,
                 chunk_metadata=chunk.chunk_metadata or {},
             ),
+            citation=citation,
         )
+
+    async def _build_citation(self, chunk: Chunk, document_title: str) -> ChunkCitation:
+        meta = chunk.chunk_metadata or {}
+        citation = ChunkCitation(
+            chunk_id=chunk.id,
+            document_id=chunk.document_id,
+            document_title=document_title,
+            index_id=chunk.index_id,
+            index_version=getattr(chunk, "index_version", 1),
+            parse_run_id=chunk.parse_run_id,
+            source_type=chunk.source_type,
+            start_char=meta.get("start_char"),
+            end_char=meta.get("end_char"),
+            page_numbers=meta.get("page_numbers") or [],
+            heading_path=meta.get("heading_path"),
+        )
+
+        if (
+            chunk.source_type == "block"
+            and chunk.parse_run_id is not None
+            and meta.get("block_ids")
+        ):
+            await self._resolve_block_citation(citation, chunk, meta["block_ids"])
+
+        return citation
+
+    async def _resolve_block_citation(
+        self, citation: ChunkCitation, chunk: Chunk, block_ids: list[str]
+    ) -> None:
+        repo = ParsedDocumentRepository(self.chunk_repo.session)
+        parsed_doc_row = await repo.get_by_run(chunk.parse_run_id)
+        if parsed_doc_row is None:
+            # Parse run deleted — keep block fields null so the UI can detect failure.
+            return
+        blocks_raw = (parsed_doc_row.content or {}).get("blocks") or []
+        block_map = {b.get("id"): b for b in blocks_raw if b.get("id")}
+        ordered = [block_map[bid] for bid in block_ids if bid in block_map]
+        if not ordered:
+            return
+
+        citation.block_ids = block_ids
+        citation.page_indices = sorted({b.get("page_index") for b in ordered if b.get("page_index") is not None})
+        citation.block_roles = [b.get("role") for b in ordered if b.get("role") is not None]
+        citation.bboxes = [
+            (
+                {
+                    "x0": b["bbox"]["x0"],
+                    "y0": b["bbox"]["y0"],
+                    "x1": b["bbox"]["x1"],
+                    "y1": b["bbox"]["y1"],
+                }
+                if b.get("bbox")
+                else None
+            )
+            for b in ordered
+        ]
+        confidences = [
+            b["quality"]["confidence"]
+            for b in ordered
+            if b.get("quality") and b["quality"].get("confidence") is not None
+        ]
+        citation.confidence = min(confidences) if confidences else None

--- a/backend/tests/schemas/test_index_config_schema.py
+++ b/backend/tests/schemas/test_index_config_schema.py
@@ -106,3 +106,51 @@ def test_index_config_max_section_chars_range():
             chunking_strategy="markdown_heading",
             max_section_chars=16001,
         ))
+
+
+def _block_config(**overrides):
+    base = dict(
+        parser="llamaparse",
+        parse_config_hash="h" * 64,
+        source_representation="block",
+        chunking_strategy="block",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_block_config_defaults():
+    cfg = IndexConfig(**_block_config())
+    assert cfg.group_by_heading is True
+    assert cfg.max_blocks_per_chunk == 10
+    assert cfg.block_role_filter is None
+
+
+def test_block_config_accepts_role_filter():
+    cfg = IndexConfig(**_block_config(block_role_filter=["table", "figure"]))
+    assert cfg.block_role_filter == ["table", "figure"]
+
+
+def test_max_blocks_per_chunk_below_min_rejected():
+    with pytest.raises(PydanticValidationError):
+        IndexConfig(**_block_config(max_blocks_per_chunk=0))
+
+
+def test_max_blocks_per_chunk_above_max_rejected():
+    with pytest.raises(PydanticValidationError):
+        IndexConfig(**_block_config(max_blocks_per_chunk=51))
+
+
+def test_block_role_filter_accepts_camel_case_alias():
+    cfg = IndexConfig.model_validate({
+        "parser": "llamaparse",
+        "parseConfigHash": "h" * 64,
+        "sourceRepresentation": "block",
+        "chunkingStrategy": "block",
+        "groupByHeading": False,
+        "maxBlocksPerChunk": 5,
+        "blockRoleFilter": ["paragraph"],
+    })
+    assert cfg.group_by_heading is False
+    assert cfg.max_blocks_per_chunk == 5
+    assert cfg.block_role_filter == ["paragraph"]

--- a/backend/tests/services/test_block_chunking_service.py
+++ b/backend/tests/services/test_block_chunking_service.py
@@ -55,3 +55,37 @@ def test_block_chunking_groups_by_heading():
     assert "Margins held steady." in chunks[0].content
     assert chunks[0].metadata["block_ids"] == ["b1", "b2", "b3"]
     assert chunks[0].metadata["block_roles"] == ["heading", "paragraph", "paragraph"]
+
+
+def test_block_chunking_table_not_split_when_cap_would_force_it():
+    """A TABLE block always forms (or extends) a group; max_blocks_per_chunk
+    never splits a single table off mid-table."""
+    svc = BlockChunkingService()
+    blocks = [
+        _block("h1", BlockRole.HEADING, "Section", y0=0.0).model_dump(),
+        _block("p1", BlockRole.PARAGRAPH, "Para 1", y0=0.1).model_dump(),
+        _block("p2", BlockRole.PARAGRAPH, "Para 2", y0=0.2).model_dump(),
+        _block("t1", BlockRole.TABLE, "table-text", y0=0.3).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config(max_blocks_per_chunk=3))
+
+    # Heading + 2 paragraphs hit cap, table joins via group_by_heading default.
+    # Spec: TABLE never splits. Either it appends to current open group
+    # (group_by_heading=True) or it closes and forms its own one-block group.
+    table_chunks = [c for c in chunks if "t1" in c.metadata["block_ids"]]
+    assert len(table_chunks) == 1
+    assert table_chunks[0].metadata["block_ids"].count("t1") == 1
+
+
+def test_block_chunking_table_standalone_when_no_open_group():
+    """When group_by_heading=False, TABLE blocks emit their own one-block chunk."""
+    svc = BlockChunkingService()
+    blocks = [
+        _block("t1", BlockRole.TABLE, "table-text", y0=0.0).model_dump(),
+        _block("t2", BlockRole.TABLE, "another-table", y0=0.1).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config(group_by_heading=False))
+
+    assert len(chunks) == 2
+    assert chunks[0].metadata["block_ids"] == ["t1"]
+    assert chunks[1].metadata["block_ids"] == ["t2"]

--- a/backend/tests/services/test_block_chunking_service.py
+++ b/backend/tests/services/test_block_chunking_service.py
@@ -112,3 +112,109 @@ def test_block_chunking_max_blocks_cap_emits_continuation_with_context():
     for cont in chunks[1:]:
         assert cont.metadata.get("context_heading") == "Big Section"
         assert cont.content.startswith("[context: Big Section]")
+
+
+def test_block_chunking_role_filter_applies_whitelist():
+    svc = BlockChunkingService()
+    blocks = [
+        _block("h1", BlockRole.HEADING, "H", y0=0.0).model_dump(),
+        _block("p1", BlockRole.PARAGRAPH, "para", y0=0.1).model_dump(),
+        _block("t1", BlockRole.TABLE, "tab", y0=0.2).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(
+        blocks=blocks, config=_config(block_role_filter=["table"])
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].metadata["block_ids"] == ["t1"]
+    assert chunks[0].metadata["block_roles"] == ["table"]
+
+
+def test_block_chunking_skips_layout_blocks():
+    svc = BlockChunkingService()
+    blocks = [
+        _block("hd", BlockRole.HEADER, "running header", y0=0.0).model_dump(),
+        _block("h1", BlockRole.HEADING, "Real heading", y0=0.05).model_dump(),
+        _block("p1", BlockRole.PARAGRAPH, "real para", y0=0.1).model_dump(),
+        _block("ft", BlockRole.FOOTER, "page 1 of 5", y0=0.95).model_dump(),
+        _block("mg", BlockRole.MARGINALIA, "[note]", y0=0.5).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config())
+
+    all_ids = {bid for c in chunks for bid in c.metadata["block_ids"]}
+    assert "hd" not in all_ids
+    assert "ft" not in all_ids
+    assert "mg" not in all_ids
+    assert all_ids == {"h1", "p1"}
+
+
+def test_block_chunking_layout_skipped_even_when_in_filter():
+    """Layout blocks are dropped even if explicitly listed in block_role_filter."""
+    svc = BlockChunkingService()
+    blocks = [
+        _block("hd", BlockRole.HEADER, "noise", y0=0.0).model_dump(),
+        _block("p1", BlockRole.PARAGRAPH, "real", y0=0.1).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(
+        blocks=blocks, config=_config(block_role_filter=["header", "paragraph"])
+    )
+    all_ids = {bid for c in chunks for bid in c.metadata["block_ids"]}
+    assert "hd" not in all_ids
+    assert "p1" in all_ids
+
+
+def test_block_chunking_no_headings_groups_all_content():
+    svc = BlockChunkingService()
+    blocks = [
+        _block(f"p{i}", BlockRole.PARAGRAPH, f"para {i}", y0=0.1 * i).model_dump()
+        for i in range(4)
+    ]
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config(max_blocks_per_chunk=10))
+
+    assert len(chunks) == 1
+    assert chunks[0].metadata["block_ids"] == ["p0", "p1", "p2", "p3"]
+    assert "context_heading" not in chunks[0].metadata
+
+
+def test_block_chunking_provenance_fields_populated():
+    svc = BlockChunkingService()
+    blocks = [
+        _block("h1", BlockRole.HEADING, "Heading", page=2, y0=0.0).model_dump(),
+        _block("p1", BlockRole.PARAGRAPH, "paragraph A", page=2, y0=0.1).model_dump(),
+        _block("p2", BlockRole.PARAGRAPH, "paragraph B", page=3, y0=0.0).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(
+        blocks=blocks,
+        config=_config(),
+        source_document_id="doc-1",
+        source_filename="report.pdf",
+    )
+
+    meta = chunks[0].metadata
+    assert meta["block_ids"] == ["h1", "p1", "p2"]
+    assert meta["page_indices"] == [2, 3]
+    assert meta["block_roles"] == ["heading", "paragraph", "paragraph"]
+    assert len(meta["bboxes"]) == 3
+    for bb in meta["bboxes"]:
+        assert set(bb.keys()) == {"x0", "y0", "x1", "y1"}
+    assert meta["source_document_id"] == "doc-1"
+    assert meta["source_filename"] == "report.pdf"
+
+
+def test_block_chunking_bbox_null_when_block_has_no_bbox():
+    svc = BlockChunkingService()
+    block_dict = Block(
+        id="b1",
+        role=BlockRole.PARAGRAPH,
+        native_type="p",
+        page_index=0,
+        text="no bbox",
+    ).model_dump()
+    chunks = svc.chunk_blocks(blocks=[block_dict], config=_config())
+
+    assert chunks[0].metadata["bboxes"] == [None]
+
+
+def test_block_chunking_empty_input_returns_empty():
+    svc = BlockChunkingService()
+    assert svc.chunk_blocks(blocks=[], config=_config()) == []

--- a/backend/tests/services/test_block_chunking_service.py
+++ b/backend/tests/services/test_block_chunking_service.py
@@ -1,0 +1,57 @@
+"""Tests for BlockChunkingService."""
+from app.cdm.models import BBox, Block, BlockRole, CoordSpace, Quality
+from app.schemas.index import IndexConfig
+from app.services.block_chunking_service import BlockChunkingService
+
+
+def _config(**overrides) -> IndexConfig:
+    base = dict(
+        parser="llamaparse",
+        parse_config_hash="h" * 64,
+        source_representation="block",
+        chunking_strategy="block",
+    )
+    base.update(overrides)
+    return IndexConfig(**base)
+
+
+def _bbox(y0: float = 0.0) -> BBox:
+    return BBox(x0=0.1, y0=y0, x1=0.9, y1=y0 + 0.05, space=CoordSpace.NORMALIZED)
+
+
+def _block(
+    bid: str,
+    role: BlockRole,
+    text: str,
+    page: int = 0,
+    y0: float = 0.0,
+    confidence: float | None = None,
+) -> Block:
+    quality = Quality(confidence=confidence) if confidence is not None else None
+    return Block(
+        id=bid,
+        role=role,
+        native_type=role.value,
+        page_index=page,
+        bbox=_bbox(y0),
+        text=text,
+        quality=quality,
+    )
+
+
+def test_block_chunking_groups_by_heading():
+    """A HEADING + following PARAGRAPHs form a single chunk."""
+    svc = BlockChunkingService()
+    blocks = [
+        _block("b1", BlockRole.HEADING, "Q3 Financial Results", y0=0.0).model_dump(),
+        _block("b2", BlockRole.PARAGRAPH, "Revenue grew 12%.", y0=0.1).model_dump(),
+        _block("b3", BlockRole.PARAGRAPH, "Margins held steady.", y0=0.2).model_dump(),
+    ]
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config())
+
+    assert len(chunks) == 1
+    assert "Q3 Financial Results" in chunks[0].content
+    assert "Revenue grew 12%." in chunks[0].content
+    assert "Margins held steady." in chunks[0].content
+    assert chunks[0].metadata["block_ids"] == ["b1", "b2", "b3"]
+    assert chunks[0].metadata["block_roles"] == ["heading", "paragraph", "paragraph"]

--- a/backend/tests/services/test_block_chunking_service.py
+++ b/backend/tests/services/test_block_chunking_service.py
@@ -89,3 +89,26 @@ def test_block_chunking_table_standalone_when_no_open_group():
     assert len(chunks) == 2
     assert chunks[0].metadata["block_ids"] == ["t1"]
     assert chunks[1].metadata["block_ids"] == ["t2"]
+
+
+def test_block_chunking_max_blocks_cap_emits_continuation_with_context():
+    """When a group exceeds max_blocks_per_chunk, the next chunk is a
+    continuation tagged with the most recent heading."""
+    svc = BlockChunkingService()
+    blocks = [
+        _block("h1", BlockRole.HEADING, "Big Section", y0=0.0).model_dump(),
+        *[
+            _block(f"p{i}", BlockRole.PARAGRAPH, f"para {i}", y0=0.1 + i * 0.01).model_dump()
+            for i in range(6)
+        ],
+    ]
+    # Cap at 3 → first chunk = heading + 2 paras, second = 3 paras (continuation),
+    # third = 1 para (continuation). Continuation chunks carry context_heading.
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config(max_blocks_per_chunk=3))
+
+    assert len(chunks) == 3
+    assert "context_heading" not in chunks[0].metadata
+    assert chunks[0].content.startswith("Big Section")
+    for cont in chunks[1:]:
+        assert cont.metadata.get("context_heading") == "Big Section"
+        assert cont.content.startswith("[context: Big Section]")

--- a/backend/tests/services/test_chunking_dispatcher.py
+++ b/backend/tests/services/test_chunking_dispatcher.py
@@ -62,15 +62,40 @@ def test_dispatch_text_source_passes_metadata_through():
     assert chunks[0].metadata["source_document_id"] == str(sdid)
 
 
-def test_dispatch_blocks_source_raises_not_implemented():
-    src = BlocksSource(blocks=[{"text": "foo"}])
-    with pytest.raises(NotImplementedError, match="block"):
-        ChunkingDispatcher().dispatch(
-            source=src,
-            config=_config("block", "block"),
-            source_document_id=str(uuid4()),
-            source_filename=None,
-        )
+def test_dispatch_blocks_source_routes_to_block_service():
+    from app.cdm.models import BBox, Block, BlockRole, CoordSpace
+
+    bbox = BBox(x0=0.0, y0=0.0, x1=1.0, y1=0.05, space=CoordSpace.NORMALIZED)
+    blocks = [
+        Block(
+            id="b1",
+            role=BlockRole.HEADING,
+            native_type="h1",
+            page_index=0,
+            bbox=bbox,
+            text="Heading",
+        ).model_dump(),
+        Block(
+            id="b2",
+            role=BlockRole.PARAGRAPH,
+            native_type="p",
+            page_index=0,
+            bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}),
+            text="Body paragraph",
+        ).model_dump(),
+    ]
+    src = BlocksSource(blocks=blocks)
+    chunks = ChunkingDispatcher().dispatch(
+        source=src,
+        config=_config("block", "block"),
+        source_document_id=str(uuid4()),
+        source_filename="acme.pdf",
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].metadata["block_ids"] == ["b1", "b2"]
+    assert chunks[0].metadata["page_indices"] == [0]
+    assert chunks[0].metadata["block_roles"] == ["heading", "paragraph"]
 
 
 def test_dispatch_empty_text_returns_empty_list():

--- a/backend/tests/services/test_index_processing_cdm.py
+++ b/backend/tests/services/test_index_processing_cdm.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from app.cdm.models import BBox, Block, BlockRole, CoordSpace
 from app.models import IndexStatus, IndexDocumentStatus
 from app.schemas.index import IndexConfig
 from app.services.exceptions import ValidationError
@@ -188,9 +189,11 @@ async def test_process_index_raises_not_implemented_for_unsupported_representati
         if c.args[2] == IndexDocumentStatus.failed
     ]
     assert len(failed_call) == 1
-    # ChunkingDispatcher raises NotImplementedError for block-based chunking
-    assert "not yet implemented" in failed_call[0].kwargs.get("error_message", "") or \
-           "not yet implemented" in str(failed_call[0].args)
+    # Blocks with invalid shape all fail CDM validation → chunk_blocks returns [] →
+    # processing raises "produced no chunks" (not NotImplementedError — block chunking
+    # is now implemented).
+    error_msg = failed_call[0].kwargs.get("error_message", "") or str(failed_call[0].args)
+    assert "no chunks" in error_msg.lower() or "not yet implemented" in error_msg.lower()
 
 
 @pytest.mark.asyncio
@@ -491,3 +494,87 @@ async def test_process_index_full_markdown_calls_seam(monkeypatch):
 
     # Dispatcher was called
     assert len(dispatch_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_process_index_block_source_produces_block_chunks():
+    """End-to-end: block source_representation produces chunks with block metadata."""
+    index = _make_mock_index()
+    index.config = {
+        "source_representation": "block",
+        "chunking_strategy": "block",
+        "parser": "llamaparse",
+        "parse_config_hash": "abc123",
+        "embedding_provider": "openai",
+        "embedding_model": "text-embedding-3-small",
+    }
+    parse_run_id = uuid4()
+    index_doc = _make_mock_index_doc(parse_run_id=parse_run_id)
+    index.index_documents = [index_doc]
+    index.version = 1
+
+    # Three valid CDM blocks on a single page: heading + two paragraphs.
+    # group_by_heading defaults to True and max_blocks_per_chunk defaults to 10,
+    # so all three blocks group into a single chunk.
+    bbox = BBox(x0=0.1, y0=0.0, x1=0.9, y1=0.05, space=CoordSpace.NORMALIZED)
+    blocks = [
+        Block(id="b1", role=BlockRole.HEADING, native_type="h1", page_index=0, bbox=bbox, text="Heading").model_dump(),
+        Block(id="b2", role=BlockRole.PARAGRAPH, native_type="p", page_index=0, bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}), text="para 1").model_dump(),
+        Block(id="b3", role=BlockRole.PARAGRAPH, native_type="p", page_index=0, bbox=bbox.model_copy(update={"y0": 0.2, "y1": 0.3}), text="para 2").model_dump(),
+    ]
+
+    parsed_doc = MagicMock()
+    parsed_doc.content = {"blocks": blocks}
+
+    parsed_doc_repo = AsyncMock()
+    parsed_doc_repo.get_by_run = AsyncMock(return_value=parsed_doc)
+
+    index_repo = AsyncMock()
+    index_repo.get_by_id_with_documents = AsyncMock(return_value=index)
+    index_repo.get_pending_documents = AsyncMock(return_value=[index_doc])
+    index_repo.update_document_status = AsyncMock()
+    index_repo.update_status = AsyncMock()
+    index_repo.update_stats = AsyncMock()
+    index_repo.increment_version = AsyncMock()
+    index_repo.write_index_event = AsyncMock()
+
+    chunk_repo = AsyncMock()
+    chunk_repo.create_batch = AsyncMock()
+    chunk_repo.get_stats = AsyncMock(return_value={
+        "total_chunks": 1, "total_documents": 1,
+        "avg_chunk_size_chars": 30.0, "avg_chunk_size_tokens": 6.0,
+        "min_chunk_size_chars": 30, "max_chunk_size_chars": 30,
+        "total_tokens": 6,
+    })
+
+    mock_embedding_provider = AsyncMock()
+    mock_embedding_provider.embed_texts = AsyncMock(return_value=[[0.1, 0.2]])
+    mock_embedding_provider.get_dimensions = MagicMock(return_value=2)
+
+    with patch("app.services.index_processing_service.EmbeddingProviderRegistry") as mock_reg, \
+         patch("app.services.source_resolution_service.ParsedDocumentRepository",
+               return_value=parsed_doc_repo), \
+         patch("app.services.index_processing_service.ProviderKeyService") as mock_pks:
+        mock_reg.get_provider.return_value = mock_embedding_provider
+        mock_pks.return_value.get_key_for_provider = AsyncMock(return_value="test-key")
+
+        service = IndexProcessingService(
+            session=AsyncMock(),
+            index_repo=index_repo,
+            chunk_repo=chunk_repo,
+            provider_key_repo=AsyncMock(),
+        )
+        await service.process_index(index.id, uuid4(), uuid4())
+
+    parsed_doc_repo.get_by_run.assert_called_once_with(parse_run_id)
+
+    chunk_repo.create_batch.assert_called_once()
+    created_chunks = chunk_repo.create_batch.call_args[0][0]
+    assert len(created_chunks) == 1
+
+    chunk = created_chunks[0]
+    assert chunk["source_type"] == "block"
+    assert chunk["parse_run_id"] == str(parse_run_id)
+    assert chunk["chunk_metadata"]["block_ids"] == ["b1", "b2", "b3"]
+    assert chunk["chunk_metadata"]["block_roles"] == ["heading", "paragraph", "paragraph"]
+    assert chunk["chunk_metadata"]["page_indices"] == [0]

--- a/backend/tests/services/test_query_citation.py
+++ b/backend/tests/services/test_query_citation.py
@@ -1,0 +1,145 @@
+"""Tests for ChunkCitation resolution inside QueryService._to_result."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.cdm.models import BBox, Block, BlockRole, CoordSpace, Quality
+from app.services.query_service import QueryService
+
+
+def _chunk(*, source_type: str, chunk_metadata: dict, parse_run_id=None,
+           document_title="Doc"):
+    chunk_id = uuid4()
+    document_id = uuid4()
+    index_id = uuid4()
+    return SimpleNamespace(
+        id=chunk_id,
+        document_id=document_id,
+        index_id=index_id,
+        index_version=1,
+        parse_run_id=parse_run_id,
+        source_type=source_type,
+        chunk_metadata=chunk_metadata,
+        chunk_index=0,
+        token_count=10,
+        char_count=42,
+        content="content",
+        document=SimpleNamespace(
+            title=document_title,
+            source_metadata={"filename": "doc.pdf"},
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_citation_resolution_text_chunk_populates_text_fields():
+    svc = QueryService(
+        index_repo=AsyncMock(),
+        chunk_repo=AsyncMock(),
+        provider_key_repo=AsyncMock(),
+    )
+    chunk = _chunk(
+        source_type="full_text",
+        chunk_metadata={"start_char": 100, "end_char": 250, "page_numbers": [3]},
+    )
+    result = await svc._to_result(chunk, score=0.9, rank=1)
+
+    assert result.citation is not None
+    assert result.citation.source_type == "full_text"
+    assert result.citation.start_char == 100
+    assert result.citation.end_char == 250
+    assert result.citation.page_numbers == [3]
+    assert result.citation.block_ids is None
+
+
+@pytest.mark.asyncio
+async def test_citation_resolution_markdown_chunk_populates_heading_path():
+    svc = QueryService(
+        index_repo=AsyncMock(),
+        chunk_repo=AsyncMock(),
+        provider_key_repo=AsyncMock(),
+    )
+    chunk = _chunk(
+        source_type="full_markdown",
+        chunk_metadata={
+            "start_char": 0,
+            "end_char": 100,
+            "heading_path": ["Financials", "Q3 Results"],
+        },
+    )
+    result = await svc._to_result(chunk, score=0.8, rank=1)
+
+    assert result.citation.heading_path == ["Financials", "Q3 Results"]
+
+
+@pytest.mark.asyncio
+async def test_citation_resolution_block_resolves_against_parsed_doc(monkeypatch):
+    parse_run_id = uuid4()
+    bbox = BBox(x0=0.1, y0=0.0, x1=0.9, y1=0.05, space=CoordSpace.NORMALIZED)
+    blocks = [
+        Block(
+            id="b1", role=BlockRole.HEADING, native_type="h1", page_index=2,
+            bbox=bbox, text="Heading", quality=Quality(confidence=0.95),
+        ).model_dump(),
+        Block(
+            id="b2", role=BlockRole.PARAGRAPH, native_type="p", page_index=2,
+            bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}),
+            text="body", quality=Quality(confidence=0.6),
+        ).model_dump(),
+    ]
+    parsed_doc_row = SimpleNamespace(content={"blocks": blocks})
+    repo_get = AsyncMock(return_value=parsed_doc_row)
+    monkeypatch.setattr(
+        "app.services.query_service.ParsedDocumentRepository",
+        lambda session: SimpleNamespace(get_by_run=repo_get),
+    )
+
+    svc = QueryService(
+        index_repo=AsyncMock(),
+        chunk_repo=SimpleNamespace(session=object()),
+        provider_key_repo=AsyncMock(),
+    )
+    chunk = _chunk(
+        source_type="block",
+        parse_run_id=parse_run_id,
+        chunk_metadata={"block_ids": ["b1", "b2"]},
+    )
+    result = await svc._to_result(chunk, score=0.7, rank=1)
+
+    cit = result.citation
+    assert cit.block_ids == ["b1", "b2"]
+    assert cit.page_indices == [2]
+    assert cit.block_roles == ["heading", "paragraph"]
+    assert len(cit.bboxes) == 2
+    assert cit.confidence == pytest.approx(0.6)
+    repo_get.assert_awaited_once_with(parse_run_id)
+
+
+@pytest.mark.asyncio
+async def test_citation_resolution_block_missing_parse_run_degrades_gracefully(monkeypatch):
+    repo_get = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "app.services.query_service.ParsedDocumentRepository",
+        lambda session: SimpleNamespace(get_by_run=repo_get),
+    )
+
+    svc = QueryService(
+        index_repo=AsyncMock(),
+        chunk_repo=SimpleNamespace(session=object()),
+        provider_key_repo=AsyncMock(),
+    )
+    chunk = _chunk(
+        source_type="block",
+        parse_run_id=uuid4(),
+        chunk_metadata={"block_ids": ["x"]},
+    )
+    result = await svc._to_result(chunk, score=0.5, rank=1)
+
+    cit = result.citation
+    assert cit.block_ids is None
+    assert cit.bboxes is None
+    assert cit.confidence is None
+    assert cit.source_type == "block"


### PR DESCRIPTION
Closes #53 (partial — backend only; frontend in a follow-up PR)

## Summary

- Extends `IndexConfig` with three block-chunking fields (`group_by_heading`, `max_blocks_per_chunk`, `block_role_filter`)
- Adds `BlockChunkingService` implementing the full spec algorithm (layout skip, heading grouping, TABLE/FIGURE never-split, continuation context, role whitelist)
- Wires `BlocksSource` into `ChunkingDispatcher` (replaces `NotImplementedError`)
- Adds `ChunkCitation` Pydantic schema; attaches `citation` field to `RetrievalResult`
- Makes `QueryService._to_result` async; builds `ChunkCitation` for all source types; resolves block citations from `ParsedDocument` with graceful degradation when parse run is deleted

## Commits

```
f2cbe7a feat(indexes): add block-config fields to IndexConfig
9ae11bb feat(indexes): add BlockChunkingService skeleton with heading-grouping happy path
2abac33 test(indexes): cover TABLE/FIGURE never-split in BlockChunkingService
9c8c24d test(indexes): cover max-blocks cap with context-heading continuation
8ab9afb test(indexes): cover role filter, layout skip, no-headings, provenance
69af036 feat(indexes): route BlocksSource to BlockChunkingService in dispatcher
b9034e9 test(indexes): end-to-end block-source processing through pipeline
5f8ba33 feat(indexes): add ChunkCitation schema and attach to RetrievalResult
07904e2 feat(query): build ChunkCitation per result; resolve block citations from ParsedDocument
```

## Test plan

- [ ] `uv run --directory backend python -m pytest -o "addopts=" tests/schemas/test_index_config_schema.py -v` — 15 pass (5 new block-config tests)
- [ ] `uv run --directory backend python -m pytest -o "addopts=" tests/services/test_block_chunking_service.py -v` — 11 pass (full algorithm coverage)
- [ ] `uv run --directory backend python -m pytest -o "addopts=" tests/services/test_chunking_dispatcher.py -v` — all pass (BlocksSource routing)
- [ ] `uv run --directory backend python -m pytest -o "addopts=" tests/services/test_index_processing_cdm.py -v` — 8 pass (including new block E2E test)
- [ ] `uv run --directory backend python -m pytest -o "addopts=" tests/services/test_query_citation.py -v` — 4 pass (citation resolution for text/markdown/block/degraded)
- [ ] Full suite: `uv run --directory backend python -m pytest -o "addopts=" tests/services/ -v` — 222 pass, 0 failures

## Spec ref

`docs/superpowers/plans/2026-05-01-cdm-index-slice-3-block-chunking.md` — Tasks 1–9

🤖 Generated with [Claude Code](https://claude.com/claude-code)