### PR TITLE
feat: document classification workload

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_classification_tables.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_classification_tables.py
@@ -1,0 +1,74 @@
+"""add classification tables
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9a8b7c6d5e4f
+Create Date: 2026-05-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "9a8b7c6d5e4f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "classification_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("parse_run_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("parse_runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("document_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("documents.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("labels_requested", postgresql.JSONB(), nullable=False),
+        sa.Column("llm_provider", sa.Text(), nullable=False),
+        sa.Column("llm_model", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("batch_size", sa.Integer(), nullable=False, server_default="10"),
+        sa.Column("batch_overlap", sa.Integer(), nullable=False, server_default="3"),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+    )
+    op.create_index("ix_classification_runs_parse_run_id", "classification_runs", ["parse_run_id"])
+    op.create_index("ix_classification_runs_document_id", "classification_runs", ["document_id"])
+    op.create_index("ix_classification_runs_status", "classification_runs", ["status"])
+
+    op.create_table(
+        "classification_regions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("classification_runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("label", sa.Text(), nullable=False),
+        sa.Column("page_start", sa.Integer(), nullable=False),
+        sa.Column("page_end", sa.Integer(), nullable=False),
+        sa.Column("block_ids", postgresql.JSONB(), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("reasoning", sa.Text(), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False, server_default="llm"),
+    )
+    op.create_index("ix_classification_regions_run_id", "classification_regions", ["run_id"])
+    op.create_index("ix_classification_regions_label", "classification_regions", ["label"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_classification_regions_label", table_name="classification_regions")
+    op.drop_index("ix_classification_regions_run_id", table_name="classification_regions")
+    op.drop_table("classification_regions")
+
+    op.drop_index("ix_classification_runs_status", table_name="classification_runs")
+    op.drop_index("ix_classification_runs_document_id", table_name="classification_runs")
+    op.drop_index("ix_classification_runs_parse_run_id", table_name="classification_runs")
+    op.drop_table("classification_runs")

--- a/backend/alembic/versions/b2c3d4e5f6a1_add_classification_tables.py
+++ b/backend/alembic/versions/b2c3d4e5f6a1_add_classification_tables.py
@@ -1,6 +1,6 @@
 """add classification tables
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: b2c3d4e5f6a1
 Revises: 9a8b7c6d5e4f
 Create Date: 2026-05-05 00:00:00.000000
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "a1b2c3d4e5f6"
+revision: str = "b2c3d4e5f6a1"
 down_revision: Union[str, None] = "9a8b7c6d5e4f"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/app/cdm/classification.py
+++ b/backend/app/cdm/classification.py
@@ -1,0 +1,24 @@
+"""Classification types for the Common Data Model."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Literal, Optional
+
+from app.cdm.models import _Frozen
+
+
+class ClassifiedRegion(_Frozen):
+    label: str
+    page_start: int
+    page_end: int
+    block_ids: List[str]
+    confidence: Optional[float] = None
+    reasoning: Optional[str] = None
+    source: Literal["llm", "human"] = "llm"
+
+
+class ClassificationRunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"

--- a/backend/app/cdm/workloads.py
+++ b/backend/app/cdm/workloads.py
@@ -5,6 +5,10 @@ from app.cdm.models import ParsedDocument
 
 def slice_doc(doc: ParsedDocument, region: ClassifiedRegion) -> ParsedDocument:
     """Return a derived sub-ParsedDocument containing only region pages."""
+    if region.page_end < region.page_start:
+        raise ValueError(
+            f"page_end ({region.page_end}) must be >= page_start ({region.page_start})"
+        )
     page_set = set(range(region.page_start, region.page_end + 1))
     pages = [p for p in doc.pages if p.index in page_set]
     blocks = [b for b in doc.blocks if b.page_index in page_set]

--- a/backend/app/cdm/workloads.py
+++ b/backend/app/cdm/workloads.py
@@ -1,0 +1,17 @@
+"""Workload functions for document processing."""
+from app.cdm.classification import ClassifiedRegion
+from app.cdm.models import ParsedDocument
+
+
+def slice_doc(doc: ParsedDocument, region: ClassifiedRegion) -> ParsedDocument:
+    """Return a derived sub-ParsedDocument containing only region pages."""
+    page_set = set(range(region.page_start, region.page_end + 1))
+    pages = [p for p in doc.pages if p.index in page_set]
+    blocks = [b for b in doc.blocks if b.page_index in page_set]
+    return doc.model_copy(update={
+        "pages": pages,
+        "blocks": blocks,
+        "page_count": len(pages),
+        "derived_from": doc.id,
+        "derivation": f"slice:{region.label}:pages {region.page_start}-{region.page_end}",
+    })

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,6 +44,21 @@ class Settings(BaseSettings):
     MAX_UPLOAD_SIZE_MB: int = 25
     ALLOWED_MIME_TYPES: list[str] = ["application/pdf", "image/jpeg", "image/png"]
 
+    # Classification LLM defaults
+    CLASSIFIER_LLM_PROVIDER: str = "ollama_local"
+    CLASSIFIER_LLM_MODEL: str = "qwen2.5:7b"
+
+    # Ollama — local instance
+    OLLAMA_LOCAL_BASE_URL: str = "http://localhost:11434/v1"
+
+    # Ollama — cloud instance (https://ollama.com)
+    # Leave OLLAMA_CLOUD_API_KEY empty to disable the ollama_cloud provider.
+    OLLAMA_CLOUD_BASE_URL: str = "https://ollama.com/v1"
+    OLLAMA_CLOUD_API_KEY: str = ""
+
+    # Groq hosted inference
+    GROQ_API_KEY: str = ""
+
     # LlamaParse / LlamaCloud
     LLAMA_CLOUD_KEY: str = ""
 

--- a/backend/app/dependencies/llm.py
+++ b/backend/app/dependencies/llm.py
@@ -1,0 +1,34 @@
+# backend/app/dependencies/llm.py
+from functools import lru_cache
+
+from app.config import settings
+from app.services.llm.ollama_adapter import OllamaAdapter
+from app.services.llm.groq_adapter import GroqAdapter
+from app.services.llm.registry import LLMRegistry
+
+
+@lru_cache(maxsize=1)
+def get_llm_registry() -> LLMRegistry:
+    """Build and cache the LLM adapter registry from env config.
+
+    Provider names are the routing keys clients pass in requests:
+      ollama_local  — local Ollama instance (always registered)
+      ollama_cloud  — Ollama Cloud (registered only if OLLAMA_CLOUD_API_KEY is set)
+      groq          — Groq hosted inference (registered only if GROQ_API_KEY is set)
+    """
+    registry = LLMRegistry()
+    registry.register(
+        "ollama_local",
+        OllamaAdapter(base_url=settings.OLLAMA_LOCAL_BASE_URL, api_key="ollama"),
+    )
+    if settings.OLLAMA_CLOUD_API_KEY:
+        registry.register(
+            "ollama_cloud",
+            OllamaAdapter(
+                base_url=settings.OLLAMA_CLOUD_BASE_URL,
+                api_key=settings.OLLAMA_CLOUD_API_KEY,
+            ),
+        )
+    if settings.GROQ_API_KEY:
+        registry.register("groq", GroqAdapter(api_key=settings.GROQ_API_KEY))
+    return registry

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.config import settings
-from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_runs, parse_run_configs, parsed_documents, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings
+from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_runs, parse_run_configs, parsed_documents, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings, classification
 from app.utils.oauth import setup_oauth
 
 # Import database engine for SQLAlchemy instrumentation
@@ -170,3 +170,5 @@ app.include_router(extraction_eval.router, prefix="/api/v1")
 app.include_router(agent.router, prefix="/api/v1")
 app.include_router(data_stores.router, prefix="/api/v1")
 app.include_router(export_mappings.router, prefix="/api/v1")
+app.include_router(classification.documents_router, prefix="/api/v1")
+app.include_router(classification.runs_router, prefix="/api/v1")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -25,6 +25,8 @@ from app.models.source_document import SourceDocument
 from app.models.parse_run import ParseRun
 from app.models.parsed_document import ParsedDocument
 from app.models.index_event import IndexEvent
+from app.models.classification_run import ClassificationRun
+from app.models.classification_region import ClassificationRegion
 
 __all__ = [
     "User",
@@ -70,4 +72,6 @@ __all__ = [
     "ParseRun",
     "ParsedDocument",
     "IndexEvent",
+    "ClassificationRun",
+    "ClassificationRegion",
 ]

--- a/backend/app/models/classification_region.py
+++ b/backend/app/models/classification_region.py
@@ -1,0 +1,35 @@
+# backend/app/models/classification_region.py
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import Float, ForeignKey, Integer, JSON, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ClassificationRegion(Base):
+    __tablename__ = "classification_regions"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    run_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("classification_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    label: Mapped[str] = mapped_column(Text, nullable=False)
+    page_start: Mapped[int] = mapped_column(Integer, nullable=False)
+    page_end: Mapped[int] = mapped_column(Integer, nullable=False)
+    block_ids: Mapped[list] = mapped_column(JSON, nullable=False)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source: Mapped[str] = mapped_column(Text, nullable=False, default="llm")
+
+    __table_args__ = (
+        sa.Index("ix_classification_regions_run_id", "run_id"),
+        sa.Index("ix_classification_regions_label", "label"),
+    )

--- a/backend/app/models/classification_run.py
+++ b/backend/app/models/classification_run.py
@@ -1,0 +1,51 @@
+# backend/app/models/classification_run.py
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ClassificationRun(Base):
+    __tablename__ = "classification_runs"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    parse_run_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("parse_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    document_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    labels_requested: Mapped[list] = mapped_column(JSON, nullable=False)
+    llm_provider: Mapped[str] = mapped_column(Text, nullable=False)
+    llm_model: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    batch_size: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
+    batch_overlap: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+        default=datetime.utcnow, server_default=sa.text("NOW()"),
+    )
+
+    __table_args__ = (
+        sa.Index("ix_classification_runs_parse_run_id", "parse_run_id"),
+        sa.Index("ix_classification_runs_document_id", "document_id"),
+        sa.Index("ix_classification_runs_status", "status"),
+    )

--- a/backend/app/repositories/classification_run_repository.py
+++ b/backend/app/repositories/classification_run_repository.py
@@ -1,0 +1,128 @@
+# backend/app/repositories/classification_run_repository.py
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cdm.classification import ClassifiedRegion
+from app.models.classification_region import ClassificationRegion as ClassificationRegionORM
+from app.models.classification_run import ClassificationRun as ClassificationRunORM
+
+
+@dataclass
+class ClassificationRunCreate:
+    parse_run_id: UUID
+    document_id: UUID
+    labels_requested: list[str]
+    llm_provider: str
+    llm_model: str
+    batch_size: int
+    batch_overlap: int
+
+
+class ClassificationRunRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, data: ClassificationRunCreate) -> ClassificationRunORM:
+        run = ClassificationRunORM(
+            parse_run_id=data.parse_run_id,
+            document_id=data.document_id,
+            labels_requested=data.labels_requested,
+            llm_provider=data.llm_provider,
+            llm_model=data.llm_model,
+            batch_size=data.batch_size,
+            batch_overlap=data.batch_overlap,
+            status="pending",
+        )
+        self.session.add(run)
+        await self.session.commit()
+        await self.session.refresh(run)
+        return run
+
+    async def get(self, run_id: UUID) -> ClassificationRunORM | None:
+        result = await self.session.execute(
+            select(ClassificationRunORM).where(ClassificationRunORM.id == run_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_for_document(self, document_id: UUID) -> list[ClassificationRunORM]:
+        result = await self.session.execute(
+            select(ClassificationRunORM)
+            .where(ClassificationRunORM.document_id == document_id)
+            .order_by(ClassificationRunORM.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def list_for_project(self, project_id: UUID) -> list[ClassificationRunORM]:
+        from app.models.document import Document as DocumentORM
+        result = await self.session.execute(
+            select(ClassificationRunORM)
+            .join(DocumentORM, ClassificationRunORM.document_id == DocumentORM.id)
+            .where(DocumentORM.project_id == project_id)
+            .order_by(ClassificationRunORM.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def update_status(
+        self,
+        run_id: UUID,
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        run = await self.get(run_id)
+        if run is None:
+            return
+        run.status = status
+        if error is not None:
+            run.error = error
+        if status == "running":
+            run.started_at = datetime.now(timezone.utc)
+        await self.session.commit()
+
+    async def update_completed(
+        self,
+        run_id: UUID,
+        input_tokens: int,
+        output_tokens: int,
+        duration_ms: int,
+    ) -> None:
+        run = await self.get(run_id)
+        if run is None:
+            return
+        run.status = "completed"
+        run.input_tokens = input_tokens
+        run.output_tokens = output_tokens
+        run.duration_ms = duration_ms
+        run.finished_at = datetime.now(timezone.utc)
+        await self.session.commit()
+
+    async def get_regions(self, run_id: UUID) -> list[ClassificationRegionORM]:
+        result = await self.session.execute(
+            select(ClassificationRegionORM)
+            .where(ClassificationRegionORM.run_id == run_id)
+            .order_by(ClassificationRegionORM.label, ClassificationRegionORM.page_start)
+        )
+        return list(result.scalars().all())
+
+    async def save_regions(self, run_id: UUID, regions: list[ClassifiedRegion]) -> None:
+        for region in regions:
+            self.session.add(ClassificationRegionORM(
+                run_id=run_id,
+                label=region.label,
+                page_start=region.page_start,
+                page_end=region.page_end,
+                block_ids=region.block_ids,
+                confidence=region.confidence,
+                reasoning=region.reasoning,
+                source=region.source,
+            ))
+        await self.session.commit()
+
+    async def delete(self, run_id: UUID) -> None:
+        run = await self.get(run_id)
+        if run is not None:
+            await self.session.delete(run)
+            await self.session.commit()

--- a/backend/app/routers/classification.py
+++ b/backend/app/routers/classification.py
@@ -1,0 +1,204 @@
+"""Classification API — two routers mounted at different prefixes in main.py."""
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import AsyncSessionLocal, get_db
+from app.dependencies.auth import get_current_active_user
+from app.dependencies.llm import get_llm_registry
+from app.models import User
+from app.repositories.classification_run_repository import (
+    ClassificationRunCreate,
+    ClassificationRunRepository,
+)
+from app.repositories.parsed_document_repository import ParsedDocumentRepository
+from app.repositories.document_repository import DocumentRepository
+from app.schemas.classification import (
+    ClassificationRegionResponse,
+    ClassificationRunCreateRequest,
+    ClassificationRunResponse,
+)
+from app.services.classification.service import ClassificationService
+from app.services.llm.registry import LLMRegistry
+
+logger = logging.getLogger(__name__)
+
+# Mounted at /api/v1/documents
+documents_router = APIRouter(prefix="/documents", tags=["classification"])
+
+# Mounted at /api/v1/classification-runs
+runs_router = APIRouter(prefix="/classification-runs", tags=["classification"])
+
+
+async def _run_classification_background(
+    run_id: UUID,
+    parse_run_id: UUID,
+    labels: list[str],
+    llm_provider: str,
+    llm_model: str,
+    batch_size: int,
+    batch_overlap: int,
+) -> None:
+    from app.cdm.models import ParsedDocument as CDMParsedDocument
+
+    async with AsyncSessionLocal() as session:
+        repo = ClassificationRunRepository(session)
+        pd_repo = ParsedDocumentRepository(session)
+
+        pd_orm = await pd_repo.get_by_run(parse_run_id)
+        if pd_orm is None:
+            await repo.update_status(run_id=run_id, status="failed", error="ParsedDocument not found")
+            return
+
+        doc = CDMParsedDocument.model_validate(pd_orm.content)
+        registry = get_llm_registry()
+        service = ClassificationService(repo=repo, llm_registry=registry)
+
+        await service.execute(
+            run_id=run_id,
+            doc=doc,
+            labels=labels,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            batch_size=batch_size,
+            batch_overlap=batch_overlap,
+        )
+
+
+def _to_run_response(run, regions=None) -> ClassificationRunResponse:
+    return ClassificationRunResponse(
+        id=run.id,
+        parseRunId=run.parse_run_id,
+        documentId=run.document_id,
+        labelsRequested=run.labels_requested,
+        llmProvider=run.llm_provider,
+        llmModel=run.llm_model,
+        status=run.status,
+        error=run.error,
+        batchSize=run.batch_size,
+        batchOverlap=run.batch_overlap,
+        inputTokens=run.input_tokens,
+        outputTokens=run.output_tokens,
+        durationMs=run.duration_ms,
+        createdAt=run.created_at,
+        regions=[
+            ClassificationRegionResponse(
+                id=r.id,
+                label=r.label,
+                pageStart=r.page_start,
+                pageEnd=r.page_end,
+                blockIds=r.block_ids,
+                confidence=r.confidence,
+                reasoning=r.reasoning,
+                source=r.source,
+            )
+            for r in (regions or [])
+        ],
+    )
+
+
+@documents_router.post(
+    "/{document_id}/classification-runs",
+    response_model=ClassificationRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_classification_run(
+    document_id: UUID,
+    body: ClassificationRunCreateRequest,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    doc_repo = DocumentRepository(db)
+    document = await doc_repo.get_by_id(document_id, current_user.id)
+    if document is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    llm_provider = body.llm_provider or settings.CLASSIFIER_LLM_PROVIDER
+    llm_model = body.llm_model or settings.CLASSIFIER_LLM_MODEL
+    batch_size = body.batch_size or 10
+    batch_overlap = body.batch_overlap or 3
+
+    repo = ClassificationRunRepository(db)
+    run = await repo.create(ClassificationRunCreate(
+        parse_run_id=body.parse_run_id,
+        document_id=document_id,
+        labels_requested=body.labels,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+        batch_size=batch_size,
+        batch_overlap=batch_overlap,
+    ))
+
+    background_tasks.add_task(
+        _run_classification_background,
+        run_id=run.id,
+        parse_run_id=body.parse_run_id,
+        labels=body.labels,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+        batch_size=batch_size,
+        batch_overlap=batch_overlap,
+    )
+
+    return _to_run_response(run)
+
+
+@documents_router.get(
+    "/{document_id}/classification-runs",
+    response_model=list[ClassificationRunResponse],
+)
+async def list_document_classification_runs(
+    document_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    doc_repo = DocumentRepository(db)
+    document = await doc_repo.get_by_id(document_id, current_user.id)
+    if document is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    repo = ClassificationRunRepository(db)
+    runs = await repo.list_for_document(document_id)
+    return [_to_run_response(r) for r in runs]
+
+
+@runs_router.get("", response_model=list[ClassificationRunResponse])
+async def list_all_classification_runs(
+    project_id: UUID = Query(...),
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    repo = ClassificationRunRepository(db)
+    runs = await repo.list_for_project(project_id)
+    return [_to_run_response(r) for r in runs]
+
+
+@runs_router.get("/{run_id}", response_model=ClassificationRunResponse)
+async def get_classification_run(
+    run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    repo = ClassificationRunRepository(db)
+    run = await repo.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Classification run not found")
+    regions = await repo.get_regions(run_id)
+    return _to_run_response(run, regions)
+
+
+@runs_router.delete("/{run_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_classification_run(
+    run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    repo = ClassificationRunRepository(db)
+    run = await repo.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Classification run not found")
+    await repo.delete(run_id)

--- a/backend/app/schemas/classification.py
+++ b/backend/app/schemas/classification.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ClassificationRunCreateRequest(BaseModel):
+    parse_run_id: UUID
+    labels: list[str]
+    llm_provider: str | None = None
+    llm_model: str | None = None
+    batch_size: int | None = None
+    batch_overlap: int | None = None
+
+
+class ClassificationRegionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: UUID
+    label: str
+    page_start: int = Field(..., alias="pageStart")
+    page_end: int = Field(..., alias="pageEnd")
+    block_ids: list[str] = Field(..., alias="blockIds")
+    confidence: float | None = None
+    reasoning: str | None = None
+    source: str
+
+
+class ClassificationRunResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: UUID
+    parse_run_id: UUID = Field(..., alias="parseRunId")
+    document_id: UUID = Field(..., alias="documentId")
+    labels_requested: list[str] = Field(..., alias="labelsRequested")
+    llm_provider: str = Field(..., alias="llmProvider")
+    llm_model: str = Field(..., alias="llmModel")
+    status: str
+    error: str | None = None
+    batch_size: int = Field(..., alias="batchSize")
+    batch_overlap: int = Field(..., alias="batchOverlap")
+    input_tokens: int | None = Field(None, alias="inputTokens")
+    output_tokens: int | None = Field(None, alias="outputTokens")
+    duration_ms: int | None = Field(None, alias="durationMs")
+    created_at: datetime = Field(..., alias="createdAt")
+    regions: list[ClassificationRegionResponse] = []

--- a/backend/app/services/classification/assembler.py
+++ b/backend/app/services/classification/assembler.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from app.cdm.classification import ClassifiedRegion
+from app.cdm.models import ParsedDocument
+
+
+@dataclass
+class BatchPageResult:
+    page: int
+    label_statuses: Dict[str, str]  # label -> "start"|"continue"|"none"
+    batch_start: int
+    batch_end: int
+
+
+def resolve_page_statuses(
+    batch_results: List[List[BatchPageResult]],
+) -> Dict[int, Dict[str, str]]:
+    """For overlapping pages, prefer results from the middle 50% of each batch window."""
+    best: Dict[int, tuple[int, Dict[str, str]]] = {}
+
+    for batch_pages in batch_results:
+        if not batch_pages:
+            continue
+        batch_start = batch_pages[0].batch_start
+        batch_end = batch_pages[0].batch_end
+        batch_len = batch_end - batch_start + 1
+        quarter = max(1, batch_len // 4)
+
+        for page_result in batch_pages:
+            page = page_result.page
+            in_middle = page < batch_end - quarter
+            priority = 0 if in_middle else 1
+            if page not in best or priority < best[page][0]:
+                best[page] = (priority, page_result.label_statuses)
+
+    return {page: statuses for page, (_, statuses) in best.items()}
+
+
+def assemble_regions(
+    resolved: Dict[int, Dict[str, str]],
+    labels: List[str],
+    doc: ParsedDocument,
+) -> List[ClassifiedRegion]:
+    """Walk sorted pages per label and build ClassifiedRegion objects."""
+    regions: List[ClassifiedRegion] = []
+
+    for label in labels:
+        current_start: Optional[int] = None
+        current_end: Optional[int] = None
+
+        for page in sorted(resolved.keys()):
+            status = resolved[page].get(label, "none")
+
+            if status == "start":
+                if current_start is not None:
+                    regions.append(_make_region(label, current_start, current_end, doc))
+                current_start = page
+                current_end = page
+            elif status == "continue" and current_start is not None:
+                current_end = page
+            elif status == "none" and current_start is not None:
+                regions.append(_make_region(label, current_start, current_end, doc))
+                current_start = None
+                current_end = None
+
+        if current_start is not None:
+            regions.append(_make_region(label, current_start, current_end, doc))
+
+    return regions
+
+
+def _make_region(
+    label: str,
+    page_start: int,
+    page_end: int,
+    doc: ParsedDocument,
+) -> ClassifiedRegion:
+    block_ids = [
+        b.id
+        for b in sorted(
+            (b for b in doc.blocks if page_start <= b.page_index <= page_end),
+            key=lambda b: (b.page_index, b.reading_order or 0),
+        )
+    ]
+    return ClassifiedRegion(
+        label=label,
+        page_start=page_start,
+        page_end=page_end,
+        block_ids=block_ids,
+    )

--- a/backend/app/services/classification/assembler.py
+++ b/backend/app/services/classification/assembler.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from app.cdm.classification import ClassifiedRegion
 from app.cdm.models import ParsedDocument
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -30,7 +33,7 @@ def resolve_page_statuses(
 
         for page_result in batch_pages:
             page = page_result.page
-            in_middle = page < batch_end - quarter
+            in_middle = (batch_start + quarter) <= page < (batch_end - quarter)
             priority = 0 if in_middle else 1
             if page not in best or priority < best[page][0]:
                 best[page] = (priority, page_result.label_statuses)
@@ -60,6 +63,11 @@ def assemble_regions(
                 current_end = page
             elif status == "continue" and current_start is not None:
                 current_end = page
+            elif status == "continue" and current_start is None:
+                logger.warning(
+                    "Ignoring 'continue' status for label %r on page %d: no preceding 'start'",
+                    label, page,
+                )
             elif status == "none" and current_start is not None:
                 regions.append(_make_region(label, current_start, current_end, doc))
                 current_start = None

--- a/backend/app/services/classification/serializer.py
+++ b/backend/app/services/classification/serializer.py
@@ -1,0 +1,33 @@
+from app.cdm.models import ParsedDocument
+
+
+def serialize_pages(doc: ParsedDocument, page_start: int, page_end: int) -> str:
+    """Serialize blocks for pages [page_start, page_end] inclusive as compact text."""
+    lines = []
+    for block in doc.blocks:
+        if block.page_index < page_start or block.page_index > page_end:
+            continue
+        content = block.markdown if block.markdown else block.text
+        if not content.strip():
+            continue
+        lines.append(f"[page {block.page_index}, {block.role.value}] {content}")
+    return "\n".join(lines)
+
+
+def build_batches(page_count: int, batch_size: int, overlap: int) -> list[tuple[int, int]]:
+    """Return (start, end) page ranges for each batch with given overlap.
+
+    Example: page_count=25, batch_size=10, overlap=3 →
+        [(0,9), (7,16), (14,23), (21,24)]
+    """
+    if page_count == 0:
+        return []
+    batches = []
+    start = 0
+    while True:
+        end = min(start + batch_size - 1, page_count - 1)
+        batches.append((start, end))
+        if end >= page_count - 1:
+            break
+        start = end - overlap + 1
+    return batches

--- a/backend/app/services/classification/service.py
+++ b/backend/app/services/classification/service.py
@@ -1,6 +1,5 @@
 # backend/app/services/classification/service.py
 from __future__ import annotations
-import json
 import logging
 import time
 from uuid import UUID

--- a/backend/app/services/classification/service.py
+++ b/backend/app/services/classification/service.py
@@ -1,0 +1,128 @@
+# backend/app/services/classification/service.py
+from __future__ import annotations
+import json
+import logging
+import time
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.cdm.classification import ClassifiedRegion
+from app.cdm.models import ParsedDocument
+from app.services.classification.assembler import (
+    BatchPageResult,
+    assemble_regions,
+    resolve_page_statuses,
+)
+from app.services.classification.serializer import build_batches, serialize_pages
+from app.services.llm.registry import LLMRegistry
+from app.services.llm.types import LLMConfig
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+You are a document classifier. Analyze the document pages provided and determine which labels apply to each page.
+
+For each label, classify each page as:
+- "start": this page begins a section matching this label
+- "continue": this page continues a section from a previous page
+- "none": this page does not contain this label
+
+Return ONLY valid JSON in this exact format:
+{
+  "pages": [
+    {"page": <page_index>, "labels": {"<label>": "start"|"continue"|"none", ...}},
+    ...
+  ]
+}
+
+Include every page index present in the document content.\
+"""
+
+
+class _PageResult(BaseModel):
+    page: int
+    labels: dict[str, str]
+
+
+class _BatchLLMResponse(BaseModel):
+    pages: list[_PageResult]
+
+
+class ClassificationService:
+    def __init__(self, repo: object, llm_registry: LLMRegistry) -> None:
+        self.repo = repo
+        self.llm_registry = llm_registry
+
+    async def execute(
+        self,
+        run_id: UUID,
+        doc: ParsedDocument,
+        labels: list[str],
+        llm_provider: str,
+        llm_model: str,
+        batch_size: int,
+        batch_overlap: int,
+    ) -> None:
+        await self.repo.update_status(run_id=run_id, status="running")
+        start = time.monotonic()
+        total_input = 0
+        total_output = 0
+
+        try:
+            adapter = self.llm_registry.get(llm_provider)
+            config = LLMConfig(
+                provider=llm_provider,
+                model=llm_model,
+                temperature=0.0,
+                max_tokens=4096,
+                json_mode=True,
+            )
+            labels_str = ", ".join(labels)
+            batches = build_batches(doc.page_count, batch_size, batch_overlap)
+            all_batch_results: list[list[BatchPageResult]] = []
+
+            for batch_start, batch_end in batches:
+                serialized = serialize_pages(doc, batch_start, batch_end)
+                messages = [
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Labels to identify: {labels_str}\n\n"
+                            f"Document pages:\n{serialized}"
+                        ),
+                    },
+                ]
+                result = await adapter.complete(messages, config)
+                total_input += result.usage.prompt_tokens
+                total_output += result.usage.completion_tokens
+
+                parsed = _BatchLLMResponse.model_validate_json(result.content)
+                batch_page_results = [
+                    BatchPageResult(
+                        page=p.page,
+                        label_statuses=p.labels,
+                        batch_start=batch_start,
+                        batch_end=batch_end,
+                    )
+                    for p in parsed.pages
+                ]
+                all_batch_results.append(batch_page_results)
+
+            resolved = resolve_page_statuses(all_batch_results)
+            regions = assemble_regions(resolved, labels, doc)
+
+            await self.repo.save_regions(run_id=run_id, regions=regions)
+            duration_ms = int((time.monotonic() - start) * 1000)
+            await self.repo.update_completed(
+                run_id=run_id,
+                input_tokens=total_input,
+                output_tokens=total_output,
+                duration_ms=duration_ms,
+            )
+
+        except Exception as exc:
+            logger.exception("Classification run %s failed", run_id)
+            await self.repo.update_status(run_id=run_id, status="failed", error=str(exc))
+            raise

--- a/backend/app/services/llm/groq_adapter.py
+++ b/backend/app/services/llm/groq_adapter.py
@@ -1,0 +1,10 @@
+"""Groq LLM adapter."""
+
+from app.services.llm.openai_adapter import OpenAIAdapter
+
+
+class GroqAdapter(OpenAIAdapter):
+    """OpenAI-compatible adapter pointing at Groq's hosted inference."""
+
+    def __init__(self, api_key: str):
+        super().__init__(api_key=api_key, base_url="https://api.groq.com/openai/v1")

--- a/backend/app/services/llm/groq_adapter.py
+++ b/backend/app/services/llm/groq_adapter.py
@@ -6,5 +6,7 @@ from app.services.llm.openai_adapter import OpenAIAdapter
 class GroqAdapter(OpenAIAdapter):
     """OpenAI-compatible adapter pointing at Groq's hosted inference."""
 
+    _provider_name = "groq"
+
     def __init__(self, api_key: str):
         super().__init__(api_key=api_key, base_url="https://api.groq.com/openai/v1")

--- a/backend/app/services/llm/ollama_adapter.py
+++ b/backend/app/services/llm/ollama_adapter.py
@@ -1,12 +1,17 @@
-"""Ollama LLM adapter."""
-
+# backend/app/services/llm/ollama_adapter.py
 from app.services.llm.openai_adapter import OpenAIAdapter
 
 
 class OllamaAdapter(OpenAIAdapter):
-    """OpenAI-compatible adapter pointing at a local Ollama instance."""
+    """OpenAI-compatible adapter for Ollama (local or cloud).
 
-    _provider_name = "ollama"
+    Local:  base_url="http://localhost:11434/v1", api_key="ollama" (dummy)
+    Cloud:  base_url="https://ollama.com/v1",    api_key=<real key>
+    """
 
-    def __init__(self, base_url: str = "http://localhost:11434/v1"):
-        super().__init__(api_key="ollama", base_url=base_url)
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434/v1",
+        api_key: str = "ollama",
+    ):
+        super().__init__(api_key=api_key, base_url=base_url)

--- a/backend/app/services/llm/ollama_adapter.py
+++ b/backend/app/services/llm/ollama_adapter.py
@@ -6,5 +6,7 @@ from app.services.llm.openai_adapter import OpenAIAdapter
 class OllamaAdapter(OpenAIAdapter):
     """OpenAI-compatible adapter pointing at a local Ollama instance."""
 
+    _provider_name = "ollama"
+
     def __init__(self, base_url: str = "http://localhost:11434/v1"):
         super().__init__(api_key="ollama", base_url=base_url)

--- a/backend/app/services/llm/ollama_adapter.py
+++ b/backend/app/services/llm/ollama_adapter.py
@@ -1,0 +1,10 @@
+"""Ollama LLM adapter."""
+
+from app.services.llm.openai_adapter import OpenAIAdapter
+
+
+class OllamaAdapter(OpenAIAdapter):
+    """OpenAI-compatible adapter pointing at a local Ollama instance."""
+
+    def __init__(self, base_url: str = "http://localhost:11434/v1"):
+        super().__init__(api_key="ollama", base_url=base_url)

--- a/backend/app/services/llm/openai_adapter.py
+++ b/backend/app/services/llm/openai_adapter.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 class OpenAIAdapter:
     """Thin wrapper around the OpenAI chat completions API."""
 
-    def __init__(self, api_key: str):
-        self.client = AsyncOpenAI(api_key=api_key)
+    def __init__(self, api_key: str, base_url: str | None = None):
+        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     async def stream_completion(
         self,

--- a/backend/app/services/llm/openai_adapter.py
+++ b/backend/app/services/llm/openai_adapter.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 class OpenAIAdapter:
     """Thin wrapper around the OpenAI chat completions API."""
 
+    _provider_name: str = "openai"
+
     def __init__(self, api_key: str, base_url: str | None = None):
         self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
@@ -62,5 +64,5 @@ class OpenAIAdapter:
             ),
             latency_ms=latency,
             model=config.model,
-            provider="openai",
+            provider=self._provider_name,
         )

--- a/backend/tests/cdm/test_classification.py
+++ b/backend/tests/cdm/test_classification.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+from app.cdm.classification import ClassifiedRegion, ClassificationRunStatus
+
+
+def test_classified_region_required_fields():
+    region = ClassifiedRegion(
+        label="balance_sheet",
+        page_start=5,
+        page_end=8,
+        block_ids=["b-001", "b-002"],
+    )
+    assert region.label == "balance_sheet"
+    assert region.page_start == 5
+    assert region.page_end == 8
+    assert region.block_ids == ["b-001", "b-002"]
+    assert region.confidence is None
+    assert region.reasoning is None
+    assert region.source == "llm"
+
+
+def test_classified_region_frozen():
+    region = ClassifiedRegion(label="x", page_start=0, page_end=1, block_ids=[])
+    with pytest.raises(ValidationError):
+        region.label = "y"  # type: ignore
+
+
+def test_classified_region_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        ClassifiedRegion(label="x", page_start=0, page_end=1, block_ids=[], unknown="bad")
+
+
+def test_classification_run_status_values():
+    assert ClassificationRunStatus.PENDING == "pending"
+    assert ClassificationRunStatus.RUNNING == "running"
+    assert ClassificationRunStatus.COMPLETED == "completed"
+    assert ClassificationRunStatus.FAILED == "failed"

--- a/backend/tests/cdm/test_workloads.py
+++ b/backend/tests/cdm/test_workloads.py
@@ -1,0 +1,53 @@
+import pytest
+from app.cdm.models import Block, BlockRole, Page, ParsedDocument
+from app.cdm.classification import ClassifiedRegion
+from app.cdm.workloads import slice_doc
+
+
+def _make_doc() -> ParsedDocument:
+    pages = [Page(index=i, block_ids=[f"b{i}"]) for i in range(5)]
+    blocks = [
+        Block(
+            id=f"b{i}",
+            role=BlockRole.PARAGRAPH,
+            native_type="paragraph",
+            text=f"text on page {i}",
+            page_index=i,
+            reading_order=0,
+        )
+        for i in range(5)
+    ]
+    return ParsedDocument(
+        id="doc-1",
+        source_document_id="src-1",
+        parse_run_id="run-1",
+        page_count=5,
+        pages=pages,
+        blocks=blocks,
+    )
+
+
+def test_slice_doc_returns_only_region_pages():
+    doc = _make_doc()
+    region = ClassifiedRegion(label="balance_sheet", page_start=1, page_end=3, block_ids=[])
+    sliced = slice_doc(doc, region)
+    assert sliced.page_count == 3
+    assert [p.index for p in sliced.pages] == [1, 2, 3]
+    assert [b.id for b in sliced.blocks] == ["b1", "b2", "b3"]
+
+
+def test_slice_doc_sets_lineage():
+    doc = _make_doc()
+    region = ClassifiedRegion(label="income_statement", page_start=0, page_end=1, block_ids=[])
+    sliced = slice_doc(doc, region)
+    assert sliced.derived_from == "doc-1"
+    assert "income_statement" in sliced.derivation
+    assert "0" in sliced.derivation
+    assert "1" in sliced.derivation
+
+
+def test_slice_doc_original_unchanged():
+    doc = _make_doc()
+    region = ClassifiedRegion(label="x", page_start=0, page_end=0, block_ids=[])
+    slice_doc(doc, region)
+    assert doc.page_count == 5  # original not mutated

--- a/backend/tests/cdm/test_workloads.py
+++ b/backend/tests/cdm/test_workloads.py
@@ -51,3 +51,10 @@ def test_slice_doc_original_unchanged():
     region = ClassifiedRegion(label="x", page_start=0, page_end=0, block_ids=[])
     slice_doc(doc, region)
     assert doc.page_count == 5  # original not mutated
+
+
+def test_slice_doc_rejects_inverted_range():
+    doc = _make_doc()
+    region = ClassifiedRegion(label="x", page_start=3, page_end=1, block_ids=[])
+    with pytest.raises(ValueError):
+        slice_doc(doc, region)

--- a/backend/tests/repositories/test_classification_run_repository.py
+++ b/backend/tests/repositories/test_classification_run_repository.py
@@ -1,0 +1,72 @@
+# backend/tests/repositories/test_classification_run_repository.py
+import pytest
+from uuid import uuid4
+from app.cdm.classification import ClassifiedRegion
+from app.repositories.classification_run_repository import (
+    ClassificationRunCreate,
+    ClassificationRunRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_run(test_db):
+    repo = ClassificationRunRepository(test_db)
+    data = ClassificationRunCreate(
+        parse_run_id=uuid4(),
+        document_id=uuid4(),
+        labels_requested=["balance_sheet"],
+        llm_provider="ollama_local",
+        llm_model="qwen2.5:7b",
+        batch_size=10,
+        batch_overlap=3,
+    )
+    run = await repo.create(data)
+    assert run.id is not None
+    assert run.status == "pending"
+    assert run.labels_requested == ["balance_sheet"]
+
+    fetched = await repo.get(run.id)
+    assert fetched is not None
+    assert fetched.llm_provider == "ollama_local"
+
+
+@pytest.mark.asyncio
+async def test_update_status(test_db):
+    repo = ClassificationRunRepository(test_db)
+    data = ClassificationRunCreate(
+        parse_run_id=uuid4(),
+        document_id=uuid4(),
+        labels_requested=["x"],
+        llm_provider="ollama_local",
+        llm_model="qwen2.5:7b",
+        batch_size=10,
+        batch_overlap=3,
+    )
+    run = await repo.create(data)
+    await repo.update_status(run.id, "running")
+    fetched = await repo.get(run.id)
+    assert fetched.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_regions(test_db):
+    repo = ClassificationRunRepository(test_db)
+    data = ClassificationRunCreate(
+        parse_run_id=uuid4(),
+        document_id=uuid4(),
+        labels_requested=["balance_sheet"],
+        llm_provider="ollama_local",
+        llm_model="qwen2.5:7b",
+        batch_size=10,
+        batch_overlap=3,
+    )
+    run = await repo.create(data)
+    regions = [
+        ClassifiedRegion(label="balance_sheet", page_start=5, page_end=8, block_ids=["b1", "b2"]),
+    ]
+    await repo.save_regions(run.id, regions)
+    fetched = await repo.get_regions(run.id)
+    assert len(fetched) == 1
+    assert fetched[0].label == "balance_sheet"
+    assert fetched[0].page_start == 5
+    assert fetched[0].block_ids == ["b1", "b2"]

--- a/backend/tests/services/classification/test_assembler.py
+++ b/backend/tests/services/classification/test_assembler.py
@@ -1,0 +1,97 @@
+from app.cdm.models import Block, BlockRole, Page, ParsedDocument
+from app.cdm.classification import ClassifiedRegion
+from app.services.classification.assembler import (
+    BatchPageResult,
+    assemble_regions,
+    resolve_page_statuses,
+)
+
+
+def _make_doc(page_count: int) -> ParsedDocument:
+    pages = [Page(index=i, block_ids=[f"b{i}"]) for i in range(page_count)]
+    blocks = [
+        Block(
+            id=f"b{i}",
+            role=BlockRole.PARAGRAPH,
+            native_type="paragraph",
+            text=f"page {i}",
+            page_index=i,
+            reading_order=0,
+        )
+        for i in range(page_count)
+    ]
+    return ParsedDocument(
+        id="d", source_document_id="s", parse_run_id="r",
+        page_count=page_count, pages=pages, blocks=blocks,
+    )
+
+
+def test_resolve_prefers_middle_pages():
+    """Page 7 appears in batch (0-9) at edge and batch (7-16) in the middle.
+    The batch where it's in the middle should win."""
+    batch_a = [
+        BatchPageResult(page=7, label_statuses={"bs": "start"}, batch_start=0, batch_end=9),
+    ]
+    batch_b = [
+        BatchPageResult(page=7, label_statuses={"bs": "none"}, batch_start=7, batch_end=16),
+        BatchPageResult(page=10, label_statuses={"bs": "continue"}, batch_start=7, batch_end=16),
+    ]
+    resolved = resolve_page_statuses([batch_a, batch_b])
+    # Page 7 at edge of batch_a (priority 1) vs middle of batch_b (priority 0)
+    assert resolved[7]["bs"] == "none"
+    assert resolved[10]["bs"] == "continue"
+
+
+def test_assemble_simple_region():
+    doc = _make_doc(5)
+    resolved = {
+        0: {"balance_sheet": "none"},
+        1: {"balance_sheet": "start"},
+        2: {"balance_sheet": "continue"},
+        3: {"balance_sheet": "none"},
+        4: {"balance_sheet": "none"},
+    }
+    regions = assemble_regions(resolved, ["balance_sheet"], doc)
+    assert len(regions) == 1
+    r = regions[0]
+    assert r.label == "balance_sheet"
+    assert r.page_start == 1
+    assert r.page_end == 2
+    assert "b1" in r.block_ids
+    assert "b2" in r.block_ids
+    assert "b0" not in r.block_ids
+
+
+def test_assemble_no_region():
+    doc = _make_doc(3)
+    resolved = {i: {"x": "none"} for i in range(3)}
+    regions = assemble_regions(resolved, ["x"], doc)
+    assert regions == []
+
+
+def test_assemble_region_open_at_end():
+    doc = _make_doc(3)
+    resolved = {
+        0: {"x": "none"},
+        1: {"x": "start"},
+        2: {"x": "continue"},
+    }
+    regions = assemble_regions(resolved, ["x"], doc)
+    assert len(regions) == 1
+    assert regions[0].page_end == 2
+
+
+def test_assemble_two_regions_same_label():
+    doc = _make_doc(6)
+    resolved = {
+        0: {"x": "start"},
+        1: {"x": "none"},
+        2: {"x": "start"},
+        3: {"x": "continue"},
+        4: {"x": "none"},
+        5: {"x": "none"},
+    }
+    regions = assemble_regions(resolved, ["x"], doc)
+    assert len(regions) == 2
+    assert regions[0].page_start == 0 and regions[0].page_end == 0
+    assert regions[1].page_start == 2 and regions[1].page_end == 3

--- a/backend/tests/services/classification/test_assembler.py
+++ b/backend/tests/services/classification/test_assembler.py
@@ -27,14 +27,14 @@ def _make_doc(page_count: int) -> ParsedDocument:
 
 
 def test_resolve_prefers_middle_pages():
-    """Page 7 appears in batch (0-9) at edge and batch (7-16) in the middle.
+    """Page 7 appears in batch (0-9) at edge and batch (4-13) in the middle.
     The batch where it's in the middle should win."""
     batch_a = [
         BatchPageResult(page=7, label_statuses={"bs": "start"}, batch_start=0, batch_end=9),
     ]
     batch_b = [
-        BatchPageResult(page=7, label_statuses={"bs": "none"}, batch_start=7, batch_end=16),
-        BatchPageResult(page=10, label_statuses={"bs": "continue"}, batch_start=7, batch_end=16),
+        BatchPageResult(page=7, label_statuses={"bs": "none"}, batch_start=4, batch_end=13),
+        BatchPageResult(page=10, label_statuses={"bs": "continue"}, batch_start=4, batch_end=13),
     ]
     resolved = resolve_page_statuses([batch_a, batch_b])
     # Page 7 at edge of batch_a (priority 1) vs middle of batch_b (priority 0)

--- a/backend/tests/services/classification/test_serializer.py
+++ b/backend/tests/services/classification/test_serializer.py
@@ -1,0 +1,75 @@
+from app.cdm.models import Block, BlockRole, Page, ParsedDocument
+from app.services.classification.serializer import build_batches, serialize_pages
+
+
+def _make_doc(page_count: int) -> ParsedDocument:
+    pages = [Page(index=i, block_ids=[f"b{i}"]) for i in range(page_count)]
+    blocks = [
+        Block(
+            id=f"b{i}",
+            role=BlockRole.PARAGRAPH,
+            native_type="paragraph",
+            text=f"content on page {i}",
+            page_index=i,
+            reading_order=0,
+        )
+        for i in range(page_count)
+    ]
+    return ParsedDocument(
+        id="doc-1",
+        source_document_id="src-1",
+        parse_run_id="run-1",
+        page_count=page_count,
+        pages=pages,
+        blocks=blocks,
+    )
+
+
+def test_serialize_pages_format():
+    doc = _make_doc(3)
+    text = serialize_pages(doc, 0, 1)
+    assert "[page 0, paragraph] content on page 0" in text
+    assert "[page 1, paragraph] content on page 1" in text
+    assert "page 2" not in text
+
+
+def test_serialize_pages_prefers_markdown():
+    from pydantic import ValidationError
+    import pytest
+    pages = [Page(index=0, block_ids=["b0"])]
+    blocks = [
+        Block(
+            id="b0",
+            role=BlockRole.TABLE,
+            native_type="table",
+            text="plain text",
+            markdown="| col1 | col2 |",
+            page_index=0,
+            reading_order=0,
+        )
+    ]
+    doc = ParsedDocument(
+        id="d", source_document_id="s", parse_run_id="r",
+        page_count=1, pages=pages, blocks=blocks,
+    )
+    text = serialize_pages(doc, 0, 0)
+    assert "| col1 | col2 |" in text
+    assert "plain text" not in text
+
+
+def test_build_batches_25_pages():
+    batches = build_batches(page_count=25, batch_size=10, overlap=3)
+    assert batches[0] == (0, 9)
+    assert batches[1] == (7, 16)
+    assert batches[2] == (14, 23)
+    assert batches[3] == (21, 24)
+
+
+def test_build_batches_small_doc():
+    batches = build_batches(page_count=5, batch_size=10, overlap=3)
+    assert batches == [(0, 4)]
+
+
+def test_build_batches_exact_fit():
+    batches = build_batches(page_count=10, batch_size=10, overlap=3)
+    assert batches == [(0, 9)]

--- a/backend/tests/services/classification/test_service.py
+++ b/backend/tests/services/classification/test_service.py
@@ -1,0 +1,63 @@
+# backend/tests/services/classification/test_service.py
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from uuid import uuid4
+import pytest
+from app.cdm.models import Block, BlockRole, Page, ParsedDocument
+from app.cdm.classification import ClassifiedRegion
+from app.services.classification.service import ClassificationService
+from app.services.llm.types import CompletionResult, TokenUsage
+
+
+def _make_doc() -> ParsedDocument:
+    pages = [Page(index=i, block_ids=[f"b{i}"]) for i in range(3)]
+    blocks = [
+        Block(id=f"b{i}", role=BlockRole.PARAGRAPH, native_type="p",
+              text=f"page {i}", page_index=i, reading_order=0)
+        for i in range(3)
+    ]
+    return ParsedDocument(
+        id="doc-1", source_document_id="s", parse_run_id="r",
+        page_count=3, pages=pages, blocks=blocks,
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_execute_saves_regions():
+    repo = MagicMock()
+    repo.update_status = AsyncMock()
+    repo.update_completed = AsyncMock()
+    repo.save_regions = AsyncMock()
+
+    llm_adapter = MagicMock()
+    llm_adapter.complete = AsyncMock(return_value=CompletionResult(
+        content='{"pages": [{"page": 0, "labels": {"x": "none"}}, {"page": 1, "labels": {"x": "start"}}, {"page": 2, "labels": {"x": "continue"}}]}',
+        usage=TokenUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+        latency_ms=200.0,
+        model="qwen2.5:7b",
+        provider="ollama",
+    ))
+
+    registry = MagicMock()
+    registry.get.return_value = llm_adapter
+
+    service = ClassificationService(repo=repo, llm_registry=registry)
+    doc = _make_doc()
+
+    await service.execute(
+        run_id=uuid4(),
+        doc=doc,
+        labels=["x"],
+        llm_provider="ollama_local",
+        llm_model="qwen2.5:7b",
+        batch_size=10,
+        batch_overlap=3,
+    )
+
+    repo.update_status.assert_any_call(run_id=ANY, status="running")
+    repo.save_regions.assert_called_once()
+    saved_regions = repo.save_regions.call_args[1]["regions"]
+    assert len(saved_regions) == 1
+    assert saved_regions[0].label == "x"
+    assert saved_regions[0].page_start == 1
+    assert saved_regions[0].page_end == 2
+    repo.update_completed.assert_called_once()

--- a/backend/tests/services/llm/test_openai_compatible_adapters.py
+++ b/backend/tests/services/llm/test_openai_compatible_adapters.py
@@ -1,10 +1,7 @@
 """Tests for OpenAI-compatible adapters (Ollama, Groq)."""
 
-from unittest.mock import AsyncMock, patch
-import pytest
 from app.services.llm.ollama_adapter import OllamaAdapter
 from app.services.llm.groq_adapter import GroqAdapter
-from app.services.llm.types import LLMConfig
 
 
 def test_ollama_adapter_init():

--- a/backend/tests/services/llm/test_openai_compatible_adapters.py
+++ b/backend/tests/services/llm/test_openai_compatible_adapters.py
@@ -1,0 +1,22 @@
+"""Tests for OpenAI-compatible adapters (Ollama, Groq)."""
+
+from unittest.mock import AsyncMock, patch
+import pytest
+from app.services.llm.ollama_adapter import OllamaAdapter
+from app.services.llm.groq_adapter import GroqAdapter
+from app.services.llm.types import LLMConfig
+
+
+def test_ollama_adapter_init():
+    adapter = OllamaAdapter(base_url="http://localhost:11434/v1")
+    assert str(adapter.client.base_url) == "http://localhost:11434/v1/"
+
+
+def test_ollama_adapter_default_base_url():
+    adapter = OllamaAdapter()
+    assert "11434" in str(adapter.client.base_url)
+
+
+def test_groq_adapter_init():
+    adapter = GroqAdapter(api_key="test-key")
+    assert "groq.com" in str(adapter.client.base_url)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
@@ -2945,6 +2946,79 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,9 @@ import DataStoresPage from './pages/DataStoresPage'
 import DataStoreDetailPage from './pages/DataStoreDetailPage'
 import ExportPlaygroundPage from './pages/ExportPlaygroundPage'
 import { ParseRunDetailPage } from './pages/ParseRunDetailPage'
+import ClassificationPage from './pages/ClassificationPage'
+import NewClassificationRunPage from './pages/NewClassificationRunPage'
+import ClassificationRunDetailPage from './pages/ClassificationRunDetailPage'
 
 const router = createBrowserRouter([
   {
@@ -95,6 +98,21 @@ const router = createBrowserRouter([
             path: 'extraction',
             element: <ExtractionPage />,
             handle: { breadcrumb: 'Extraction' },
+          },
+          {
+            path: 'classify',
+            element: <ClassificationPage />,
+            handle: { breadcrumb: 'Classify' },
+          },
+          {
+            path: 'classify/new',
+            element: <NewClassificationRunPage />,
+            handle: { breadcrumb: 'New Classification Run' },
+          },
+          {
+            path: 'classify/:runId',
+            element: <ClassificationRunDetailPage />,
+            handle: { breadcrumb: 'Classification Run' },
           },
           {
             path: 'data-stores',

--- a/frontend/src/api/classification.ts
+++ b/frontend/src/api/classification.ts
@@ -1,0 +1,48 @@
+// frontend/src/api/classification.ts
+import apiClient from './client'
+import type { ClassificationRun, ClassificationRunCreateRequest } from '@/types/classification'
+
+export async function createClassificationRun(
+  documentId: string,
+  data: ClassificationRunCreateRequest,
+): Promise<ClassificationRun> {
+  const response = await apiClient.post<ClassificationRun>(
+    `/documents/${documentId}/classification-runs`,
+    {
+      parse_run_id: data.parseRunId,
+      labels: data.labels,
+      llm_provider: data.llmProvider,
+      llm_model: data.llmModel,
+      batch_size: data.batchSize,
+      batch_overlap: data.batchOverlap,
+    },
+  )
+  return response.data
+}
+
+export async function listDocumentClassificationRuns(
+  documentId: string,
+): Promise<ClassificationRun[]> {
+  const response = await apiClient.get<ClassificationRun[]>(
+    `/documents/${documentId}/classification-runs`,
+  )
+  return response.data
+}
+
+export async function listAllClassificationRuns(
+  projectId: string,
+): Promise<ClassificationRun[]> {
+  const response = await apiClient.get<ClassificationRun[]>(
+    `/classification-runs?project_id=${projectId}`,
+  )
+  return response.data
+}
+
+export async function getClassificationRun(runId: string): Promise<ClassificationRun> {
+  const response = await apiClient.get<ClassificationRun>(`/classification-runs/${runId}`)
+  return response.data
+}
+
+export async function deleteClassificationRun(runId: string): Promise<void> {
+  await apiClient.delete(`/classification-runs/${runId}`)
+}

--- a/frontend/src/components/classification/ClassificationRegionCard.tsx
+++ b/frontend/src/components/classification/ClassificationRegionCard.tsx
@@ -1,0 +1,51 @@
+// frontend/src/components/classification/ClassificationRegionCard.tsx
+import { useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import type { ClassificationRegion } from '@/types/classification'
+
+interface Props {
+  region: ClassificationRegion
+}
+
+export function ClassificationRegionCard({ region }: Props) {
+  const [reasoningOpen, setReasoningOpen] = useState(false)
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-medium">{region.label}</CardTitle>
+          <div className="flex items-center gap-2">
+            {region.confidence !== null && (
+              <Badge variant="outline">
+                {(region.confidence * 100).toFixed(0)}% confidence
+              </Badge>
+            )}
+            <span className="text-sm text-muted-foreground">
+              Pages {region.pageStart + 1}–{region.pageEnd + 1}
+            </span>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground space-y-2">
+        <p>{region.blockIds.length} blocks</p>
+        {region.reasoning && (
+          <div>
+            <button
+              className="flex items-center gap-1 text-xs font-medium hover:text-foreground"
+              onClick={() => setReasoningOpen((v) => !v)}
+            >
+              {reasoningOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+              Reasoning
+            </button>
+            {reasoningOpen && (
+              <p className="mt-1 text-xs leading-relaxed">{region.reasoning}</p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/classification/ClassificationRegionList.tsx
+++ b/frontend/src/components/classification/ClassificationRegionList.tsx
@@ -1,0 +1,22 @@
+// frontend/src/components/classification/ClassificationRegionList.tsx
+import { ClassificationRegionCard } from './ClassificationRegionCard'
+import type { ClassificationRegion } from '@/types/classification'
+
+interface Props {
+  regions: ClassificationRegion[]
+}
+
+export function ClassificationRegionList({ regions }: Props) {
+  if (regions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No regions identified.</p>
+    )
+  }
+  return (
+    <div className="space-y-3">
+      {regions.map((region) => (
+        <ClassificationRegionCard key={region.id} region={region} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/classification/ClassificationRunForm.tsx
+++ b/frontend/src/components/classification/ClassificationRunForm.tsx
@@ -1,0 +1,162 @@
+// frontend/src/components/classification/ClassificationRunForm.tsx
+import { useState } from 'react'
+import { X, ChevronDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+
+const PROVIDER_OPTIONS = [
+  { value: 'ollama_local', label: 'Ollama — local' },
+  { value: 'ollama_cloud', label: 'Ollama — cloud' },
+  { value: 'groq', label: 'Groq (hosted)' },
+  { value: 'anthropic', label: 'Anthropic' },
+]
+
+const DEFAULT_MODELS: Record<string, string> = {
+  ollama_local: 'qwen2.5:7b',
+  ollama_cloud: 'qwen3:32b',
+  groq: 'llama-3.3-70b-versatile',
+  anthropic: 'claude-haiku-4-5-20251001',
+}
+
+export interface ClassificationRunFormValues {
+  labels: string[]
+  llmProvider: string
+  llmModel: string
+  batchSize: number
+  batchOverlap: number
+}
+
+interface Props {
+  defaultValues?: Partial<ClassificationRunFormValues>
+  onSubmit: (values: ClassificationRunFormValues) => void
+  isSubmitting?: boolean
+  submitLabel?: string
+}
+
+export function ClassificationRunForm({
+  defaultValues,
+  onSubmit,
+  isSubmitting,
+  submitLabel = 'Start classification',
+}: Props) {
+  const [labels, setLabels] = useState<string[]>(defaultValues?.labels ?? [])
+  const [labelInput, setLabelInput] = useState('')
+  const [provider, setProvider] = useState(defaultValues?.llmProvider ?? 'ollama_local')
+  const [model, setModel] = useState(defaultValues?.llmModel ?? DEFAULT_MODELS['ollama_local'])
+  const [batchSize, setBatchSize] = useState(defaultValues?.batchSize ?? 10)
+  const [batchOverlap, setBatchOverlap] = useState(defaultValues?.batchOverlap ?? 3)
+
+  const addLabel = () => {
+    const trimmed = labelInput.trim()
+    if (trimmed && !labels.includes(trimmed)) {
+      setLabels((prev) => [...prev, trimmed])
+    }
+    setLabelInput('')
+  }
+
+  const removeLabel = (l: string) => setLabels((prev) => prev.filter((x) => x !== l))
+
+  const handleProviderChange = (p: string) => {
+    setProvider(p)
+    setModel(DEFAULT_MODELS[p] ?? '')
+  }
+
+  const handleSubmit = () => {
+    if (labels.length === 0) return
+    onSubmit({ labels, llmProvider: provider, llmModel: model, batchSize, batchOverlap })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Label>Labels to classify</Label>
+        <div className="flex gap-2">
+          <Input
+            placeholder="e.g. balance_sheet"
+            value={labelInput}
+            onChange={(e) => setLabelInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addLabel() } }}
+          />
+          <Button type="button" variant="outline" onClick={addLabel}>Add</Button>
+        </div>
+        {labels.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {labels.map((l) => (
+              <Badge key={l} variant="secondary" className="flex items-center gap-1">
+                {l}
+                <button onClick={() => removeLabel(l)} className="ml-1 hover:text-destructive">
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label>LLM provider</Label>
+          <Select value={provider} onValueChange={handleProviderChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PROVIDER_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label>Model</Label>
+          <Input value={model} onChange={(e) => setModel(e.target.value)} />
+        </div>
+      </div>
+
+      <Collapsible>
+        <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+          <ChevronDown className="h-4 w-4" />
+          Advanced
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-3 grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>Batch size (pages)</Label>
+            <Input
+              type="number"
+              min={1}
+              value={batchSize}
+              onChange={(e) => setBatchSize(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Batch overlap (pages)</Label>
+            <Input
+              type="number"
+              min={0}
+              value={batchOverlap}
+              onChange={(e) => setBatchOverlap(Number(e.target.value))}
+            />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      <Button onClick={handleSubmit} disabled={labels.length === 0 || isSubmitting}>
+        {isSubmitting ? 'Starting…' : submitLabel}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/classification/ClassificationRunStatusBadge.tsx
+++ b/frontend/src/components/classification/ClassificationRunStatusBadge.tsx
@@ -1,0 +1,22 @@
+// frontend/src/components/classification/ClassificationRunStatusBadge.tsx
+import { Badge } from '@/components/ui/badge'
+import type { ClassificationRunStatus } from '@/types/classification'
+
+const STATUS_STYLES: Record<ClassificationRunStatus, string> = {
+  pending: 'bg-gray-100 text-gray-700',
+  running: 'bg-blue-100 text-blue-700',
+  completed: 'bg-green-100 text-green-700',
+  failed: 'bg-red-100 text-red-700',
+}
+
+interface Props {
+  status: ClassificationRunStatus
+}
+
+export function ClassificationRunStatusBadge({ status }: Props) {
+  return (
+    <Badge className={STATUS_STYLES[status]}>
+      {status}
+    </Badge>
+  )
+}

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { RadioGroup, RadioGroupItem }

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, FolderKanban, FileText, Database, BarChart3, Settings, FileSearch, Bot, HardDrive, ArrowUpFromLine } from 'lucide-react'
+import { LayoutDashboard, FolderKanban, FileText, Database, BarChart3, Settings, FileSearch, Bot, HardDrive, ArrowUpFromLine, Tags } from 'lucide-react'
 
 export const navigationItems = [
   { label: 'Dashboard', href: '/', icon: LayoutDashboard, activeColor: 'border-l-primary' },
@@ -6,6 +6,7 @@ export const navigationItems = [
   { label: 'Documents', href: '/documents', icon: FileText, activeColor: 'border-l-blue-500' },
   { label: 'Index', href: '/index', icon: Database, activeColor: 'border-l-teal-500' },
   { label: 'Extraction', href: '/extraction', icon: FileSearch, activeColor: 'border-l-orange-500' },
+  { label: 'Classify', href: '/classify', icon: Tags, activeColor: 'border-l-pink-500' },
   { label: 'Data Stores', href: '/data-stores', icon: HardDrive, activeColor: 'border-l-cyan-500' },
   { label: 'Export', href: '/export', icon: ArrowUpFromLine, activeColor: 'border-l-emerald-500' },
   { label: 'Evaluation', href: '/evaluation', icon: BarChart3, activeColor: 'border-l-amber-500' },

--- a/frontend/src/hooks/useClassificationRuns.ts
+++ b/frontend/src/hooks/useClassificationRuns.ts
@@ -1,0 +1,140 @@
+// frontend/src/hooks/useClassificationRuns.ts
+import { useCallback, useEffect, useRef, useState } from 'react'
+import * as classificationApi from '@/api/classification'
+import type { ClassificationRun, ClassificationRunStatus } from '@/types/classification'
+
+const POLL_MS = 5000
+const TERMINAL: ReadonlyArray<ClassificationRunStatus> = ['completed', 'failed']
+
+function isTerminal(status: ClassificationRunStatus): boolean {
+  return TERMINAL.includes(status)
+}
+
+interface UseClassificationRunsReturn {
+  runs: ClassificationRun[]
+  isLoading: boolean
+  error: string | null
+  refresh: () => void
+  deleteRun: (runId: string) => Promise<void>
+}
+
+export function useClassificationRuns(projectId: string | null): UseClassificationRunsReturn {
+  const [runs, setRuns] = useState<ClassificationRun[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [forcePolling, setForcePolling] = useState(false)
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const forceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current !== null) {
+      clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }, [])
+
+  const fetchList = useCallback(
+    async (id: string, silent = false) => {
+      if (!silent) { setIsLoading(true); setError(null) }
+      try {
+        const data = await classificationApi.listAllClassificationRuns(id)
+        setRuns(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch classification runs')
+      } finally {
+        if (!silent) setIsLoading(false)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!projectId) { setRuns([]); stopPolling(); return }
+    void fetchList(projectId)
+  }, [projectId, fetchList, stopPolling])
+
+  useEffect(() => {
+    if (!projectId) return
+    const hasActive = runs.some((r) => !isTerminal(r.status))
+    if (!hasActive && !forcePolling) { stopPolling(); return }
+    if (pollingRef.current !== null) return
+    pollingRef.current = setInterval(() => void fetchList(projectId, true), POLL_MS)
+    return () => stopPolling()
+  }, [projectId, runs, fetchList, stopPolling, forcePolling])
+
+  useEffect(() => () => stopPolling(), [stopPolling])
+
+  const refresh = useCallback(() => {
+    if (!projectId) return
+    void fetchList(projectId, true)
+    setForcePolling(true)
+    if (forceTimerRef.current !== null) clearTimeout(forceTimerRef.current)
+    forceTimerRef.current = setTimeout(() => {
+      setForcePolling(false)
+      forceTimerRef.current = null
+    }, 30_000)
+  }, [projectId, fetchList])
+
+  const deleteRun = useCallback(
+    async (runId: string) => {
+      await classificationApi.deleteClassificationRun(runId)
+      if (projectId) void fetchList(projectId, true)
+    },
+    [projectId, fetchList],
+  )
+
+  return { runs, isLoading, error, refresh, deleteRun }
+}
+
+interface UseClassificationRunDetailReturn {
+  run: ClassificationRun | null
+  isLoading: boolean
+  error: string | null
+  refresh: () => void
+}
+
+export function useClassificationRunDetail(runId: string | null): UseClassificationRunDetailReturn {
+  const [run, setRun] = useState<ClassificationRun | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current !== null) { clearInterval(pollingRef.current); pollingRef.current = null }
+  }, [])
+
+  const fetchRun = useCallback(async (id: string, silent = false) => {
+    if (!silent) { setIsLoading(true); setError(null) }
+    try {
+      const data = await classificationApi.getClassificationRun(id)
+      setRun(data)
+      return data
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch run')
+      return null
+    } finally {
+      if (!silent) setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!runId) { setRun(null); stopPolling(); return }
+    void fetchRun(runId)
+  }, [runId, fetchRun, stopPolling])
+
+  useEffect(() => {
+    if (!runId) return
+    if (run && isTerminal(run.status)) { stopPolling(); return }
+    if (pollingRef.current !== null) return
+    pollingRef.current = setInterval(() => void fetchRun(runId, true), POLL_MS)
+    return () => stopPolling()
+  }, [runId, run, fetchRun, stopPolling])
+
+  useEffect(() => () => stopPolling(), [stopPolling])
+
+  const refresh = useCallback(() => {
+    if (runId) void fetchRun(runId, true)
+  }, [runId, fetchRun])
+
+  return { run, isLoading, error, refresh }
+}

--- a/frontend/src/pages/ClassificationPage.tsx
+++ b/frontend/src/pages/ClassificationPage.tsx
@@ -1,0 +1,115 @@
+// frontend/src/pages/ClassificationPage.tsx
+import { useNavigate } from 'react-router-dom'
+import { Plus, Trash2 } from 'lucide-react'
+import { useProject } from '@/contexts/ProjectContext'
+import { useClassificationRuns } from '@/hooks/useClassificationRuns'
+import { ClassificationRunStatusBadge } from '@/components/classification/ClassificationRunStatusBadge'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { toast } from 'sonner'
+import { formatDistanceToNow } from 'date-fns'
+
+export default function ClassificationPage(): JSX.Element {
+  const navigate = useNavigate()
+  const { currentProject } = useProject()
+  const { runs, isLoading, error, deleteRun } = useClassificationRuns(currentProject?.id ?? null)
+
+  const handleDelete = async (runId: string) => {
+    try {
+      await deleteRun(runId)
+      toast.success('Classification run deleted')
+    } catch {
+      toast.error('Failed to delete run')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Classify</h1>
+          <p className="text-muted-foreground mt-1">{currentProject?.name}</p>
+        </div>
+        <Button onClick={() => navigate('/classify/new')}>
+          <Plus className="h-4 w-4 mr-2" />
+          New classification run
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => <Skeleton key={i} className="h-12 w-full" />)}
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p>No classification runs yet.</p>
+          <Button className="mt-4" onClick={() => navigate('/classify/new')}>
+            Start your first run
+          </Button>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Labels</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Provider / Model</TableHead>
+              <TableHead>Duration</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {runs.map((run) => (
+              <TableRow
+                key={run.id}
+                className="cursor-pointer hover:bg-muted/50"
+                onClick={() => navigate(`/classify/${run.id}`)}
+              >
+                <TableCell>
+                  <span className="text-sm">{run.labelsRequested.join(', ')}</span>
+                </TableCell>
+                <TableCell>
+                  <ClassificationRunStatusBadge status={run.status} />
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {run.llmProvider} / {run.llmModel}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {run.durationMs !== null ? `${(run.durationMs / 1000).toFixed(1)}s` : '—'}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}
+                </TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleDelete(run.id)}
+                  >
+                    <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ClassificationRunDetailPage.tsx
+++ b/frontend/src/pages/ClassificationRunDetailPage.tsx
@@ -1,0 +1,106 @@
+// frontend/src/pages/ClassificationRunDetailPage.tsx
+import { useNavigate, useParams } from 'react-router-dom'
+import { useClassificationRunDetail } from '@/hooks/useClassificationRuns'
+import { ClassificationRunStatusBadge } from '@/components/classification/ClassificationRunStatusBadge'
+import { ClassificationRegionList } from '@/components/classification/ClassificationRegionList'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { ChevronLeft, RotateCw } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+
+export default function ClassificationRunDetailPage(): JSX.Element {
+  const { runId } = useParams<{ runId: string }>()
+  const navigate = useNavigate()
+  const { run, isLoading, error } = useClassificationRunDetail(runId ?? null)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (!run) return <></>
+
+  const handleRerun = () => {
+    navigate(`/classify/new?documentId=${run.documentId}`)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/classify')}>
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold">Classification run</h1>
+            <ClassificationRunStatusBadge status={run.status} />
+          </div>
+          <p className="text-muted-foreground text-sm mt-1">
+            {run.llmProvider} / {run.llmModel} ·{' '}
+            {formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleRerun}>
+          <RotateCw className="h-4 w-4 mr-2" />
+          Re-run
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4 text-sm">
+        <div>
+          <p className="text-muted-foreground">Labels</p>
+          <p className="font-medium">{run.labelsRequested.join(', ')}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Regions found</p>
+          <p className="font-medium">{run.regions.length}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Tokens</p>
+          <p className="font-medium">
+            {run.inputTokens !== null ? `${run.inputTokens} in / ${run.outputTokens} out` : '—'}
+          </p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Duration</p>
+          <p className="font-medium">
+            {run.durationMs !== null ? `${(run.durationMs / 1000).toFixed(1)}s` : '—'}
+          </p>
+        </div>
+      </div>
+
+      {run.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{run.error}</AlertDescription>
+        </Alert>
+      )}
+
+      {run.status === 'running' && (
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Classification in progress…
+        </p>
+      )}
+
+      {run.status === 'completed' && (
+        <section>
+          <h2 className="text-lg font-medium mb-3">Identified regions</h2>
+          <ClassificationRegionList regions={run.regions} />
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/NewClassificationRunPage.tsx
+++ b/frontend/src/pages/NewClassificationRunPage.tsx
@@ -1,0 +1,168 @@
+// frontend/src/pages/NewClassificationRunPage.tsx
+import { useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useProject } from '@/contexts/ProjectContext'
+import { useDocuments } from '@/hooks/useDocuments'
+import { useParseRuns } from '@/hooks/useParseRuns'
+import { ClassificationRunForm } from '@/components/classification/ClassificationRunForm'
+import type { ClassificationRunFormValues } from '@/components/classification/ClassificationRunForm'
+import { createClassificationRun } from '@/api/classification'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { toast } from 'sonner'
+import { formatDistanceToNow } from 'date-fns'
+import { ChevronLeft } from 'lucide-react'
+
+type Step = 'document' | 'parse-run' | 'configure'
+
+export default function NewClassificationRunPage(): JSX.Element {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { currentProject } = useProject()
+
+  const [step, setStep] = useState<Step>('document')
+  const [documentSearch, setDocumentSearch] = useState('')
+  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(
+    searchParams.get('documentId'),
+  )
+  const [selectedParseRunId, setSelectedParseRunId] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const { documents } = useDocuments(currentProject?.id ?? null)
+  const { parseRuns } = useParseRuns(selectedDocumentId)
+
+  const filteredDocuments = documents.filter((d) =>
+    d.title.toLowerCase().includes(documentSearch.toLowerCase()),
+  )
+
+  const handleDocumentSelect = (id: string) => {
+    setSelectedDocumentId(id)
+    setSelectedParseRunId(null)
+    setStep('parse-run')
+  }
+
+  const handleParseRunSelect = (id: string) => {
+    setSelectedParseRunId(id)
+    setStep('configure')
+  }
+
+  const handleSubmit = async (values: ClassificationRunFormValues) => {
+    if (!selectedDocumentId || !selectedParseRunId) return
+    setIsSubmitting(true)
+    try {
+      const run = await createClassificationRun(selectedDocumentId, {
+        parseRunId: selectedParseRunId,
+        labels: values.labels,
+        llmProvider: values.llmProvider,
+        llmModel: values.llmModel,
+        batchSize: values.batchSize,
+        batchOverlap: values.batchOverlap,
+      })
+      toast.success('Classification started')
+      navigate(`/classify/${run.id}`)
+    } catch (err) {
+      toast.error('Failed to start classification', {
+        description: err instanceof Error ? err.message : 'An error occurred',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const selectedDocTitle = documents.find((d) => d.id === selectedDocumentId)?.title
+
+  const completedParseRuns = parseRuns.filter(
+    (r) => r.status === 'succeeded' || r.status === 'partial',
+  )
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/classify')}>
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-2xl font-bold">New classification run</h1>
+      </div>
+
+      {/* Step 1: Select document */}
+      <div className={step !== 'document' ? 'opacity-50 pointer-events-none' : ''}>
+        <h2 className="text-lg font-medium mb-3">
+          {step !== 'document' && selectedDocumentId
+            ? `Document: ${selectedDocTitle}`
+            : '1. Select document'}
+        </h2>
+        {step === 'document' && (
+          <div className="space-y-3">
+            <Input
+              placeholder="Search documents…"
+              value={documentSearch}
+              onChange={(e) => setDocumentSearch(e.target.value)}
+            />
+            <div className="border rounded-md divide-y max-h-64 overflow-y-auto">
+              {filteredDocuments.map((doc) => (
+                <button
+                  key={doc.id}
+                  className="w-full text-left px-4 py-3 hover:bg-muted/50 text-sm"
+                  onClick={() => handleDocumentSelect(doc.id)}
+                >
+                  {doc.title}
+                </button>
+              ))}
+              {filteredDocuments.length === 0 && (
+                <p className="px-4 py-3 text-sm text-muted-foreground">No documents found.</p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Step 2: Select parse run */}
+      {(step === 'parse-run' || step === 'configure') && (
+        <div className={step !== 'parse-run' ? 'opacity-50 pointer-events-none' : ''}>
+          <h2 className="text-lg font-medium mb-3">
+            {step !== 'parse-run' && selectedParseRunId
+              ? 'Parse run selected'
+              : '2. Select parse run'}
+          </h2>
+          {step === 'parse-run' && (
+            <RadioGroup
+              value={selectedParseRunId ?? ''}
+              onValueChange={handleParseRunSelect}
+              className="space-y-2"
+            >
+              {completedParseRuns.map((run) => (
+                <div key={run.id} className="flex items-center gap-3 border rounded-md px-4 py-3">
+                  <RadioGroupItem value={run.id} id={run.id} />
+                  <Label htmlFor={run.id} className="flex-1 cursor-pointer">
+                    <span className="font-medium">{run.parser}</span>
+                    <span className="text-sm text-muted-foreground ml-2">
+                      {run.finishedAt
+                        ? formatDistanceToNow(new Date(run.finishedAt), { addSuffix: true })
+                        : ''}
+                    </span>
+                  </Label>
+                </div>
+              ))}
+              {completedParseRuns.length === 0 && (
+                <Alert>
+                  <AlertDescription>No completed parse runs for this document.</AlertDescription>
+                </Alert>
+              )}
+            </RadioGroup>
+          )}
+        </div>
+      )}
+
+      {/* Step 3: Configure */}
+      {step === 'configure' && (
+        <div>
+          <h2 className="text-lg font-medium mb-3">3. Configure labels and model</h2>
+          <ClassificationRunForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/types/classification.ts
+++ b/frontend/src/types/classification.ts
@@ -1,0 +1,41 @@
+// frontend/src/types/classification.ts
+
+export type ClassificationRunStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+export interface ClassificationRegion {
+  id: string
+  label: string
+  pageStart: number
+  pageEnd: number
+  blockIds: string[]
+  confidence: number | null
+  reasoning: string | null
+  source: 'llm' | 'human'
+}
+
+export interface ClassificationRun {
+  id: string
+  parseRunId: string
+  documentId: string
+  labelsRequested: string[]
+  llmProvider: string
+  llmModel: string
+  status: ClassificationRunStatus
+  error: string | null
+  batchSize: number
+  batchOverlap: number
+  inputTokens: number | null
+  outputTokens: number | null
+  durationMs: number | null
+  createdAt: string
+  regions: ClassificationRegion[]
+}
+
+export interface ClassificationRunCreateRequest {
+  parseRunId: string
+  labels: string[]
+  llmProvider?: string
+  llmModel?: string
+  batchSize?: number
+  batchOverlap?: number
+}


### PR DESCRIPTION
## Summary

- Add LLM-based document classification that identifies which pages/blocks of a `ParsedDocument` match user-defined labels, storing results for re-use
- Backend follows `router → service → repository → database` pattern: CDM types, page serializer, assembler with overlap resolution, ORM models + Alembic migration, repository, service, schemas, and router
- Frontend adds a `/classify` route with list page, 3-step wizard (document → parse run → configure), and detail page with auto-polling

## What's included

**Backend:**
- `cdm/classification.py` — `ClassifiedRegion`, `ClassificationRunStatus` CDM types
- `cdm/workloads.py` — `slice_doc` utility
- `services/llm/` — `OllamaAdapter`, `GroqAdapter` (OpenAI-compatible wrappers)
- `services/classification/serializer.py` — page serializer + batch builder
- `services/classification/assembler.py` — overlap resolution + region assembly
- `models/classification_run.py`, `models/classification_region.py` — ORM models
- `alembic/versions/b2c3d4e5f6a1_add_classification_tables.py` — migration
- `repositories/classification_run_repository.py` — full CRUD + region persistence
- `services/classification/service.py` — classification orchestration service
- `dependencies/llm.py` — LLM registry factory (ollama_local always; ollama_cloud/groq conditional)
- `config.py` — classifier LLM defaults and provider API key settings
- `routers/classification.py` — POST/GET/DELETE endpoints at `/api/v1/documents/{id}/classification-runs` and `/api/v1/classification-runs`

**Frontend:**
- `types/classification.ts`, `api/classification.ts` — types and API client
- `hooks/useClassificationRuns.ts` — list + detail hooks with 5s polling
- `components/classification/` — StatusBadge, RegionCard, RegionList, RunForm
- `pages/ClassificationPage.tsx`, `NewClassificationRunPage.tsx`, `ClassificationRunDetailPage.tsx`
- Navigation: "Classify" entry added to sidebar

## Test Plan

- [ ] 646 backend tests pass (`uv run python -m pytest -o "addopts="`)
- [ ] Frontend lint and build pass
- [ ] Navigate to `/classify` — see empty state with "Start your first run"
- [ ] Create a new classification run — wizard steps through document → parse run → labels/model config
- [ ] Detail page polls and updates when run completes/fails
- [ ] Regions displayed after successful run

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)