### PR TITLE
feat: unified provider key storage (BYOK-first with env-var fallback)

### DIFF
--- a/backend/app/adapters/extraction/ollama.py
+++ b/backend/app/adapters/extraction/ollama.py
@@ -44,6 +44,14 @@ Return a single JSON object that conforms to the schema (including __source fiel
 class OllamaExtractor(OpenAICompatMixin, DataExtractor):
     """Structured extraction via Ollama's OpenAI-compatible REST API."""
 
+    def __init__(
+        self,
+        default_endpoint: str | None = None,
+        default_api_key: str | None = None,
+    ) -> None:
+        self._default_endpoint = default_endpoint
+        self._default_api_key = default_api_key
+
     @property
     def extractor_type(self) -> str:
         return "ollama"
@@ -73,7 +81,12 @@ class OllamaExtractor(OpenAICompatMixin, DataExtractor):
         schema: dict[str, Any],
         config: dict[str, Any] | None = None,
     ) -> ExtractionOutput:
-        cfg = config or {}
+        cfg = dict(config or {})
+        # Apply constructor defaults when not overridden per-run
+        if self._default_endpoint and "endpoint" not in cfg:
+            cfg["endpoint"] = self._default_endpoint
+        if self._default_api_key and "api_key" not in cfg:
+            cfg["api_key"] = self._default_api_key
         context = build_extraction_context(
             parsed_document, cfg.get("inject_block_ids", False)
         )

--- a/backend/app/adapters/extraction/registry.py
+++ b/backend/app/adapters/extraction/registry.py
@@ -99,6 +99,9 @@ def get_extractor(
 
     if method == "ollama":
         from app.adapters.extraction.ollama import OllamaExtractor
-        return OllamaExtractor()
+        return OllamaExtractor(
+            default_endpoint=credentials.get("endpoint"),
+            default_api_key=credentials.get("api_key"),
+        )
 
     raise ValueError(f"Unknown extraction method: {method!r}")

--- a/backend/app/routers/classification.py
+++ b/backend/app/routers/classification.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database import AsyncSessionLocal, get_db
 from app.dependencies.auth import get_current_active_user
-from app.dependencies.llm import get_llm_registry
 from app.models import User
 from app.repositories.classification_run_repository import (
     ClassificationRunCreate,
@@ -16,6 +15,7 @@ from app.repositories.classification_run_repository import (
 )
 from app.repositories.parsed_document_repository import ParsedDocumentRepository
 from app.repositories.document_repository import DocumentRepository
+from app.repositories.provider_key_repository import ProviderKeyRepository
 from app.schemas.classification import (
     AnnotatedBlockResponse,
     ClassificationRegionResponse,
@@ -24,6 +24,9 @@ from app.schemas.classification import (
 )
 from app.services.classification.service import ClassificationService
 from app.services.llm.registry import LLMRegistry
+from app.services.llm.ollama_adapter import OllamaAdapter
+from app.services.llm.groq_adapter import GroqAdapter
+from app.services.provider_key_service import resolve_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +37,29 @@ documents_router = APIRouter(prefix="/documents", tags=["classification"])
 runs_router = APIRouter(prefix="/classification-runs", tags=["classification"])
 
 
+def _classification_provider_to_byok(llm_provider: str) -> str | None:
+    """Map classification LLM provider names to BYOK provider IDs."""
+    return {"groq": "groq", "ollama_cloud": "ollama_cloud"}.get(llm_provider)
+
+
+def _build_llm_registry(provider: str, api_key: str | None) -> LLMRegistry:
+    """Build a per-request LLM registry with the resolved API key."""
+    registry = LLMRegistry()
+    if provider == "ollama_local":
+        registry.register(
+            "ollama_local",
+            OllamaAdapter(base_url=settings.OLLAMA_LOCAL_BASE_URL, api_key="ollama"),
+        )
+    elif provider == "ollama_cloud" and api_key:
+        registry.register(
+            "ollama_cloud",
+            OllamaAdapter(base_url=settings.OLLAMA_CLOUD_BASE_URL, api_key=api_key),
+        )
+    elif provider == "groq" and api_key:
+        registry.register("groq", GroqAdapter(api_key=api_key))
+    return registry
+
+
 async def _run_classification_background(
     run_id: UUID,
     parse_run_id: UUID,
@@ -42,6 +68,7 @@ async def _run_classification_background(
     llm_model: str,
     batch_size: int,
     batch_overlap: int,
+    api_key: str | None,
 ) -> None:
     from app.cdm.models import ParsedDocument as CDMParsedDocument
 
@@ -56,7 +83,7 @@ async def _run_classification_background(
                 return
 
             doc = CDMParsedDocument.model_validate(pd_orm.content)
-            registry = get_llm_registry()
+            registry = _build_llm_registry(llm_provider, api_key)
             service = ClassificationService(repo=repo, llm_registry=registry)
 
             await service.execute(
@@ -144,6 +171,12 @@ async def create_classification_run(
         batch_overlap=batch_overlap,
     ))
 
+    byok_provider = _classification_provider_to_byok(llm_provider)
+    api_key: str | None = None
+    if byok_provider:
+        provider_key_repo = ProviderKeyRepository(db)
+        api_key = await resolve_api_key(provider_key_repo, current_user.id, byok_provider)
+
     background_tasks.add_task(
         _run_classification_background,
         run_id=run.id,
@@ -153,6 +186,7 @@ async def create_classification_run(
         llm_model=llm_model,
         batch_size=batch_size,
         batch_overlap=batch_overlap,
+        api_key=api_key,
     )
 
     return _to_run_response(run)

--- a/backend/app/routers/classification.py
+++ b/backend/app/routers/classification.py
@@ -176,6 +176,14 @@ async def create_classification_run(
     if byok_provider:
         provider_key_repo = ProviderKeyRepository(db)
         api_key = await resolve_api_key(provider_key_repo, current_user.id, byok_provider)
+        if not api_key:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"No API key configured for provider '{llm_provider}'. "
+                    "Add one in Settings → API Keys."
+                ),
+            )
 
     background_tasks.add_task(
         _run_classification_background,

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -417,6 +417,7 @@ async def create_document_parse_run(
         storage_service=storage_service,
         llamaparse_client=get_llamaparse_client(),
         landingai_client=get_landingai_client(),
+        force=True,
     )
     return {"status": "accepted"}
 

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -24,6 +24,8 @@ from app.ports import StorageService
 from app.repositories.document_repository import DocumentRepository
 from app.repositories.parse_run_repository import ParseRunRepository
 from app.repositories.project_repository import ProjectRepository
+from app.repositories.provider_key_repository import ProviderKeyRepository
+from app.services.provider_key_service import resolve_api_key
 from app.schemas.document import (
     DocumentResponse,
     DocumentListResponse,
@@ -42,6 +44,44 @@ from pydantic import BaseModel as PydanticBaseModel
 class _ParseRunCreateRequest(PydanticBaseModel):
     parser_type: str = "simple"
     config: dict | None = None
+
+
+_PARSER_PROVIDER: dict[str, str] = {
+    "llamaparse": "llama_cloud",
+    "landing_ai": "landing_ai",
+}
+
+_PARSER_KEY_LABEL: dict[str, str] = {
+    "llamaparse": "LlamaCloud",
+    "landing_ai": "Landing AI",
+}
+
+
+async def _resolve_parser_key(
+    db: AsyncSession,
+    user_id: UUID,
+    parser_type: str,
+) -> tuple[str | None, str | None]:
+    """Return (llamaparse_api_key, landingai_api_key) for the given parser type.
+
+    Raises HTTP 400 if the chosen parser requires a key that is not configured
+    in BYOK settings or the environment.
+    """
+    provider = _PARSER_PROVIDER.get(parser_type)
+    if not provider:
+        return None, None  # simple parser — no key needed
+
+    key = await resolve_api_key(ProviderKeyRepository(db), user_id, provider)
+    if not key:
+        label = _PARSER_KEY_LABEL.get(parser_type, parser_type)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"No {label} API key configured. Add one in Settings → API Keys.",
+        )
+
+    if parser_type == "llamaparse":
+        return key, None
+    return None, key
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 
@@ -87,7 +127,9 @@ async def upload_document(
     storage_service: StorageService = Depends(get_storage_service),
 ):
     """Upload a document and initiate background processing."""
-    from app.dependencies.documents import get_llamaparse_client, get_landingai_client
+    llamaparse_api_key, landingai_api_key = await _resolve_parser_key(
+        db, current_user.id, parser_type
+    )
 
     try:
         config_dict = None
@@ -122,8 +164,8 @@ async def upload_document(
                 representation_kind=representation_kind,
                 config=parse_cfg,
                 storage_service=storage_service,
-                llamaparse_client=get_llamaparse_client(),
-                landingai_client=get_landingai_client(),
+                llamaparse_api_key=llamaparse_api_key,
+                landingai_api_key=landingai_api_key,
             )
         else:
             logger.error(
@@ -161,7 +203,9 @@ async def bulk_upload_documents(
     storage_service: StorageService = Depends(get_storage_service),
 ):
     """Bulk upload documents and initiate background processing for each."""
-    from app.dependencies.documents import get_llamaparse_client, get_landingai_client
+    llamaparse_api_key, landingai_api_key = await _resolve_parser_key(
+        db, current_user.id, parser_type
+    )
 
     if len(files) > 20:
         raise HTTPException(
@@ -210,8 +254,8 @@ async def bulk_upload_documents(
                 representation_kind=representation_kind,
                 config=parse_cfg,
                 storage_service=storage_service,
-                llamaparse_client=get_llamaparse_client(),
-                landingai_client=get_landingai_client(),
+                llamaparse_api_key=llamaparse_api_key,
+                landingai_api_key=landingai_api_key,
             )
         else:
             logger.error(
@@ -386,7 +430,6 @@ async def create_document_parse_run(
     storage_service: StorageService = Depends(get_storage_service),
 ):
     """Dispatch a new CDM parse run for an existing document."""
-    from app.dependencies.documents import get_llamaparse_client, get_landingai_client
     from app.services.document_service import process_cdm_parsing
 
     document_repo = DocumentRepository(db)
@@ -402,6 +445,10 @@ async def create_document_parse_run(
             detail="Document has no source_document_id; upload must be re-done via CDM path",
         )
 
+    llamaparse_api_key, landingai_api_key = await _resolve_parser_key(
+        db, current_user.id, body.parser_type
+    )
+
     cfg = body.config or {}
     representation_kind = cfg.get("representation_kind", "extract_rich")
     parse_cfg = {k: v for k, v in cfg.items() if k != "representation_kind"}
@@ -415,8 +462,8 @@ async def create_document_parse_run(
         representation_kind=representation_kind,
         config=parse_cfg,
         storage_service=storage_service,
-        llamaparse_client=get_llamaparse_client(),
-        landingai_client=get_landingai_client(),
+        llamaparse_api_key=llamaparse_api_key,
+        landingai_api_key=landingai_api_key,
         force=True,
     )
     return {"status": "accepted"}

--- a/backend/app/routers/extraction.py
+++ b/backend/app/routers/extraction.py
@@ -9,6 +9,7 @@ from fastapi import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database import get_db
 from app.dependencies.auth import get_current_active_user
 from app.models import User
@@ -16,6 +17,7 @@ from app.repositories.document_repository import DocumentRepository
 from app.repositories.extraction_schema_repository import ExtractionSchemaRepository
 from app.repositories.extraction_result_repository import ExtractionResultRepository
 from app.repositories.parsed_document_repository import ParsedDocumentRepository
+from app.repositories.provider_key_repository import ProviderKeyRepository
 from app.repositories.source_document_repository import SourceDocumentRepository
 from app.dependencies.documents import get_storage_service
 from app.schemas.extraction_result import (
@@ -29,6 +31,7 @@ from app.schemas.extraction_result import (
 )
 from app.services.extraction_service import ExtractionService, process_extraction
 from app.services.exceptions import NotFoundError, ConflictError
+from app.services.provider_key_service import resolve_api_key
 from app.adapters.extraction.registry import get_extractor
 
 
@@ -47,21 +50,34 @@ def get_extraction_service(
     )
 
 
-def _resolve_credentials_from_settings(method: str) -> dict:
-    """Resolve adapter credentials from application settings.
+async def _resolve_credentials_from_settings(
+    repo: ProviderKeyRepository,
+    user_id: UUID,
+    method: str,
+) -> dict:
+    """Resolve adapter credentials: DB first, env-var fallback.
 
-    BYOK seam: replace this function body with a project_extractor_credentials
-    DB lookup when BYOK is implemented. Nothing else in the system changes.
+    Maps extraction method names to BYOK provider IDs.
+    The Ollama endpoint URL is config (not a secret) and always comes from settings.
     """
-    from app.config import settings
-    if method == "llamaextract":
-        return {"api_key": getattr(settings, "LLAMA_CLOUD_KEY", None)}
+    provider_map = {
+        "llamaextract": "llama_cloud",
+        "ollama":        "ollama_cloud",
+        "groq":          "groq",
+        "vision_agent":  "landing_ai",
+    }
+    provider = provider_map.get(method)
+    if not provider:
+        return {}
+
+    key = await resolve_api_key(repo, user_id, provider)
+
     if method == "ollama":
         return {
-            "endpoint": getattr(settings, "OLLAMA_ENDPOINT", "http://localhost:11434/v1"),
-            "api_key": getattr(settings, "OLLAMA_API_KEY", None),
+            "endpoint": settings.OLLAMA_ENDPOINT or "http://localhost:11434/v1",
+            "api_key": key,
         }
-    return {}
+    return {"api_key": key} if key else {}
 
 
 # --- Schema endpoints ---
@@ -176,7 +192,10 @@ async def run_extraction(
     db: AsyncSession = Depends(get_db),
 ):
     try:
-        credentials = _resolve_credentials_from_settings(body.extraction_method)
+        provider_key_repo = ProviderKeyRepository(db)
+        credentials = await _resolve_credentials_from_settings(
+            provider_key_repo, current_user.id, body.extraction_method
+        )
         extractor = get_extractor(
             body.extraction_method,
             credentials,

--- a/backend/app/routers/extraction.py
+++ b/backend/app/routers/extraction.py
@@ -205,12 +205,14 @@ async def run_extraction(
             },
         )
 
+        # Merge BYOK credentials as defaults; per-request config overrides them.
+        merged_config = {**credentials, **(body.config or {})}
         result = await service.run_extraction(
             parse_run_id=body.parse_run_id,
             extraction_schema_id=body.extraction_schema_id,
             extraction_method=body.extraction_method,
             user_id=current_user.id,
-            config=body.config,
+            config=merged_config,
         )
 
         background_tasks.add_task(

--- a/backend/app/routers/extraction.py
+++ b/backend/app/routers/extraction.py
@@ -63,8 +63,6 @@ async def _resolve_credentials_from_settings(
     provider_map = {
         "llamaextract": "llama_cloud",
         "ollama":        "ollama_cloud",
-        "groq":          "groq",
-        "vision_agent":  "landing_ai",
     }
     provider = provider_map.get(method)
     if not provider:
@@ -205,14 +203,12 @@ async def run_extraction(
             },
         )
 
-        # Merge BYOK credentials as defaults; per-request config overrides them.
-        merged_config = {**credentials, **(body.config or {})}
         result = await service.run_extraction(
             parse_run_id=body.parse_run_id,
             extraction_schema_id=body.extraction_schema_id,
             extraction_method=body.extraction_method,
             user_id=current_user.id,
-            config=merged_config,
+            config=body.config,
         )
 
         background_tasks.add_task(

--- a/backend/app/routers/indexes.py
+++ b/backend/app/routers/indexes.py
@@ -54,7 +54,7 @@ from app.services.query_service import QueryService
 from app.services.source_resolution_service import SourceResolutionService
 from app.services.trace_collector import TraceCollector
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
-from app.utils.encryption import decrypt
+from app.services.provider_key_service import resolve_api_key
 
 router = APIRouter(prefix="/projects/{project_id}/indexes", tags=["indexes"])
 
@@ -577,14 +577,15 @@ async def playground_answer(
     """Stream an answer for the playground via Server-Sent Events."""
     await verify_project_access(project_id, current_user, project_repo)
 
-    # Resolve the LLM provider API key (reuses embedding key storage)
+    # Resolve the LLM provider API key: DB first, env-var fallback
     llm_provider = data.llm_config.provider
-    key_record = await provider_key_repo.get_for_provider(
+    api_key = await resolve_api_key(
+        repo=provider_key_repo,
         user_id=current_user.id,
         provider=llm_provider,
         project_id=project_id,
     )
-    if not key_record:
+    if not api_key:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
@@ -592,8 +593,6 @@ async def playground_answer(
                 "Add one in Settings → API Keys."
             ),
         )
-
-    api_key = decrypt(key_record.api_key_encrypted)
 
     collector = None
     if trace:

--- a/backend/app/schemas/provider_key.py
+++ b/backend/app/schemas/provider_key.py
@@ -6,7 +6,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 # Supported embedding providers
-SUPPORTED_PROVIDERS = ["openai", "voyage", "local", "anthropic"]
+SUPPORTED_PROVIDERS = [
+    "openai", "voyage", "local", "anthropic",
+    "groq", "llama_cloud", "landing_ai", "ollama_cloud",
+]
 
 
 class ProviderKeyCreate(BaseModel):
@@ -103,7 +106,31 @@ PROVIDER_MODELS = {
         "requires_key": True,
         "models": [],
         "dimensions": {}
-    }
+    },
+    "groq": {
+        "display_name": "Groq",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+    "llama_cloud": {
+        "display_name": "LlamaIndex Cloud",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+    "landing_ai": {
+        "display_name": "Landing AI",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+    "ollama_cloud": {
+        "display_name": "Ollama Cloud",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
 }
 
 

--- a/backend/app/services/answer_service.py
+++ b/backend/app/services/answer_service.py
@@ -61,7 +61,7 @@ class AnswerService:
 
         # Send chunks to the client
         chunks_data = [
-            r.model_dump(by_alias=True) for r in query_response.results
+            r.model_dump(by_alias=True, mode="json") for r in query_response.results
         ]
         yield _sse_event("chunks", chunks_data)
 
@@ -145,7 +145,7 @@ class AnswerService:
             # Emit trace event after done
             if collector:
                 trace = collector.build_trace()
-                yield _sse_event("trace", trace.model_dump(by_alias=True))
+                yield _sse_event("trace", trace.model_dump(by_alias=True, mode="json"))
 
         except Exception as e:
             if llm_span is not None and llm_span_ctx is not None:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -451,8 +451,8 @@ async def process_cdm_parsing(
     representation_kind: str,
     config: dict,
     storage_service: StorageService,
-    llamaparse_client: Any,
-    landingai_client: Any = None,
+    llamaparse_api_key: str | None = None,
+    landingai_api_key: str | None = None,
     force: bool = False,
 ) -> None:
     """Background task: CDM parse + persist for a newly uploaded document.
@@ -460,6 +460,10 @@ async def process_cdm_parsing(
     Opens a fresh DB session (independent of the request session) so that
     long-running parsers (LlamaParse, LandingAI) don't time out on the
     connection that was held open during request handling.
+
+    API keys are passed as strings (resolved via BYOK in the calling router) and
+    used to construct parser clients inside the task, so no plaintext key is
+    stored in the config or returned in API responses.
 
     Pass ``force=True`` to bypass same-config reuse and always run a fresh parse.
     """
@@ -472,6 +476,17 @@ async def process_cdm_parsing(
     from app.repositories.source_document_repository import SourceDocumentRepository
     from app.services.parsing.errors import ParseFailedError
     from app.services.parsing.parsing_service import ParsingService
+
+    # Build parser clients from the resolved API keys
+    llamaparse_client = None
+    if llamaparse_api_key:
+        from llama_cloud import AsyncLlamaCloud
+        llamaparse_client = AsyncLlamaCloud(api_key=llamaparse_api_key)
+
+    landingai_client = None
+    if landingai_api_key:
+        from landingai_ade import LandingAIADE
+        landingai_client = LandingAIADE(apikey=landingai_api_key)
 
     async with AsyncSessionLocal() as session:
         document_repo = DocumentRepository(session)

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -453,12 +453,15 @@ async def process_cdm_parsing(
     storage_service: StorageService,
     llamaparse_client: Any,
     landingai_client: Any = None,
+    force: bool = False,
 ) -> None:
     """Background task: CDM parse + persist for a newly uploaded document.
 
     Opens a fresh DB session (independent of the request session) so that
     long-running parsers (LlamaParse, LandingAI) don't time out on the
     connection that was held open during request handling.
+
+    Pass ``force=True`` to bypass same-config reuse and always run a fresh parse.
     """
     from app.cdm.models import ParserKind
     from app.cdm.source import SourceDocument as SourceDocumentCDM
@@ -524,6 +527,7 @@ async def process_cdm_parsing(
                     representation_kind=representation_kind,
                     config=config,
                     project_id=project_id,
+                    force=force,
                 )
             except ParseFailedError as e:
                 await document_repo.update_status(

--- a/backend/app/services/parsing/parsing_service.py
+++ b/backend/app/services/parsing/parsing_service.py
@@ -128,6 +128,7 @@ class ParsingService:
         representation_kind: str,
         config: dict[str, Any],
         project_id: UUID,
+        force: bool = False,
     ) -> tuple[ParseRunCDM, ParsedDocumentCDM | None]:
         """Run parse with same-project reuse. Persists success, partial, and failure runs.
 
@@ -136,21 +137,25 @@ class ParsingService:
           - parsed_doc is not None when run.status is SUCCEEDED or PARTIAL.
           - parsed_doc is None when run.status is FAILED.
         Raises ParseFailedError on terminal failure after the failed ParseRun is persisted.
+
+        Pass ``force=True`` to bypass the same-config reuse check and always run a fresh
+        parse. Used by the explicit re-parse endpoint.
         """
         parser = ParserKind(config.get("parser", ParserKind.LLAMAPARSE.value))
         config_hash = _compute_config_hash(config)
         source_uuid = UUID(source.id)
 
-        existing = await self._parse_run_repo.get_latest_for_project(
-            source_document_id=source_uuid,
-            representation_kind=representation_kind,
-            config_hash=config_hash,
-            project_id=project_id,
-        )
-        if existing is not None and existing.status in ("succeeded", "partial"):
-            cdm_run = _run_orm_to_cdm(existing)
-            doc_orm = await self._parsed_doc_repo.get_by_run(existing.id)
-            return cdm_run, _doc_orm_to_cdm(doc_orm) if doc_orm else None
+        if not force:
+            existing = await self._parse_run_repo.get_latest_for_project(
+                source_document_id=source_uuid,
+                representation_kind=representation_kind,
+                config_hash=config_hash,
+                project_id=project_id,
+            )
+            if existing is not None and existing.status in ("succeeded", "partial"):
+                cdm_run = _run_orm_to_cdm(existing)
+                doc_orm = await self._parsed_doc_repo.get_by_run(existing.id)
+                return cdm_run, _doc_orm_to_cdm(doc_orm) if doc_orm else None
 
         runner = _RUNNERS.get(parser)
         if runner is None:

--- a/backend/app/services/provider_key_service.py
+++ b/backend/app/services/provider_key_service.py
@@ -1,6 +1,7 @@
 """Service for provider key management (BYOK)."""
 from uuid import UUID
 
+from app.config import settings
 from app.repositories.provider_key_repository import ProviderKeyRepository
 from app.schemas.provider_key import (
     ProviderKeyCreate,
@@ -174,3 +175,32 @@ class ProviderKeyService:
             project_id=project_id
         )
         return key is not None
+
+
+async def resolve_api_key(
+    repo: ProviderKeyRepository,
+    user_id: UUID,
+    provider: str,
+    project_id: UUID | None = None,
+) -> str | None:
+    """Resolve an API key: DB first (project-level → account-level), then env-var fallback.
+
+    Returns None if no key is found in either source.
+    Empty string env vars are treated as not configured.
+    """
+    key_record = await repo.get_for_provider(
+        user_id=user_id,
+        provider=provider,
+        project_id=project_id,
+    )
+    if key_record:
+        return decrypt(key_record.api_key_encrypted)
+
+    env_fallbacks: dict[str, str] = {
+        "groq":         settings.GROQ_API_KEY,
+        "llama_cloud":  settings.LLAMA_CLOUD_KEY,
+        "landing_ai":   settings.VISION_AGENT_API_KEY,
+        "ollama_cloud": settings.OLLAMA_CLOUD_API_KEY,
+    }
+    value = env_fallbacks.get(provider, "")
+    return value if value else None

--- a/backend/tests/routers/test_classification_key_resolution.py
+++ b/backend/tests/routers/test_classification_key_resolution.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from app.routers.classification import _classification_provider_to_byok, _build_llm_registry
+
+
+def test_provider_mapping_groq():
+    assert _classification_provider_to_byok("groq") == "groq"
+
+
+def test_provider_mapping_ollama_cloud():
+    assert _classification_provider_to_byok("ollama_cloud") == "ollama_cloud"
+
+
+def test_provider_mapping_ollama_local_returns_none():
+    assert _classification_provider_to_byok("ollama_local") is None
+
+
+def test_provider_mapping_unknown_returns_none():
+    assert _classification_provider_to_byok("some_unknown_provider") is None
+
+
+def test_build_registry_groq_with_key():
+    registry = _build_llm_registry("groq", "my-groq-key")
+    assert registry.has("groq")
+
+
+def test_build_registry_groq_without_key_not_registered():
+    registry = _build_llm_registry("groq", None)
+    assert not registry.has("groq")
+
+
+def test_build_registry_ollama_local_always_registered():
+    with patch("app.routers.classification.settings") as mock_settings:
+        mock_settings.OLLAMA_LOCAL_BASE_URL = "http://localhost:11434/v1"
+        registry = _build_llm_registry("ollama_local", None)
+    assert registry.has("ollama_local")
+
+
+def test_build_registry_ollama_cloud_with_key():
+    with patch("app.routers.classification.settings") as mock_settings:
+        mock_settings.OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
+        registry = _build_llm_registry("ollama_cloud", "cloud-key-abc")
+    assert registry.has("ollama_cloud")

--- a/backend/tests/routers/test_documents_cdm_router.py
+++ b/backend/tests/routers/test_documents_cdm_router.py
@@ -107,9 +107,10 @@ async def test_upload_cdm_writes_all_four_tables(client: AsyncClient, test_db: A
             {ParserKind.LLAMAPARSE: AsyncMock(side_effect=fake_run_llamaparse)},
         ),
         patch(
-            "app.dependencies.documents.get_llamaparse_client",
-            return_value=MagicMock(),
+            "app.routers.documents.resolve_api_key",
+            new=AsyncMock(return_value="test-api-key"),
         ),
+        patch("llama_cloud.AsyncLlamaCloud", MagicMock(return_value=MagicMock())),
         patch("app.database.AsyncSessionLocal", mock_session_factory),
     ):
         response = await client.post(
@@ -172,7 +173,7 @@ async def test_upload_always_uses_cdm_regardless_of_flag(client: AsyncClient, te
         headers={"Authorization": f"Bearer {token}"},
         data={
             "project_id": project_id,
-            "parser_type": "llamaparse",
+            "parser_type": "simple",
             "title": "Always CDM Test Doc",
         },
         files=[("file", ("test.pdf", MINIMAL_PDF, "application/pdf"))],

--- a/backend/tests/routers/test_extraction_credentials.py
+++ b/backend/tests/routers/test_extraction_credentials.py
@@ -1,0 +1,66 @@
+"""Tests for extraction router credentials resolution."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from app.routers.extraction import _resolve_credentials_from_settings
+
+USER_ID = uuid4()
+
+
+def _make_repo(encrypted_value=None):
+    """Create a mock ProviderKeyRepository."""
+    repo = AsyncMock()
+    if encrypted_value:
+        key_record = MagicMock()
+        key_record.api_key_encrypted = encrypted_value
+        repo.get_for_provider.return_value = key_record
+    else:
+        repo.get_for_provider.return_value = None
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_llamaextract_returns_db_key():
+    """LlamaExtract should resolve key from DB (decrypted)."""
+    from app.utils.encryption import encrypt
+    repo = _make_repo(encrypt("llamacloud-key-456"))
+    result = await _resolve_credentials_from_settings(repo, USER_ID, "llamaextract")
+    assert result == {"api_key": "llamacloud-key-456"}
+    repo.get_for_provider.assert_awaited_once_with(
+        user_id=USER_ID, provider="llama_cloud", project_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_llamaextract_falls_back_to_env():
+    """LlamaExtract should fall back to LLAMA_CLOUD_KEY env var."""
+    repo = _make_repo()
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.LLAMA_CLOUD_KEY = "env-llama-key"
+        mock_settings.GROQ_API_KEY = ""
+        mock_settings.VISION_AGENT_API_KEY = ""
+        mock_settings.OLLAMA_CLOUD_API_KEY = ""
+        result = await _resolve_credentials_from_settings(repo, USER_ID, "llamaextract")
+    assert result == {"api_key": "env-llama-key"}
+
+
+@pytest.mark.asyncio
+async def test_ollama_returns_endpoint_and_key():
+    """Ollama should return both endpoint and api_key."""
+    from app.utils.encryption import encrypt
+    repo = _make_repo(encrypt("ollama-key-789"))
+    with patch("app.routers.extraction.settings") as mock_settings:
+        mock_settings.OLLAMA_ENDPOINT = "http://myollama:11434/v1"
+        result = await _resolve_credentials_from_settings(repo, USER_ID, "ollama")
+    assert result["endpoint"] == "http://myollama:11434/v1"
+    assert result["api_key"] == "ollama-key-789"
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_returns_empty_dict():
+    """Unknown extraction methods should return empty dict."""
+    repo = AsyncMock()
+    result = await _resolve_credentials_from_settings(repo, USER_ID, "unknown_method")
+    assert result == {}
+    repo.get_for_provider.assert_not_called()

--- a/backend/tests/schemas/test_provider_key_schema.py
+++ b/backend/tests/schemas/test_provider_key_schema.py
@@ -1,0 +1,13 @@
+"""Tests for provider key schema."""
+from app.schemas.provider_key import SUPPORTED_PROVIDERS, PROVIDER_MODELS
+
+
+def test_new_providers_in_supported_list():
+    for p in ("groq", "llama_cloud", "landing_ai", "ollama_cloud"):
+        assert p in SUPPORTED_PROVIDERS, f"{p} missing from SUPPORTED_PROVIDERS"
+
+
+def test_new_providers_in_models_dict():
+    for p in ("groq", "llama_cloud", "landing_ai", "ollama_cloud"):
+        assert p in PROVIDER_MODELS, f"{p} missing from PROVIDER_MODELS"
+        assert PROVIDER_MODELS[p]["requires_key"] is True

--- a/backend/tests/services/test_resolve_api_key.py
+++ b/backend/tests/services/test_resolve_api_key.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from app.services.provider_key_service import resolve_api_key
+
+USER_ID = uuid4()
+
+
+def _make_repo(encrypted_value=None):
+    repo = AsyncMock()
+    if encrypted_value:
+        key_record = MagicMock()
+        key_record.api_key_encrypted = encrypted_value
+        repo.get_for_provider.return_value = key_record
+    else:
+        repo.get_for_provider.return_value = None
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_decrypted_db_key():
+    from app.utils.encryption import encrypt
+    plaintext = "sk-db-key-123"
+    repo = _make_repo(encrypt(plaintext))
+    result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result == plaintext
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_back_to_env_var_when_no_db_key():
+    repo = _make_repo()
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.GROQ_API_KEY = "env-groq-key"
+        mock_settings.LLAMA_CLOUD_KEY = ""
+        mock_settings.VISION_AGENT_API_KEY = ""
+        mock_settings.OLLAMA_CLOUD_API_KEY = ""
+        result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result == "env-groq-key"
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_when_env_var_is_empty():
+    repo = _make_repo()
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.GROQ_API_KEY = ""
+        mock_settings.LLAMA_CLOUD_KEY = ""
+        mock_settings.VISION_AGENT_API_KEY = ""
+        mock_settings.OLLAMA_CLOUD_API_KEY = ""
+        result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_for_db_only_provider_with_no_key():
+    # voyage has no env-var fallback
+    repo = _make_repo()
+    result = await resolve_api_key(repo, USER_ID, "voyage")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_key_takes_precedence_over_env_var():
+    from app.utils.encryption import encrypt
+    plaintext = "sk-db-key-wins"
+    repo = _make_repo(encrypt(plaintext))
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.GROQ_API_KEY = "env-key-should-be-ignored"
+        result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result == plaintext

--- a/docs/superpowers/plans/2026-05-25-ollama-extractor.md
+++ b/docs/superpowers/plans/2026-05-25-ollama-extractor.md
@@ -1,0 +1,1347 @@
+# Ollama Extractor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `OllamaExtractor` — a structured extraction adapter that calls any Ollama-compatible endpoint (local, self-hosted, or cloud) using Ollama's OpenAI-compatible REST API.
+
+**Architecture:** `OllamaExtractor` inherits from `OpenAICompatMixin` (new shared client + JSON completion logic) and `DataExtractor` (existing port). The mixin owns all openai-SDK concerns; the extractor owns prompt building, schema augmentation, citation extraction, and `ExtractionOutput` assembly. All LLM context helpers (`build_extraction_context`, `augment_schema_with_sources`, `strip_source_fields`) are already implemented in `llm_context.py` and need no changes.
+
+**Tech Stack:** Python 3.12, `openai` SDK v2.16.0 (already installed), FastAPI async, React 18 + TypeScript, shadcn/ui + Tailwind CSS.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `backend/app/ports/data_extraction.py` | Add `ExtractionError` |
+| Modify | `backend/app/config.py` | Add `OLLAMA_ENDPOINT: str = ""` |
+| Create | `backend/app/adapters/extraction/openai_compat_mixin.py` | `OpenAICompatMixin._build_client` + `_call_model` |
+| Create | `backend/app/adapters/extraction/ollama.py` | `OllamaExtractor` — prompt building + extract() |
+| Modify | `backend/app/adapters/extraction/registry.py` | Register ollama in `get_extractor()` factory |
+| Create | `backend/tests/adapters/extraction/test_ollama_extractor.py` | Unit tests (mixin + extractor + registry) |
+| Modify | `frontend/src/components/extraction/ExtractionForm.tsx` | Ollama config section; hide LlamaExtract-only fields when ollama is selected |
+
+No router, service, repository, ORM, migration, or schema changes are needed — all of those were already wired up in the general CDM extraction spec.
+
+---
+
+### Task 1: ExtractionError + OLLAMA_ENDPOINT setting
+
+**Files:**
+- Modify: `backend/app/ports/data_extraction.py`
+- Modify: `backend/app/config.py`
+
+- [ ] **Step 1: Add `ExtractionError` to the port file**
+
+  Open `backend/app/ports/data_extraction.py` and add after the imports, before the dataclass definitions:
+
+  ```python
+  class ExtractionError(Exception):
+      """Raised by LLM extraction adapters for recoverable extraction failures."""
+  ```
+
+  The file after the change starts with:
+  ```python
+  from abc import ABC, abstractmethod
+  from dataclasses import dataclass, field
+  from typing import Any
+  from uuid import UUID
+
+
+  class ExtractionError(Exception):
+      """Raised by LLM extraction adapters for recoverable extraction failures."""
+
+
+  @dataclass(frozen=True)
+  class FieldCitation:
+  ...
+  ```
+
+- [ ] **Step 2: Add `OLLAMA_ENDPOINT` to settings**
+
+  Open `backend/app/config.py`. After the `OLLAMA_CLOUD_API_KEY` line (≈ line 57), add:
+
+  ```python
+      # Ollama — extraction endpoint
+      # Set to enable OllamaExtractor. Empty = extractor shows as "not configured".
+      # Example: OLLAMA_ENDPOINT=http://localhost:11434/v1
+      OLLAMA_ENDPOINT: str = ""
+  ```
+
+- [ ] **Step 3: Verify imports work**
+
+  ```bash
+  uv run --directory backend python -c "
+  from app.ports.data_extraction import ExtractionError
+  from app.config import settings
+  assert issubclass(ExtractionError, Exception)
+  assert hasattr(settings, 'OLLAMA_ENDPOINT')
+  print('OK')
+  "
+  ```
+
+  Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add backend/app/ports/data_extraction.py backend/app/config.py
+  git commit -m "feat(extraction): add ExtractionError and OLLAMA_ENDPOINT setting"
+  ```
+
+---
+
+### Task 2: OpenAICompatMixin
+
+**Files:**
+- Create: `backend/app/adapters/extraction/openai_compat_mixin.py`
+- Create (tests): `backend/tests/adapters/extraction/test_ollama_extractor.py`
+
+- [ ] **Step 1: Write the failing mixin tests**
+
+  Create `backend/tests/adapters/extraction/test_ollama_extractor.py`:
+
+  ```python
+  """Unit tests for OpenAICompatMixin and OllamaExtractor."""
+  import json
+  import pytest
+  from unittest.mock import AsyncMock, MagicMock, patch
+
+  from app.ports.data_extraction import ExtractionError
+
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  PARSE_RUN_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+  def _make_parsed_doc(blocks=None):
+      from app.cdm.models import ParsedDocument, Page
+      blocks = blocks or []
+      pages = [Page(index=0, block_ids=[])]
+      return ParsedDocument(
+          id="doc-1",
+          source_document_id="src-1",
+          parse_run_id=PARSE_RUN_ID,
+          page_count=1,
+          pages=pages,
+          blocks=blocks,
+      )
+
+
+  def _mock_response(content: str):
+      response = MagicMock()
+      response.choices = [MagicMock()]
+      response.choices[0].message.content = content
+      return response
+
+
+  # ---------------------------------------------------------------------------
+  # OpenAICompatMixin
+  # ---------------------------------------------------------------------------
+
+  class TestBuildClient:
+      def test_sets_base_url_and_default_api_key(self):
+          from app.adapters.extraction.openai_compat_mixin import OpenAICompatMixin
+
+          class Concrete(OpenAICompatMixin):
+              pass
+
+          mixin = Concrete()
+          client = mixin._build_client("http://localhost:11434/v1", None)
+          assert "localhost:11434" in str(client.base_url)
+          assert client.api_key == "ollama"
+
+      def test_uses_provided_api_key(self):
+          from app.adapters.extraction.openai_compat_mixin import OpenAICompatMixin
+
+          class Concrete(OpenAICompatMixin):
+              pass
+
+          mixin = Concrete()
+          client = mixin._build_client("http://localhost:11434/v1", "my-key")
+          assert client.api_key == "my-key"
+
+
+  class TestCallModel:
+      @pytest.fixture
+      def mixin(self):
+          from app.adapters.extraction.openai_compat_mixin import OpenAICompatMixin
+
+          class Concrete(OpenAICompatMixin):
+              pass
+
+          return Concrete()
+
+      async def test_json_schema_mode_sends_response_format(self, mixin):
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              return_value=_mock_response('{"key": "val"}')
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              result = await mixin._call_model(
+                  messages=[{"role": "user", "content": "x"}],
+                  augmented_schema={"type": "object", "properties": {}},
+                  config={
+                      "model": "llama3.2:8b",
+                      "endpoint": "http://localhost:11434/v1",
+                      "structured_output_mode": "json_schema",
+                  },
+              )
+          call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+          assert call_kwargs["response_format"]["type"] == "json_schema"
+          assert call_kwargs["response_format"]["json_schema"]["name"] == "extraction_result"
+          assert call_kwargs["response_format"]["json_schema"]["strict"] is True
+          assert result == {"key": "val"}
+
+      async def test_json_mode_sends_json_object_response_format(self, mixin):
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              return_value=_mock_response('{"x": 1}')
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              await mixin._call_model(
+                  messages=[],
+                  augmented_schema={},
+                  config={
+                      "model": "m",
+                      "endpoint": "http://localhost:11434/v1",
+                      "structured_output_mode": "json_mode",
+                  },
+              )
+          call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+          assert call_kwargs["response_format"] == {"type": "json_object"}
+
+      async def test_prompt_only_mode_omits_response_format(self, mixin):
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              return_value=_mock_response('{"x": 1}')
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              await mixin._call_model(
+                  messages=[],
+                  augmented_schema={},
+                  config={
+                      "model": "m",
+                      "endpoint": "http://localhost:11434/v1",
+                      "structured_output_mode": "prompt_only",
+                  },
+              )
+          call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+          assert "response_format" not in call_kwargs
+
+      async def test_non_json_response_raises_extraction_error(self, mixin):
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              return_value=_mock_response("Sorry, I cannot extract this.")
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              with pytest.raises(ExtractionError, match="non-JSON"):
+                  await mixin._call_model(
+                      messages=[],
+                      augmented_schema={},
+                      config={
+                          "model": "m",
+                          "endpoint": "http://localhost:11434/v1",
+                          "structured_output_mode": "prompt_only",
+                      },
+                  )
+
+      async def test_connection_error_raises_extraction_error(self, mixin):
+          import openai
+
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              side_effect=openai.APIConnectionError(request=MagicMock())
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              with pytest.raises(ExtractionError, match="Cannot connect to Ollama"):
+                  await mixin._call_model(
+                      messages=[],
+                      augmented_schema={},
+                      config={
+                          "model": "m",
+                          "endpoint": "http://localhost:11434/v1",
+                          "structured_output_mode": "json_schema",
+                      },
+                  )
+
+      async def test_bad_request_error_logs_warning_and_reraises(self, mixin):
+          import openai
+
+          mock_client = AsyncMock()
+          bad_request = openai.BadRequestError(
+              message="unsupported",
+              response=MagicMock(status_code=400, headers={}),
+              body={"error": {"message": "unsupported"}},
+          )
+          mock_client.chat.completions.create = AsyncMock(side_effect=bad_request)
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              with pytest.raises(openai.BadRequestError):
+                  await mixin._call_model(
+                      messages=[],
+                      augmented_schema={},
+                      config={
+                          "model": "m",
+                          "endpoint": "http://localhost:11434/v1",
+                          "structured_output_mode": "json_schema",
+                      },
+                  )
+
+      async def test_temperature_passed_to_api(self, mixin):
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              return_value=_mock_response('{}')
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              await mixin._call_model(
+                  messages=[],
+                  augmented_schema={},
+                  config={
+                      "model": "m",
+                      "endpoint": "http://localhost:11434/v1",
+                      "temperature": 0.7,
+                      "structured_output_mode": "prompt_only",
+                  },
+              )
+          call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+          assert call_kwargs["temperature"] == 0.7
+
+      async def test_default_temperature_is_zero(self, mixin):
+          mock_client = AsyncMock()
+          mock_client.chat.completions.create = AsyncMock(
+              return_value=_mock_response('{}')
+          )
+          with patch.object(mixin, "_build_client", return_value=mock_client):
+              await mixin._call_model(
+                  messages=[],
+                  augmented_schema={},
+                  config={
+                      "model": "m",
+                      "endpoint": "http://localhost:11434/v1",
+                      "structured_output_mode": "prompt_only",
+                  },
+              )
+          call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+          assert call_kwargs["temperature"] == 0.0
+  ```
+
+- [ ] **Step 2: Run tests — verify they all fail**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py::TestBuildClient tests/adapters/extraction/test_ollama_extractor.py::TestCallModel -v
+  ```
+
+  Expected: ERRORS or FAILURES (module not found / import error).
+
+- [ ] **Step 3: Create `openai_compat_mixin.py`**
+
+  Create `backend/app/adapters/extraction/openai_compat_mixin.py`:
+
+  ```python
+  """OpenAI-compatible REST protocol mixin.
+
+  Shared by OllamaExtractor and future Together/Groq/OpenAI adapters.
+  """
+  import json
+  import logging
+
+  import openai
+  from openai import AsyncOpenAI
+
+  from app.ports.data_extraction import ExtractionError
+
+  logger = logging.getLogger(__name__)
+
+
+  class OpenAICompatMixin:
+      """Provides _build_client() and _call_model() for OpenAI-compatible endpoints."""
+
+      def _build_client(self, endpoint: str, api_key: str | None) -> AsyncOpenAI:
+          return AsyncOpenAI(
+              base_url=endpoint,
+              api_key=api_key or "ollama",
+          )
+
+      async def _call_model(
+          self,
+          messages: list[dict],
+          augmented_schema: dict,
+          config: dict,
+      ) -> dict:
+          endpoint = config.get("endpoint", "http://localhost:11434/v1")
+          api_key = config.get("api_key")
+          model = config.get("model")
+          temperature = config.get("temperature", 0.0)
+          mode = config.get("structured_output_mode", "json_schema")
+
+          client = self._build_client(endpoint, api_key)
+
+          kwargs: dict = {
+              "model": model,
+              "messages": messages,
+              "temperature": temperature,
+          }
+
+          if mode == "json_schema":
+              kwargs["response_format"] = {
+                  "type": "json_schema",
+                  "json_schema": {
+                      "name": "extraction_result",
+                      "strict": True,
+                      "schema": augmented_schema,
+                  },
+              }
+          elif mode == "json_mode":
+              kwargs["response_format"] = {"type": "json_object"}
+          # prompt_only: no response_format key
+
+          try:
+              response = await client.chat.completions.create(**kwargs)
+          except openai.BadRequestError as e:
+              if e.status_code in (400, 422):
+                  logger.warning(
+                      "Structured output rejected by model (HTTP %s). "
+                      "Consider switching structured_output_mode to 'json_mode'.",
+                      e.status_code,
+                  )
+              raise
+          except openai.APIConnectionError as e:
+              raise ExtractionError(
+                  f"Cannot connect to Ollama endpoint {endpoint!r}. Is Ollama running?"
+              ) from e
+
+          raw_content = response.choices[0].message.content
+          try:
+              return json.loads(raw_content)
+          except (json.JSONDecodeError, ValueError) as exc:
+              raise ExtractionError(
+                  f"Model returned non-JSON response: {raw_content[:200]!r}"
+              ) from exc
+  ```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py::TestBuildClient tests/adapters/extraction/test_ollama_extractor.py::TestCallModel -v
+  ```
+
+  Expected: All PASSED.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add backend/app/adapters/extraction/openai_compat_mixin.py backend/tests/adapters/extraction/test_ollama_extractor.py
+  git commit -m "feat(extraction): add OpenAICompatMixin with _build_client and _call_model"
+  ```
+
+---
+
+### Task 3: OllamaExtractor
+
+**Files:**
+- Create: `backend/app/adapters/extraction/ollama.py`
+- Modify (tests): `backend/tests/adapters/extraction/test_ollama_extractor.py`
+
+- [ ] **Step 1: Append OllamaExtractor tests to the test file**
+
+  Append to `backend/tests/adapters/extraction/test_ollama_extractor.py`:
+
+  ```python
+  # ---------------------------------------------------------------------------
+  # OllamaExtractor
+  # ---------------------------------------------------------------------------
+
+  class TestOllamaExtractorProperties:
+      def test_extractor_type(self):
+          from app.adapters.extraction.ollama import OllamaExtractor
+          assert OllamaExtractor().extractor_type == "ollama"
+
+      def test_display_name(self):
+          from app.adapters.extraction.ollama import OllamaExtractor
+          assert OllamaExtractor().display_name == "Ollama"
+
+
+  class TestBuildMessages:
+      @pytest.fixture
+      def extractor(self):
+          from app.adapters.extraction.ollama import OllamaExtractor
+          return OllamaExtractor()
+
+      def test_uses_default_system_prompt(self, extractor):
+          from app.adapters.extraction.ollama import DEFAULT_SYSTEM_PROMPT
+          msgs = extractor._build_messages({"type": "object"}, "ctx", {})
+          assert msgs[0]["role"] == "system"
+          assert msgs[0]["content"] == DEFAULT_SYSTEM_PROMPT
+
+      def test_uses_custom_system_prompt(self, extractor):
+          msgs = extractor._build_messages(
+              {"type": "object"}, "ctx", {"system_prompt": "Custom system"}
+          )
+          assert msgs[0]["content"] == "Custom system"
+
+      def test_schema_json_interpolated_in_user_message(self, extractor):
+          aug_schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+          msgs = extractor._build_messages(aug_schema, "doc text", {})
+          user_content = msgs[1]["content"]
+          assert json.dumps(aug_schema, indent=2) in user_content
+
+      def test_document_context_interpolated_in_user_message(self, extractor):
+          msgs = extractor._build_messages({"type": "object"}, "the document", {})
+          assert "the document" in msgs[1]["content"]
+
+      def test_no_unresolved_format_placeholders(self, extractor):
+          msgs = extractor._build_messages({"type": "object"}, "ctx", {})
+          user_content = msgs[1]["content"]
+          # {schema_json} and {document_context} must have been replaced
+          assert "{schema_json}" not in user_content
+          assert "{document_context}" not in user_content
+
+      def test_custom_user_prompt_template(self, extractor):
+          msgs = extractor._build_messages(
+              {"type": "object"},
+              "ctx",
+              {"user_prompt_template": "Schema: {schema_json} | Doc: {document_context}"},
+          )
+          assert msgs[1]["content"].startswith("Schema:")
+          assert "ctx" in msgs[1]["content"]
+
+      def test_messages_have_two_items(self, extractor):
+          msgs = extractor._build_messages({"type": "object"}, "ctx", {})
+          assert len(msgs) == 2
+          assert msgs[0]["role"] == "system"
+          assert msgs[1]["role"] == "user"
+
+
+  class TestOllamaExtractorExtract:
+      @pytest.fixture
+      def extractor(self):
+          from app.adapters.extraction.ollama import OllamaExtractor
+          return OllamaExtractor()
+
+      @pytest.fixture
+      def parsed_doc(self):
+          return _make_parsed_doc()
+
+      async def test_returns_correct_extraction_output(self, extractor, parsed_doc):
+          from uuid import UUID
+          schema = {"type": "object", "properties": {"total": {"type": "number"}}}
+          raw_response = {"total": 500, "total__source": {"page_index": 1}}
+
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value=raw_response):
+              output = await extractor.extract(parsed_doc, schema, {"model": "llama3.2:8b"})
+
+          assert output.structured_data == {"total": 500}
+          assert output.source_parse_run_id == UUID(PARSE_RUN_ID)
+          assert output.provider_response_raw is None
+          assert output.extraction_metadata["model"] == "llama3.2:8b"
+          assert "latency_ms" in output.extraction_metadata
+          assert isinstance(output.extraction_metadata["latency_ms"], int)
+
+      async def test_citations_populated_from_source_fields(self, extractor, parsed_doc):
+          schema = {"type": "object", "properties": {"vendor": {"type": "string"}}}
+          raw_response = {
+              "vendor": "Acme Corp",
+              "vendor__source": {"page_index": 2, "block_id": "blk-1"},
+          }
+
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value=raw_response):
+              output = await extractor.extract(parsed_doc, schema, {"model": "m"})
+
+          assert len(output.citations) == 1
+          assert output.citations[0].field_path == "vendor"
+          assert output.citations[0].page_index == 2
+          assert output.citations[0].block_ids == ["blk-1"]
+
+      async def test_inject_block_ids_false_by_default(self, extractor, parsed_doc):
+          schema = {"type": "object", "properties": {}}
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value={}) as mock_call, \
+               patch("app.adapters.extraction.ollama.build_extraction_context") as mock_ctx:
+              mock_ctx.return_value = "ctx"
+              await extractor.extract(parsed_doc, schema, {"model": "m"})
+
+          mock_ctx.assert_called_once_with(parsed_doc, False)
+
+      async def test_inject_block_ids_true_when_configured(self, extractor, parsed_doc):
+          schema = {"type": "object", "properties": {}}
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value={}) as mock_call, \
+               patch("app.adapters.extraction.ollama.build_extraction_context") as mock_ctx:
+              mock_ctx.return_value = "ctx"
+              await extractor.extract(parsed_doc, schema, {"model": "m", "inject_block_ids": True})
+
+          mock_ctx.assert_called_once_with(parsed_doc, True)
+
+      async def test_call_model_receives_augmented_schema(self, extractor, parsed_doc):
+          schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value={}) as mock_call:
+              await extractor.extract(parsed_doc, schema, {"model": "m"})
+
+          _, augmented_schema, _ = mock_call.call_args.args
+          assert "x__source" in augmented_schema["properties"]
+
+      async def test_call_model_receives_cfg(self, extractor, parsed_doc):
+          schema = {"type": "object", "properties": {}}
+          cfg = {"model": "llama3.2:8b", "structured_output_mode": "json_mode"}
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value={}) as mock_call:
+              await extractor.extract(parsed_doc, schema, cfg)
+
+          _, _, passed_cfg = mock_call.call_args.args
+          assert passed_cfg["structured_output_mode"] == "json_mode"
+
+      async def test_empty_config_uses_defaults(self, extractor, parsed_doc):
+          schema = {"type": "object", "properties": {}}
+          with patch.object(extractor, "_call_model", new_callable=AsyncMock, return_value={}):
+              output = await extractor.extract(parsed_doc, schema)  # config=None
+
+          assert output.structured_data == {}
+          assert output.citations == []
+  ```
+
+- [ ] **Step 2: Run new tests — verify they fail**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py::TestOllamaExtractorProperties tests/adapters/extraction/test_ollama_extractor.py::TestBuildMessages tests/adapters/extraction/test_ollama_extractor.py::TestOllamaExtractorExtract -v
+  ```
+
+  Expected: ERRORS (module `app.adapters.extraction.ollama` not found).
+
+- [ ] **Step 3: Create `ollama.py`**
+
+  Create `backend/app/adapters/extraction/ollama.py`:
+
+  ```python
+  """Ollama extraction adapter.
+
+  Calls any Ollama-compatible endpoint using the OpenAI REST protocol.
+  Endpoint and API key are per-run config — not global settings.
+  """
+  import json
+  import time
+  from typing import Any
+  from uuid import UUID
+
+  from app.adapters.extraction.llm_context import (
+      augment_schema_with_sources,
+      build_extraction_context,
+      strip_source_fields,
+  )
+  from app.adapters.extraction.openai_compat_mixin import OpenAICompatMixin
+  from app.cdm.models import ParsedDocument
+  from app.ports.data_extraction import DataExtractor, ExtractionOutput
+
+  DEFAULT_SYSTEM_PROMPT = (
+      "You are a structured data extraction assistant. Extract information from the provided "
+      "document according to the given JSON schema. Be precise and faithful to the source text. "
+      "Only extract values that are explicitly present in the document."
+  )
+
+  DEFAULT_USER_PROMPT_TEMPLATE = """\
+  Extract structured data from the following document according to this JSON schema:
+
+  <schema>
+  {schema_json}
+  </schema>
+
+  For each field you extract, include a corresponding `{{field_name}}__source` object \
+  with `page_index` (integer, required) and `block_id` (string, if available) indicating \
+  where in the document you found the value.
+
+  <document>
+  {document_context}
+  </document>
+
+  Return a single JSON object that conforms to the schema (including __source fields)."""
+
+
+  class OllamaExtractor(OpenAICompatMixin, DataExtractor):
+      """Structured extraction via Ollama's OpenAI-compatible REST API."""
+
+      @property
+      def extractor_type(self) -> str:
+          return "ollama"
+
+      @property
+      def display_name(self) -> str:
+          return "Ollama"
+
+      def _build_messages(
+          self,
+          aug_schema: dict[str, Any],
+          context: str,
+          cfg: dict[str, Any],
+      ) -> list[dict[str, str]]:
+          system_prompt = cfg.get("system_prompt") or DEFAULT_SYSTEM_PROMPT
+          schema_json = json.dumps(aug_schema, indent=2)
+          template = cfg.get("user_prompt_template") or DEFAULT_USER_PROMPT_TEMPLATE
+          user_content = template.format(schema_json=schema_json, document_context=context)
+          return [
+              {"role": "system", "content": system_prompt},
+              {"role": "user", "content": user_content},
+          ]
+
+      async def extract(
+          self,
+          parsed_document: ParsedDocument,
+          schema: dict[str, Any],
+          config: dict[str, Any] | None = None,
+      ) -> ExtractionOutput:
+          cfg = config or {}
+          context = build_extraction_context(
+              parsed_document, cfg.get("inject_block_ids", False)
+          )
+          aug_schema = augment_schema_with_sources(schema)
+          messages = self._build_messages(aug_schema, context, cfg)
+
+          t0 = time.monotonic()
+          raw = await self._call_model(messages, aug_schema, cfg)
+          latency_ms = int((time.monotonic() - t0) * 1000)
+
+          structured_data, citations = strip_source_fields(raw, schema)
+
+          return ExtractionOutput(
+              structured_data=structured_data,
+              source_parse_run_id=UUID(parsed_document.parse_run_id),
+              citations=citations,
+              provider_response_raw=None,
+              extraction_metadata={"model": cfg.get("model"), "latency_ms": latency_ms},
+          )
+  ```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py::TestOllamaExtractorProperties tests/adapters/extraction/test_ollama_extractor.py::TestBuildMessages tests/adapters/extraction/test_ollama_extractor.py::TestOllamaExtractorExtract -v
+  ```
+
+  Expected: All PASSED.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add backend/app/adapters/extraction/ollama.py backend/tests/adapters/extraction/test_ollama_extractor.py
+  git commit -m "feat(extraction): add OllamaExtractor with prompt building and extract()"
+  ```
+
+---
+
+### Task 4: Register OllamaExtractor in factory
+
+**Files:**
+- Modify: `backend/app/adapters/extraction/registry.py`
+- Modify (tests): `backend/tests/adapters/extraction/test_ollama_extractor.py`
+
+- [ ] **Step 1: Append registry tests**
+
+  Append to `backend/tests/adapters/extraction/test_ollama_extractor.py`:
+
+  ```python
+  # ---------------------------------------------------------------------------
+  # Registry
+  # ---------------------------------------------------------------------------
+
+  class TestRegistryOllama:
+      def test_get_extractor_returns_ollama_extractor(self):
+          from app.adapters.extraction.ollama import OllamaExtractor
+          from app.adapters.extraction.registry import get_extractor
+
+          extractor = get_extractor("ollama", {})
+          assert isinstance(extractor, OllamaExtractor)
+          assert extractor.extractor_type == "ollama"
+
+      def test_ollama_extractor_needs_no_credentials(self):
+          from app.adapters.extraction.registry import get_extractor
+
+          # No credentials, no dependencies — should construct fine
+          extractor = get_extractor("ollama", {})
+          assert extractor is not None
+  ```
+
+- [ ] **Step 2: Run new tests — verify they fail**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py::TestRegistryOllama -v
+  ```
+
+  Expected: FAILED — `ValueError: Unknown extraction method: 'ollama'`.
+
+- [ ] **Step 3: Register ollama in `get_extractor()`**
+
+  Open `backend/app/adapters/extraction/registry.py`. Replace:
+
+  ```python
+      raise ValueError(f"Unknown extraction method: {method!r}")
+  ```
+
+  with:
+
+  ```python
+      if method == "ollama":
+          from app.adapters.extraction.ollama import OllamaExtractor
+          return OllamaExtractor()
+
+      raise ValueError(f"Unknown extraction method: {method!r}")
+  ```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py::TestRegistryOllama -v
+  ```
+
+  Expected: All PASSED.
+
+- [ ] **Step 5: Run full extraction test suite**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/ -v
+  ```
+
+  Expected: All PASSED (no regressions in registry, llm_context, or llamaextract tests).
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add backend/app/adapters/extraction/registry.py backend/tests/adapters/extraction/test_ollama_extractor.py
+  git commit -m "feat(extraction): register OllamaExtractor in factory"
+  ```
+
+---
+
+### Task 5: Frontend — Ollama config section in ExtractionForm
+
+**Files:**
+- Modify: `frontend/src/components/extraction/ExtractionForm.tsx`
+
+The current form shows Mode, PageRange, Citations, and Reasoning for all extractors — these are LlamaExtract-specific. This task:
+1. Guards all LlamaExtract-specific fields behind `extractionMethod === 'llamaextract'`
+2. Adds an Ollama-specific config section
+3. Builds the correct config dict per method in `handleRun`
+
+- [ ] **Step 1: Replace `ExtractionForm.tsx` with the updated implementation**
+
+  Replace the entire contents of `frontend/src/components/extraction/ExtractionForm.tsx`:
+
+  ```tsx
+  import { useState, useEffect } from 'react'
+  import type { ExtractionSchema, ExtractorInfo, RunExtractionRequest } from '@/types/extraction'
+  import { Button } from '@/components/ui/button'
+  import { Label } from '@/components/ui/label'
+  import { Input } from '@/components/ui/input'
+  import { Checkbox } from '@/components/ui/checkbox'
+  import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+  } from '@/components/ui/select'
+  import { Pencil, Play } from 'lucide-react'
+
+  interface ExtractionFormProps {
+    parseRunId: string
+    schemas: ExtractionSchema[]
+    extractors: ExtractorInfo[]
+    onRun: (request: RunExtractionRequest) => Promise<void>
+    onEditSchema?: (schema: ExtractionSchema) => void
+  }
+
+  type OllamaEndpointPreset = 'local' | 'cloud' | 'custom'
+
+  const OLLAMA_ENDPOINTS: Record<OllamaEndpointPreset, string> = {
+    local: 'http://localhost:11434/v1',
+    cloud: 'https://api.ollama.com/v1',
+    custom: '',
+  }
+
+  export function ExtractionForm({
+    parseRunId,
+    schemas,
+    extractors,
+    onRun,
+    onEditSchema,
+  }: ExtractionFormProps) {
+    const [schemaId, setSchemaId] = useState('')
+    const [extractionMethod, setExtractionMethod] = useState('')
+
+    // LlamaExtract config
+    const [extractionMode, setExtractionMode] = useState('MULTIMODAL')
+    const [citeSources, setCiteSources] = useState(false)
+    const [useReasoning, setUseReasoning] = useState(false)
+    const [pageRange, setPageRange] = useState('')
+    const [extractionTarget, setExtractionTarget] = useState('PER_DOC')
+    const [confidenceScores, setConfidenceScores] = useState(false)
+
+    // Ollama config
+    const [ollamaModel, setOllamaModel] = useState('')
+    const [ollamaEndpointPreset, setOllamaEndpointPreset] = useState<OllamaEndpointPreset>('local')
+    const [ollamaCustomEndpoint, setOllamaCustomEndpoint] = useState('')
+    const [ollamaApiKey, setOllamaApiKey] = useState('')
+    const [ollamaStructuredOutputMode, setOllamaStructuredOutputMode] = useState('json_schema')
+    const [ollamaInjectBlockIds, setOllamaInjectBlockIds] = useState(false)
+
+    const [isRunning, setIsRunning] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+      if (schemas.length > 0 && !schemaId) setSchemaId(schemas[0].id)
+    }, [schemas, schemaId])
+
+    useEffect(() => {
+      if (extractors.length > 0 && !extractionMethod) setExtractionMethod(extractors[0].extractionMethod)
+    }, [extractors, extractionMethod])
+
+    const selectedExtractor = extractors.find((e) => e.extractionMethod === extractionMethod)
+    const isConfigured = selectedExtractor?.configured ?? true
+
+    function getOllamaEndpoint(): string {
+      if (ollamaEndpointPreset === 'custom') return ollamaCustomEndpoint
+      return OLLAMA_ENDPOINTS[ollamaEndpointPreset]
+    }
+
+    const handleRun = async () => {
+      setError(null)
+
+      if (!schemaId) {
+        setError('Please select a schema')
+        return
+      }
+      if (!extractionMethod) {
+        setError('No extraction method available')
+        return
+      }
+      if (extractionMethod === 'ollama' && !ollamaModel.trim()) {
+        setError('Model name is required for Ollama')
+        return
+      }
+
+      let config: Record<string, unknown>
+
+      if (extractionMethod === 'llamaextract') {
+        config = { extraction_mode: extractionMode }
+        if (citeSources) config.cite_sources = true
+        if (useReasoning) config.use_reasoning = true
+        if (pageRange.trim()) config.page_range = pageRange.trim()
+        config.extraction_target = extractionTarget
+        if (confidenceScores) config.confidence_scores = true
+      } else if (extractionMethod === 'ollama') {
+        config = {
+          model: ollamaModel.trim(),
+          endpoint: getOllamaEndpoint(),
+          structured_output_mode: ollamaStructuredOutputMode,
+          inject_block_ids: ollamaInjectBlockIds,
+        }
+        if (ollamaApiKey.trim()) config.api_key = ollamaApiKey.trim()
+      } else {
+        config = {}
+      }
+
+      setIsRunning(true)
+      try {
+        await onRun({
+          parseRunId,
+          extractionSchemaId: schemaId,
+          extractionMethod,
+          config,
+        })
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to run extraction')
+      } finally {
+        setIsRunning(false)
+      }
+    }
+
+    const hasSchemas = schemas.length > 0
+    const hasExtractors = extractors.length > 0
+
+    if (!hasSchemas || !hasExtractors) {
+      return (
+        <div className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+          {!hasExtractors
+            ? 'No extraction methods available. Contact your administrator.'
+            : 'Create a schema first to run extractions.'}
+        </div>
+      )
+    }
+
+    const isOllamaModelMissing = extractionMethod === 'ollama' && !ollamaModel.trim()
+    const isRunDisabled = isRunning || !isConfigured || isOllamaModelMissing
+
+    return (
+      <div className="space-y-4">
+        {/* Schema + Method row */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label className="text-xs">Schema</Label>
+            <div className="flex items-center gap-1">
+              <Select value={schemaId} onValueChange={setSchemaId}>
+                <SelectTrigger className="h-9">
+                  <SelectValue placeholder="Select schema" />
+                </SelectTrigger>
+                <SelectContent>
+                  {schemas.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {onEditSchema && schemaId && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 shrink-0"
+                  title="Edit selected schema"
+                  onClick={() => {
+                    const selected = schemas.find((s) => s.id === schemaId)
+                    if (selected) onEditSchema(selected)
+                  }}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {extractors.length > 1 ? (
+            <div className="space-y-1.5">
+              <Label className="text-xs">Method</Label>
+              <Select value={extractionMethod} onValueChange={setExtractionMethod}>
+                <SelectTrigger className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {extractors.map((e) => (
+                    <SelectItem key={e.extractionMethod} value={e.extractionMethod} disabled={!e.configured}>
+                      {e.name}{!e.configured ? ' (not configured)' : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <Label className="text-xs">Method</Label>
+              <div className="h-9 flex items-center text-sm text-muted-foreground px-3 border rounded-md bg-muted/50">
+                {extractors[0]?.name}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* LlamaExtract-specific config */}
+        {extractionMethod === 'llamaextract' && (
+          <>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Mode</Label>
+                <Select value={extractionMode} onValueChange={setExtractionMode}>
+                  <SelectTrigger className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="FAST">Fast</SelectItem>
+                    <SelectItem value="BALANCED">Balanced</SelectItem>
+                    <SelectItem value="MULTIMODAL">Multimodal</SelectItem>
+                    <SelectItem value="PREMIUM">Premium</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label className="text-xs">Page Range</Label>
+                <Input
+                  value={pageRange}
+                  onChange={(e) => setPageRange(e.target.value)}
+                  placeholder="e.g. 1-5"
+                  className="h-9"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="extraction-target" className="text-xs">Target</Label>
+                <Select value={extractionTarget} onValueChange={setExtractionTarget}>
+                  <SelectTrigger id="extraction-target" className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="PER_DOC">Per Document</SelectItem>
+                    <SelectItem value="PER_PAGE">Per Page</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-end pb-2">
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="confidence-scores"
+                    checked={confidenceScores}
+                    onCheckedChange={(checked) => setConfidenceScores(checked === true)}
+                  />
+                  <Label htmlFor="confidence-scores" className="text-xs font-normal">
+                    Confidence Scores
+                  </Label>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="cite-sources-inline"
+                  checked={citeSources}
+                  onCheckedChange={(checked) => setCiteSources(checked === true)}
+                />
+                <Label htmlFor="cite-sources-inline" className="text-xs font-normal">
+                  Citations
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="use-reasoning-inline"
+                  checked={useReasoning}
+                  onCheckedChange={(checked) => setUseReasoning(checked === true)}
+                />
+                <Label htmlFor="use-reasoning-inline" className="text-xs font-normal">
+                  Reasoning
+                </Label>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Ollama-specific config */}
+        {extractionMethod === 'ollama' && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Model</Label>
+                <Input
+                  value={ollamaModel}
+                  onChange={(e) => setOllamaModel(e.target.value)}
+                  placeholder="e.g. llama3.2:8b"
+                  className="h-9"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Output Mode</Label>
+                <Select value={ollamaStructuredOutputMode} onValueChange={setOllamaStructuredOutputMode}>
+                  <SelectTrigger className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="json_schema">JSON Schema</SelectItem>
+                    <SelectItem value="json_mode">JSON Mode</SelectItem>
+                    <SelectItem value="prompt_only">Prompt Only</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Endpoint</Label>
+                <Select
+                  value={ollamaEndpointPreset}
+                  onValueChange={(v) => setOllamaEndpointPreset(v as OllamaEndpointPreset)}
+                >
+                  <SelectTrigger className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="local">Local (localhost:11434)</SelectItem>
+                    <SelectItem value="cloud">Ollama Cloud</SelectItem>
+                    <SelectItem value="custom">Custom</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {(ollamaEndpointPreset === 'cloud' || ollamaEndpointPreset === 'custom') && (
+                <div className="space-y-1.5">
+                  <Label className="text-xs">API Key</Label>
+                  <Input
+                    type="password"
+                    value={ollamaApiKey}
+                    onChange={(e) => setOllamaApiKey(e.target.value)}
+                    placeholder="Bearer token"
+                    className="h-9"
+                  />
+                </div>
+              )}
+            </div>
+
+            {ollamaEndpointPreset === 'custom' && (
+              <div className="space-y-1.5">
+                <Label className="text-xs">Custom Endpoint URL</Label>
+                <Input
+                  value={ollamaCustomEndpoint}
+                  onChange={(e) => setOllamaCustomEndpoint(e.target.value)}
+                  placeholder="https://your-ollama-host/v1"
+                  className="h-9"
+                />
+              </div>
+            )}
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="inject-block-ids"
+                checked={ollamaInjectBlockIds}
+                onCheckedChange={(checked) => setOllamaInjectBlockIds(checked === true)}
+              />
+              <Label htmlFor="inject-block-ids" className="text-xs font-normal">
+                Inject block IDs (block-level citations)
+              </Label>
+            </div>
+          </div>
+        )}
+
+        {/* Run button */}
+        <div className="flex items-center justify-between">
+          <div />
+          <Button onClick={handleRun} disabled={isRunDisabled} size="sm">
+            {isRunning ? (
+              'Running...'
+            ) : (
+              <>
+                <Play className="h-3.5 w-3.5 mr-1.5" />
+                Run Extraction
+              </>
+            )}
+          </Button>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {!isConfigured && (
+          <p className="text-xs text-amber-600">
+            {selectedExtractor?.name ?? 'This extractor'} is not configured. Contact your administrator.
+          </p>
+        )}
+      </div>
+    )
+  }
+  ```
+
+- [ ] **Step 2: Run TypeScript checks**
+
+  ```bash
+  npm --prefix frontend run build 2>&1 | tail -20
+  ```
+
+  Expected: Build succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Run frontend lint**
+
+  ```bash
+  npm --prefix frontend run lint
+  ```
+
+  Expected: No lint errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add frontend/src/components/extraction/ExtractionForm.tsx
+  git commit -m "feat(extraction): add Ollama config section to ExtractionForm"
+  ```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run the full backend test suite**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/ -v --tb=short
+  ```
+
+  Expected: All tests PASSED, no regressions.
+
+- [ ] **Step 2: Run the complete new test file**
+
+  ```bash
+  uv run --directory backend python -m pytest tests/adapters/extraction/test_ollama_extractor.py -v
+  ```
+
+  Expected: All PASSED.
+
+- [ ] **Step 3: Verify extractor catalogue includes ollama**
+
+  ```bash
+  uv run --directory backend python -c "
+  from app.adapters.extraction.registry import get_known_extractors, get_extractor
+  cat = get_known_extractors()
+  methods = [e['extraction_method'] for e in cat]
+  assert 'ollama' in methods, f'ollama not in catalogue: {methods}'
+  e = get_extractor('ollama', {})
+  assert e.extractor_type == 'ollama'
+  print('Catalogue:', methods)
+  print('Factory OK:', e)
+  "
+  ```
+
+  Expected: Prints `Catalogue: ['llamaextract', 'ollama']` and `Factory OK: ...`.
+
+- [ ] **Step 4: Run frontend tests**
+
+  ```bash
+  npm --prefix frontend run test -- --run
+  ```
+
+  Expected: All tests PASSED (no regressions).
+
+- [ ] **Step 5: Final commit if any loose files**
+
+  ```bash
+  git status
+  ```
+
+  Should be clean if each task was committed correctly.
+
+---
+
+## Self-Review Against Spec
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| Works with local Ollama (zero config beyond model name) | Task 3 — config defaults endpoint to localhost |
+| Works with Ollama cloud + self-hosted via endpoint/API key | Task 5 — frontend preset selector |
+| `response_format: json_schema` default; fallback to json_mode/prompt_only | Task 2 — mixin structured_output_mode handling |
+| `citations` with page-level provenance via `__source` fields | Task 3 — strip_source_fields produces FieldCitation list |
+| Default system/user prompts; fully customisable via config | Task 3 — DEFAULT_SYSTEM_PROMPT + DEFAULT_USER_PROMPT_TEMPLATE |
+| Config-only to add new compatible endpoint | Task 3 + 5 — endpoint is per-run config, no code change needed |
+| Registry key `"ollama"`, position first in preference order | Already in registry.py catalogue; UI ordering is a UI concern |
+| `ExtractionError` for malformed JSON | Task 2 — mixin raises ExtractionError |
+| `ExtractionError` for connection refused with Ollama hint | Task 2 — mixin catches APIConnectionError |
+| 400/422 logs warning + re-raises | Task 2 — mixin catches BadRequestError |
+| Missing `page_index` → `FieldCitation(page_index=None)` | Handled by existing `strip_source_fields` |
+| `inject_block_ids` config flag | Task 3 — passed to build_extraction_context |
+| `OLLAMA_ENDPOINT` setting | Task 1 |
+| Frontend endpoint presets (local/cloud/custom) | Task 5 |
+| Frontend API key field for cloud/custom | Task 5 |
+| Frontend structured_output_mode selector | Task 5 |
+
+**Gaps identified:** None. All spec requirements are covered.
+
+**Placeholder scan:** No TBD, TODO, or vague steps present. Every code step shows the complete implementation.
+
+**Type consistency check:**
+- `_call_model(messages: list[dict], augmented_schema: dict, config: dict) → dict` — used consistently in Task 2 (mixin) and Task 3 (extractor calls it with `messages, aug_schema, cfg`)
+- `ExtractionError` defined in Task 1 (ports file), imported in Task 2 (mixin)
+- `OllamaExtractor()` constructed with no args in Task 3 (implementation) and Task 4 (registry)
+- `DEFAULT_SYSTEM_PROMPT` and `DEFAULT_USER_PROMPT_TEMPLATE` exported from `ollama.py` and referenced in Task 3 tests
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-25-ollama-extractor.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-26-unified-provider-keys.md
+++ b/docs/superpowers/plans/2026-05-26-unified-provider-keys.md
@@ -1,0 +1,750 @@
+# Unified Provider Key Storage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the existing BYOK provider key system to cover extraction and classification providers, with env-var fallback, so all features resolve API keys through one code path.
+
+**Architecture:** Add 4 new providers to the registry schema; add a `resolve_api_key` module-level function to `provider_key_service.py` that checks the DB first (project-level → account-level) then falls back to env vars; replace the inline decrypt in the playground, the env-var reads in extraction, and the cached registry in classification with calls to this function.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy async, pytest, unittest.mock
+
+**Spec:** `docs/superpowers/specs/2026-05-26-unified-provider-keys-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `backend/app/schemas/provider_key.py` | Add 4 providers to `SUPPORTED_PROVIDERS` and `PROVIDER_MODELS` |
+| `backend/app/services/provider_key_service.py` | Add module-level `resolve_api_key` function |
+| `backend/app/routers/indexes.py` | Replace inline `repo.get_for_provider` + `decrypt` with `resolve_api_key` |
+| `backend/app/routers/extraction.py` | Make `_resolve_credentials_from_settings` async, wire `resolve_api_key` |
+| `backend/app/routers/classification.py` | Add `_classification_provider_to_byok`, `_build_llm_registry`; pass resolved key to background task |
+| `backend/tests/schemas/test_provider_key_schema.py` | New — registry coverage |
+| `backend/tests/services/test_resolve_api_key.py` | New — unit tests for `resolve_api_key` |
+| `backend/tests/routers/test_extraction_credentials.py` | New — unit tests for extraction resolver |
+| `backend/tests/routers/test_classification_key_resolution.py` | New — unit tests for classification helpers |
+
+---
+
+## Task 1: Extend the provider registry
+
+**Files:**
+- Modify: `backend/app/schemas/provider_key.py`
+- Create: `backend/tests/schemas/test_provider_key_schema.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/schemas/test_provider_key_schema.py
+from app.schemas.provider_key import SUPPORTED_PROVIDERS, PROVIDER_MODELS
+
+
+def test_new_providers_in_supported_list():
+    for p in ("groq", "llama_cloud", "landing_ai", "ollama_cloud"):
+        assert p in SUPPORTED_PROVIDERS, f"{p} missing from SUPPORTED_PROVIDERS"
+
+
+def test_new_providers_in_models_dict():
+    for p in ("groq", "llama_cloud", "landing_ai", "ollama_cloud"):
+        assert p in PROVIDER_MODELS, f"{p} missing from PROVIDER_MODELS"
+        assert PROVIDER_MODELS[p]["requires_key"] is True
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```
+uv run --directory backend python -m pytest tests/schemas/test_provider_key_schema.py -v
+```
+
+Expected: FAIL — "groq missing from SUPPORTED_PROVIDERS"
+
+- [ ] **Step 3: Extend the schema file**
+
+In `backend/app/schemas/provider_key.py`, replace the `SUPPORTED_PROVIDERS` list:
+
+```python
+SUPPORTED_PROVIDERS = [
+    "openai", "voyage", "local", "anthropic",
+    "groq", "llama_cloud", "landing_ai", "ollama_cloud",
+]
+```
+
+Add these four entries to `PROVIDER_MODELS` after the `"anthropic"` entry:
+
+```python
+    "groq": {
+        "display_name": "Groq",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+    "llama_cloud": {
+        "display_name": "LlamaIndex Cloud",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+    "landing_ai": {
+        "display_name": "Landing AI",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+    "ollama_cloud": {
+        "display_name": "Ollama Cloud",
+        "requires_key": True,
+        "models": [],
+        "dimensions": {},
+    },
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```
+uv run --directory backend python -m pytest tests/schemas/test_provider_key_schema.py -v
+```
+
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/schemas/provider_key.py backend/tests/schemas/test_provider_key_schema.py
+git commit -m "feat(provider-keys): add groq, llama_cloud, landing_ai, ollama_cloud to registry"
+```
+
+---
+
+## Task 2: Add `resolve_api_key` function
+
+**Files:**
+- Modify: `backend/app/services/provider_key_service.py`
+- Create: `backend/tests/services/test_resolve_api_key.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/services/test_resolve_api_key.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from app.services.provider_key_service import resolve_api_key
+
+USER_ID = uuid4()
+
+
+def _make_repo(encrypted_value=None):
+    repo = AsyncMock()
+    if encrypted_value:
+        key_record = MagicMock()
+        key_record.api_key_encrypted = encrypted_value
+        repo.get_for_provider.return_value = key_record
+    else:
+        repo.get_for_provider.return_value = None
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_decrypted_db_key():
+    from app.utils.encryption import encrypt
+    plaintext = "sk-db-key-123"
+    repo = _make_repo(encrypt(plaintext))
+    result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result == plaintext
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_back_to_env_var_when_no_db_key():
+    repo = _make_repo()
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.GROQ_API_KEY = "env-groq-key"
+        mock_settings.LLAMA_CLOUD_KEY = ""
+        mock_settings.VISION_AGENT_API_KEY = ""
+        mock_settings.OLLAMA_CLOUD_API_KEY = ""
+        result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result == "env-groq-key"
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_when_env_var_is_empty():
+    repo = _make_repo()
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.GROQ_API_KEY = ""
+        mock_settings.LLAMA_CLOUD_KEY = ""
+        mock_settings.VISION_AGENT_API_KEY = ""
+        mock_settings.OLLAMA_CLOUD_API_KEY = ""
+        result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_for_db_only_provider_with_no_key():
+    # voyage has no env-var fallback
+    repo = _make_repo()
+    result = await resolve_api_key(repo, USER_ID, "voyage")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_db_key_takes_precedence_over_env_var():
+    from app.utils.encryption import encrypt
+    plaintext = "sk-db-key-wins"
+    repo = _make_repo(encrypt(plaintext))
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.GROQ_API_KEY = "env-key-should-be-ignored"
+        result = await resolve_api_key(repo, USER_ID, "groq")
+    assert result == plaintext
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+```
+uv run --directory backend python -m pytest tests/services/test_resolve_api_key.py -v
+```
+
+Expected: FAIL — "cannot import name 'resolve_api_key'"
+
+- [ ] **Step 3: Add `resolve_api_key` to `backend/app/services/provider_key_service.py`**
+
+Add this import at the top of the file alongside existing imports:
+
+```python
+from app.config import settings
+```
+
+Add this function at the bottom of the file, after the `ProviderKeyService` class:
+
+```python
+async def resolve_api_key(
+    repo: ProviderKeyRepository,
+    user_id: UUID,
+    provider: str,
+    project_id: UUID | None = None,
+) -> str | None:
+    """Resolve an API key: DB first (project-level → account-level), then env-var fallback.
+
+    Returns None if no key is found in either source.
+    Empty string env vars are treated as not configured.
+    """
+    key_record = await repo.get_for_provider(
+        user_id=user_id,
+        provider=provider,
+        project_id=project_id,
+    )
+    if key_record:
+        return decrypt(key_record.api_key_encrypted)
+
+    env_fallbacks: dict[str, str] = {
+        "groq":         settings.GROQ_API_KEY,
+        "llama_cloud":  settings.LLAMA_CLOUD_KEY,
+        "landing_ai":   settings.VISION_AGENT_API_KEY,
+        "ollama_cloud": settings.OLLAMA_CLOUD_API_KEY,
+    }
+    value = env_fallbacks.get(provider, "")
+    return value if value else None
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```
+uv run --directory backend python -m pytest tests/services/test_resolve_api_key.py -v
+```
+
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/provider_key_service.py backend/tests/services/test_resolve_api_key.py
+git commit -m "feat(provider-keys): add resolve_api_key with DB-first env-var fallback"
+```
+
+---
+
+## Task 3: Wire playground (indexes router)
+
+**Files:**
+- Modify: `backend/app/routers/indexes.py`
+
+The playground currently does its own `repo.get_for_provider` + `decrypt` inline (around lines 581–596). Replace with `resolve_api_key`.
+
+- [ ] **Step 1: Add the import to `backend/app/routers/indexes.py`**
+
+Find the block of service/utility imports near the top of the file and add:
+
+```python
+from app.services.provider_key_service import resolve_api_key
+```
+
+- [ ] **Step 2: Replace the inline key resolution in `playground_answer`**
+
+Find this block (around lines 580–596):
+
+```python
+    # Resolve the LLM provider API key (reuses embedding key storage)
+    llm_provider = data.llm_config.provider
+    key_record = await provider_key_repo.get_for_provider(
+        user_id=current_user.id,
+        provider=llm_provider,
+        project_id=project_id,
+    )
+    if not key_record:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"No API key configured for provider '{llm_provider}'. "
+                "Add one in Settings → API Keys."
+            ),
+        )
+
+    api_key = decrypt(key_record.api_key_encrypted)
+```
+
+Replace it with:
+
+```python
+    # Resolve the LLM provider API key: DB first, env-var fallback
+    llm_provider = data.llm_config.provider
+    api_key = await resolve_api_key(
+        repo=provider_key_repo,
+        user_id=current_user.id,
+        provider=llm_provider,
+        project_id=project_id,
+    )
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"No API key configured for provider '{llm_provider}'. "
+                "Add one in Settings → API Keys."
+            ),
+        )
+```
+
+- [ ] **Step 3: Check if `decrypt` import is still needed elsewhere in `indexes.py`**
+
+```bash
+grep -n "decrypt" backend/app/routers/indexes.py
+```
+
+If the only usage was the line just removed, also remove the `decrypt` import from the imports block at the top.
+
+- [ ] **Step 4: Run the full test suite**
+
+```
+uv run --directory backend python -m pytest tests/ -v --ignore=tests/cdm -x
+```
+
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/indexes.py
+git commit -m "feat(playground): resolve LLM key via resolve_api_key"
+```
+
+---
+
+## Task 4: Wire extraction router
+
+**Files:**
+- Modify: `backend/app/routers/extraction.py`
+- Create: `backend/tests/routers/test_extraction_credentials.py`
+
+The current `_resolve_credentials_from_settings(method)` is synchronous and reads directly from env vars. It needs to become async, accept a repo and user_id, and call `resolve_api_key`.
+
+Note: the `ollama` extraction method also returns an `endpoint` URL from `settings.OLLAMA_ENDPOINT`. That URL is config (not a secret) and stays in `.env` — only the API key moves to BYOK.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/routers/test_extraction_credentials.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from app.routers.extraction import _resolve_credentials_from_settings
+
+USER_ID = uuid4()
+
+
+def _make_repo(encrypted_value=None):
+    repo = AsyncMock()
+    if encrypted_value:
+        key_record = MagicMock()
+        key_record.api_key_encrypted = encrypted_value
+        repo.get_for_provider.return_value = key_record
+    else:
+        repo.get_for_provider.return_value = None
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_llamaextract_returns_db_key():
+    from app.utils.encryption import encrypt
+    repo = _make_repo(encrypt("llamacloud-key-456"))
+    result = await _resolve_credentials_from_settings(repo, USER_ID, "llamaextract")
+    assert result == {"api_key": "llamacloud-key-456"}
+    repo.get_for_provider.assert_awaited_once_with(
+        user_id=USER_ID, provider="llama_cloud", project_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_llamaextract_falls_back_to_env():
+    repo = _make_repo()
+    with patch("app.services.provider_key_service.settings") as mock_settings:
+        mock_settings.LLAMA_CLOUD_KEY = "env-llama-key"
+        mock_settings.GROQ_API_KEY = ""
+        mock_settings.VISION_AGENT_API_KEY = ""
+        mock_settings.OLLAMA_CLOUD_API_KEY = ""
+        result = await _resolve_credentials_from_settings(repo, USER_ID, "llamaextract")
+    assert result == {"api_key": "env-llama-key"}
+
+
+@pytest.mark.asyncio
+async def test_ollama_returns_endpoint_and_key():
+    from app.utils.encryption import encrypt
+    repo = _make_repo(encrypt("ollama-key-789"))
+    with patch("app.routers.extraction.settings") as mock_settings:
+        mock_settings.OLLAMA_ENDPOINT = "http://myollama:11434/v1"
+        result = await _resolve_credentials_from_settings(repo, USER_ID, "ollama")
+    assert result["endpoint"] == "http://myollama:11434/v1"
+    assert result["api_key"] == "ollama-key-789"
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_returns_empty_dict():
+    repo = AsyncMock()
+    result = await _resolve_credentials_from_settings(repo, USER_ID, "unknown_method")
+    assert result == {}
+    repo.get_for_provider.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+```
+uv run --directory backend python -m pytest tests/routers/test_extraction_credentials.py -v
+```
+
+Expected: FAIL — `_resolve_credentials_from_settings` takes 1 argument, not 3
+
+- [ ] **Step 3: Update `backend/app/routers/extraction.py`**
+
+Add these imports alongside existing imports at the top of the file:
+
+```python
+from app.config import settings
+from app.repositories.provider_key_repository import ProviderKeyRepository
+from app.services.provider_key_service import resolve_api_key
+```
+
+Replace the entire `_resolve_credentials_from_settings` function (lines 50–64):
+
+```python
+async def _resolve_credentials_from_settings(
+    repo: ProviderKeyRepository,
+    user_id: UUID,
+    method: str,
+) -> dict:
+    """Resolve adapter credentials: DB first, env-var fallback.
+
+    Maps extraction method names to BYOK provider IDs.
+    The Ollama endpoint URL is config (not a secret) and always comes from settings.
+    """
+    provider_map = {
+        "llamaextract": "llama_cloud",
+        "ollama":        "ollama_cloud",
+        "groq":          "groq",
+        "vision_agent":  "landing_ai",
+    }
+    provider = provider_map.get(method)
+    if not provider:
+        return {}
+
+    key = await resolve_api_key(repo, user_id, provider)
+
+    if method == "ollama":
+        return {
+            "endpoint": settings.OLLAMA_ENDPOINT or "http://localhost:11434/v1",
+            "api_key": key,
+        }
+    return {"api_key": key} if key else {}
+```
+
+In the `run_extraction` endpoint, find this line (around line 179):
+
+```python
+        credentials = _resolve_credentials_from_settings(body.extraction_method)
+```
+
+Replace with:
+
+```python
+        provider_key_repo = ProviderKeyRepository(db)
+        credentials = await _resolve_credentials_from_settings(
+            provider_key_repo, current_user.id, body.extraction_method
+        )
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```
+uv run --directory backend python -m pytest tests/routers/test_extraction_credentials.py -v
+```
+
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run the full test suite**
+
+```
+uv run --directory backend python -m pytest tests/ -v --ignore=tests/cdm -x
+```
+
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/routers/extraction.py backend/tests/routers/test_extraction_credentials.py
+git commit -m "feat(extraction): wire BYOK key resolution with env-var fallback"
+```
+
+---
+
+## Task 5: Wire classification router
+
+**Files:**
+- Modify: `backend/app/routers/classification.py`
+- Create: `backend/tests/routers/test_classification_key_resolution.py`
+
+Classification uses a module-level cached `LLMRegistry` built at startup from env vars. We replace this with a per-request registry built from the resolved key, so users can supply their own Groq or Ollama Cloud keys.
+
+`ollama_local` never needs a key and stays as-is. `groq` and `ollama_cloud` are the two providers that benefit from BYOK.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/routers/test_classification_key_resolution.py
+from unittest.mock import patch
+
+from app.routers.classification import _classification_provider_to_byok, _build_llm_registry
+
+
+def test_provider_mapping_groq():
+    assert _classification_provider_to_byok("groq") == "groq"
+
+
+def test_provider_mapping_ollama_cloud():
+    assert _classification_provider_to_byok("ollama_cloud") == "ollama_cloud"
+
+
+def test_provider_mapping_ollama_local_returns_none():
+    assert _classification_provider_to_byok("ollama_local") is None
+
+
+def test_provider_mapping_unknown_returns_none():
+    assert _classification_provider_to_byok("some_unknown_provider") is None
+
+
+def test_build_registry_groq_with_key():
+    registry = _build_llm_registry("groq", "my-groq-key")
+    assert registry.has("groq")
+
+
+def test_build_registry_groq_without_key_not_registered():
+    registry = _build_llm_registry("groq", None)
+    assert not registry.has("groq")
+
+
+def test_build_registry_ollama_local_always_registered():
+    with patch("app.routers.classification.settings") as mock_settings:
+        mock_settings.OLLAMA_LOCAL_BASE_URL = "http://localhost:11434/v1"
+        registry = _build_llm_registry("ollama_local", None)
+    assert registry.has("ollama_local")
+
+
+def test_build_registry_ollama_cloud_with_key():
+    with patch("app.routers.classification.settings") as mock_settings:
+        mock_settings.OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
+        registry = _build_llm_registry("ollama_cloud", "cloud-key-abc")
+    assert registry.has("ollama_cloud")
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+```
+uv run --directory backend python -m pytest tests/routers/test_classification_key_resolution.py -v
+```
+
+Expected: FAIL — "cannot import name '_classification_provider_to_byok'"
+
+- [ ] **Step 3: Update `backend/app/routers/classification.py`**
+
+Add these imports alongside existing imports at the top of the file:
+
+```python
+from app.repositories.provider_key_repository import ProviderKeyRepository
+from app.services.llm.registry import LLMRegistry
+from app.services.llm.ollama_adapter import OllamaAdapter
+from app.services.llm.groq_adapter import GroqAdapter
+from app.services.provider_key_service import resolve_api_key
+```
+
+Check that `get_llm_registry` is not used anywhere else in the file, then remove its import:
+
+```bash
+grep -n "get_llm_registry" backend/app/routers/classification.py
+```
+
+If the only remaining occurrence is the import line itself, remove:
+
+```python
+from app.dependencies.llm import get_llm_registry
+```
+
+Add these two helper functions before `_run_classification_background`:
+
+```python
+def _classification_provider_to_byok(llm_provider: str) -> str | None:
+    """Map classification LLM provider names to BYOK provider IDs."""
+    return {"groq": "groq", "ollama_cloud": "ollama_cloud"}.get(llm_provider)
+
+
+def _build_llm_registry(provider: str, api_key: str | None) -> LLMRegistry:
+    """Build a per-request LLM registry with the resolved API key."""
+    registry = LLMRegistry()
+    if provider == "ollama_local":
+        registry.register(
+            "ollama_local",
+            OllamaAdapter(base_url=settings.OLLAMA_LOCAL_BASE_URL, api_key="ollama"),
+        )
+    elif provider == "ollama_cloud" and api_key:
+        registry.register(
+            "ollama_cloud",
+            OllamaAdapter(base_url=settings.OLLAMA_CLOUD_BASE_URL, api_key=api_key),
+        )
+    elif provider == "groq" and api_key:
+        registry.register("groq", GroqAdapter(api_key=api_key))
+    return registry
+```
+
+In `_run_classification_background`, add `api_key: str | None` as the last parameter and replace `get_llm_registry()`:
+
+Old signature and registry line:
+```python
+async def _run_classification_background(
+    run_id: UUID,
+    parse_run_id: UUID,
+    labels: list[str],
+    llm_provider: str,
+    llm_model: str,
+    batch_size: int,
+    batch_overlap: int,
+) -> None:
+```
+```python
+            registry = get_llm_registry()
+```
+
+New:
+```python
+async def _run_classification_background(
+    run_id: UUID,
+    parse_run_id: UUID,
+    labels: list[str],
+    llm_provider: str,
+    llm_model: str,
+    batch_size: int,
+    batch_overlap: int,
+    api_key: str | None,
+) -> None:
+```
+```python
+            registry = _build_llm_registry(llm_provider, api_key)
+```
+
+In `create_classification_run`, add key resolution before `background_tasks.add_task` and pass `api_key`:
+
+```python
+    byok_provider = _classification_provider_to_byok(llm_provider)
+    api_key: str | None = None
+    if byok_provider:
+        provider_key_repo = ProviderKeyRepository(db)
+        api_key = await resolve_api_key(provider_key_repo, current_user.id, byok_provider)
+
+    background_tasks.add_task(
+        _run_classification_background,
+        run_id=run.id,
+        parse_run_id=body.parse_run_id,
+        labels=body.labels,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+        batch_size=batch_size,
+        batch_overlap=batch_overlap,
+        api_key=api_key,
+    )
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```
+uv run --directory backend python -m pytest tests/routers/test_classification_key_resolution.py -v
+```
+
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Run the full test suite**
+
+```
+uv run --directory backend python -m pytest tests/ -v --ignore=tests/cdm -x
+```
+
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/routers/classification.py backend/tests/routers/test_classification_key_resolution.py
+git commit -m "feat(classification): wire BYOK key resolution, build per-request LLM registry"
+```
+
+---
+
+## Task 6: Verify settings UI shows new providers
+
+**Files:** No code changes — verification only.
+
+- [ ] **Step 1: Start the backend**
+
+```
+uv run --directory backend uvicorn app.main:app --reload
+```
+
+- [ ] **Step 2: Start the frontend**
+
+```
+npm --prefix frontend run dev
+```
+
+- [ ] **Step 3: Check the providers API response**
+
+```
+curl http://localhost:8000/api/v1/settings/provider-keys/providers
+```
+
+Expected: response includes entries for `groq`, `llama_cloud`, `landing_ai`, `ollama_cloud`, each with `"requiresKey": true`.
+
+- [ ] **Step 4: Open the settings UI**
+
+Navigate to `http://localhost:5173` → Settings → API Keys.
+
+Confirm that `Groq`, `LlamaIndex Cloud`, `Landing AI`, and `Ollama Cloud` appear in the provider list alongside the existing providers.
+
+- [ ] **Step 5: Add a test key for one new provider**
+
+Add a Groq key via the UI. Confirm it saves, appears masked, and can be deleted.

--- a/docs/superpowers/specs/2026-05-26-unified-provider-keys-design.md
+++ b/docs/superpowers/specs/2026-05-26-unified-provider-keys-design.md
@@ -1,0 +1,123 @@
+# Unified Provider Key Storage
+
+**Date:** 2026-05-26
+**Status:** Approved
+
+## Problem
+
+Provider API keys are stored in two inconsistent places:
+
+- **Playground** uses BYOK: keys stored encrypted in the `provider_keys` DB table, resolved per user/project.
+- **Extraction** uses `.env`: keys read directly from application settings at runtime.
+- **Classification** — to be confirmed during implementation (may also read env vars directly).
+
+This means users cannot bring their own extraction keys, and there is no single place to manage credentials.
+
+## Goal
+
+Unify all provider API keys under the existing BYOK system with an env-var fallback, so:
+
+- Users can configure any provider key via the settings UI.
+- Deployments that set env vars continue to work without any UI configuration.
+- All features (playground, extraction, classification) resolve keys through one code path.
+
+## Design
+
+### 1. Provider Registry
+
+Extend `SUPPORTED_PROVIDERS` in `backend/app/schemas/provider_key.py` with four new providers:
+
+| Provider ID    | Display Name      | Replaces env var        |
+|----------------|-------------------|-------------------------|
+| `groq`         | Groq              | `GROQ_API_KEY`          |
+| `llama_cloud`  | LlamaIndex Cloud  | `LLAMA_CLOUD_KEY`       |
+| `landing_ai`   | Landing AI        | `VISION_AGENT_API_KEY`  |
+| `ollama_cloud` | Ollama Cloud      | `OLLAMA_CLOUD_API_KEY`  |
+
+Existing providers remain unchanged:
+
+| Provider ID | Display Name    | Notes                        |
+|-------------|-----------------|------------------------------|
+| `openai`    | OpenAI          | Embeddings + LLM             |
+| `voyage`    | Voyage AI       | Embeddings only              |
+| `anthropic` | Anthropic       | LLM only                     |
+| `local`     | Local (Ollama)  | No key required              |
+
+No database migration required — `provider` is a free-form string column.
+
+Grouping or capability tagging (e.g. "Embeddings", "LLM", "Extraction") is intentionally deferred. Adding optional display metadata to provider entries later is backward-compatible and requires no data model changes.
+
+The env var name `VISION_AGENT_API_KEY` is kept as-is to avoid breaking existing deployments. Only the provider ID exposed in the API changes to `landing_ai`.
+
+### 2. Resolver Function
+
+Add `resolve_api_key` to `backend/app/services/provider_key_service.py`:
+
+```python
+async def resolve_api_key(
+    db: AsyncSession,
+    user_id: UUID,
+    provider: str,
+    project_id: UUID | None = None,
+) -> str | None:
+    # 1. DB: project-level key → account-level key (existing logic)
+    key_record = await repo.get_for_provider(db, user_id, provider, project_id)
+    if key_record:
+        return decrypt(key_record.api_key_encrypted)
+
+    # 2. Env var fallback (only providers that currently live in .env)
+    env_fallbacks = {
+        "groq":         settings.GROQ_API_KEY,
+        "llama_cloud":  settings.LLAMA_CLOUD_KEY,
+        "landing_ai":   settings.VISION_AGENT_API_KEY,
+        "ollama_cloud": settings.OLLAMA_CLOUD_API_KEY,
+    }
+    return env_fallbacks.get(provider)
+```
+
+`openai`, `anthropic`, `voyage`, and `local` have no env var equivalent and are DB-only (no change from today).
+
+### 3. Wiring
+
+**Extraction** (`backend/app/routers/extraction.py`):
+
+Replace the body of `_resolve_credentials_from_settings()` — the existing seam comment marks exactly this point — with calls to `resolve_api_key`. The function signature stays the same; only the body changes.
+
+```python
+async def _resolve_credentials_from_settings(
+    db: AsyncSession,
+    user_id: UUID,
+    project_id: UUID,
+    extractor_type: str,
+) -> dict:
+    provider_map = {
+        "llama_cloud":  "llama_cloud",
+        "ollama":       "ollama_cloud",
+        "groq":         "groq",
+        "vision_agent": "landing_ai",
+    }
+    provider = provider_map.get(extractor_type)
+    if not provider:
+        return {}
+    key = await resolve_api_key(db, user_id, provider, project_id)
+    return {"api_key": key} if key else {}
+```
+
+**Playground** (`backend/app/routers/indexes.py`):
+
+Replace the inline `repo.get_for_provider` + `decrypt` block with a single `resolve_api_key` call. The error handling (HTTP 400 if no key found) stays in the router.
+
+**Classification** — check during implementation whether it reads env vars directly. If so, wire it through `resolve_api_key` the same way.
+
+### 4. UI
+
+No new components. The settings page already renders all providers where `requiresKey: true`. The four new providers will appear automatically once added to the registry.
+
+The provider list is flat — no grouping or capability badges in this iteration.
+
+## Out of Scope
+
+- Non-AI integrations (Slack, etc.) — deferred until use case is defined (user-facing vs. admin-configured).
+- Ollama local endpoint URL (`OLLAMA_LOCAL_BASE_URL`, `OLLAMA_CLOUD_BASE_URL`) — these are config values, not secrets; they stay in `.env`.
+- Per-user encryption keys — the app-wide `ENCRYPTION_KEY` is sufficient.
+- Capability/category metadata on providers — can be added later as optional display-only fields.

--- a/frontend/src/components/extraction/ExtractionForm.tsx
+++ b/frontend/src/components/extraction/ExtractionForm.tsx
@@ -51,7 +51,6 @@ export function ExtractionForm({
   const [ollamaModel, setOllamaModel] = useState('')
   const [ollamaEndpointPreset, setOllamaEndpointPreset] = useState<OllamaEndpointPreset>('local')
   const [ollamaCustomEndpoint, setOllamaCustomEndpoint] = useState('')
-  const [ollamaApiKey, setOllamaApiKey] = useState('')
   const [ollamaStructuredOutputMode, setOllamaStructuredOutputMode] = useState('json_schema')
   const [ollamaInjectBlockIds, setOllamaInjectBlockIds] = useState(false)
 
@@ -106,7 +105,6 @@ export function ExtractionForm({
         structured_output_mode: ollamaStructuredOutputMode,
         inject_block_ids: ollamaInjectBlockIds,
       }
-      if (ollamaApiKey.trim()) config.api_key = ollamaApiKey.trim()
     } else {
       config = {}
     }
@@ -314,38 +312,28 @@ export function ExtractionForm({
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">Endpoint</Label>
-              <Select
-                value={ollamaEndpointPreset}
-                onValueChange={(v) => setOllamaEndpointPreset(v as OllamaEndpointPreset)}
-              >
-                <SelectTrigger className="h-9">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="local">Local (host.docker.internal:11434)</SelectItem>
-                  <SelectItem value="cloud">Ollama Cloud</SelectItem>
-                  <SelectItem value="custom">Custom</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {(ollamaEndpointPreset === 'cloud' || ollamaEndpointPreset === 'custom') && (
-              <div className="space-y-1.5">
-                <Label className="text-xs">API Key</Label>
-                <Input
-                  type="password"
-                  autoComplete="new-password"
-                  value={ollamaApiKey}
-                  onChange={(e) => setOllamaApiKey(e.target.value)}
-                  placeholder="Bearer token"
-                  className="h-9"
-                />
-              </div>
-            )}
+          <div className="space-y-1.5">
+            <Label className="text-xs">Endpoint</Label>
+            <Select
+              value={ollamaEndpointPreset}
+              onValueChange={(v) => setOllamaEndpointPreset(v as OllamaEndpointPreset)}
+            >
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="local">Local (host.docker.internal:11434)</SelectItem>
+                <SelectItem value="cloud">Ollama Cloud</SelectItem>
+                <SelectItem value="custom">Custom</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
+
+          {(ollamaEndpointPreset === 'cloud' || ollamaEndpointPreset === 'custom') && (
+            <p className="text-[11px] text-muted-foreground">
+              API key is resolved from Settings → API Keys (Ollama Cloud). No key is sent in the request.
+            </p>
+          )}
 
           {ollamaEndpointPreset === 'custom' && (
             <div className="space-y-1.5">


### PR DESCRIPTION
Closes #66

## Summary

- Adds `resolve_api_key` to `provider_key_service` — resolves keys DB-first (project → account), falls back to env var, returns `None` if unconfigured
- Extends `SUPPORTED_PROVIDERS` with four new entries: `groq`, `llama_cloud`, `landing_ai`, `ollama_cloud` — appear automatically in the Settings UI
- Wires playground, extraction, and classification through the single resolver; removes direct `settings.*` key reads from all three routers
- Fixes pre-existing Ollama extraction bug: credentials are now injected via `OllamaExtractor.__init__` rather than merged into the stored config (avoids persisting decrypted keys in the DB)

## Test Plan

- [ ] Add a `groq` key in Settings → API Keys; run classification with `groq` provider — should succeed
- [ ] Add a `llama_cloud` key in Settings → API Keys; run a LlamaExtract extraction — should succeed
- [ ] Remove the key, set `LLAMA_CLOUD_KEY` in `.env` — extraction should still succeed (env fallback)
- [ ] Leave both unset — extraction should return HTTP 400 with a clear message
- [ ] Settings page shows Groq, LlamaIndex Cloud, Landing AI, Ollama Cloud as configurable providers
- [ ] `GET /api/v1/extractors` — existing extractors still listed; `configured` flag unchanged for env-var-only deployments

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-05-26-unified-provider-keys-design.md`
- Plan: `docs/superpowers/plans/2026-05-26-unified-provider-keys.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)