### PR TITLE
fix(eval): thread page boundaries through chunking pipeline so retrieval metrics are non-zero

### DIFF
--- a/backend/app/cdm/adapters/simple_text.py
+++ b/backend/app/cdm/adapters/simple_text.py
@@ -42,6 +42,8 @@ class SimpleTextAdapter:
                 pages.append(Page(
                     index=page_index,
                     block_ids=[block_id],
+                    start_char=start_char,
+                    end_char=end_char,
                 ))
         else:
             # Fallback: single page/block containing all text
@@ -56,6 +58,8 @@ class SimpleTextAdapter:
             pages = [Page(
                 index=0,
                 block_ids=[block_id],
+                start_char=0,
+                end_char=len(full_text),
             )]
 
         return ParsedDocument(

--- a/backend/app/cdm/eval/fixtures/landing_ai_cleanshelf.expected.json
+++ b/backend/app/cdm/eval/fixtures/landing_ai_cleanshelf.expected.json
@@ -1,5 +1,5 @@
 {
-  "id": "a343b40d-feef-4181-a256-beddbeda437d",
+  "id": "65451f09-8980-4dcb-807e-b8fe6a5abb49",
   "source_document_id": "structural-test-src",
   "parse_run_id": "structural-test-run",
   "source_filename": "cleanshelf-12-4-26.jpg",
@@ -7,6 +7,8 @@
   "pages": [
     {
       "index": 0,
+      "start_char": null,
+      "end_char": null,
       "width": null,
       "height": null,
       "unit": null,

--- a/backend/app/cdm/models.py
+++ b/backend/app/cdm/models.py
@@ -120,6 +120,8 @@ class Block(_Frozen):
 
 class Page(_Frozen):
     index: int
+    start_char: Optional[int] = None
+    end_char: Optional[int] = None
     width: Optional[float] = None
     height: Optional[float] = None
     unit: Optional[str] = None

--- a/backend/app/services/chunking_dispatcher.py
+++ b/backend/app/services/chunking_dispatcher.py
@@ -59,7 +59,7 @@ class ChunkingDispatcher:
                 config=config,
                 source_document_id=source_document_id,
                 source_filename=source_filename,
-                page_boundaries=None,
+                page_boundaries=source.page_boundaries or None,
             )
         if isinstance(source, BlocksSource):
             if config.chunking_strategy == "classified_block":

--- a/backend/app/services/source_resolution_service.py
+++ b/backend/app/services/source_resolution_service.py
@@ -8,7 +8,7 @@ source_filename) flows through the dispatcher's call site so that the save
 path's chunk metadata stays byte-identical with the pre-refactor behaviour
 (which sourced filename from `Document.source_metadata.filename`).
 """
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Union
 from uuid import UUID
 
@@ -25,6 +25,7 @@ SourceRepresentation = Literal["full_text", "full_markdown", "block"]
 class TextSource:
     """Text-shaped source (full_text or full_markdown)."""
     text: str
+    page_boundaries: list[dict] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -34,6 +35,26 @@ class BlocksSource:
 
 
 ChunkSource = Union[TextSource, BlocksSource]
+
+
+def _extract_page_boundaries(content: dict) -> list[dict]:
+    """Extract 1-based page boundaries from CDM content pages.
+
+    Pages without start_char/end_char (old parse runs or block-native parsers)
+    are silently skipped, returning an empty list.
+    """
+    pages = content.get("pages") or []
+    result = []
+    for p in pages:
+        start = p.get("start_char")
+        end = p.get("end_char")
+        if start is not None and end is not None:
+            result.append({
+                "page": p["index"] + 1,  # CDM index is 0-based; chunking_service expects 1-based
+                "start_char": start,
+                "end_char": end,
+            })
+    return result
 
 
 class SourceResolutionService:
@@ -57,12 +78,17 @@ class SourceResolutionService:
                 f"Parsed document {parsed_document_id} not found"
             )
 
+        content = parsed_doc.content or {}
+
         if source_representation == "full_text":
             if parsed_doc.full_text is None:
                 raise ValidationError(
                     f"Parsed document {parsed_document_id} has no full_text"
                 )
-            return TextSource(text=parsed_doc.full_text)
+            return TextSource(
+                text=parsed_doc.full_text,
+                page_boundaries=_extract_page_boundaries(content),
+            )
 
         if source_representation == "full_markdown":
             if parsed_doc.full_markdown is None:
@@ -70,10 +96,13 @@ class SourceResolutionService:
                     f"Parsed document {parsed_document_id} has no full_markdown. "
                     "Re-parse with a configuration that outputs markdown."
                 )
-            return TextSource(text=parsed_doc.full_markdown)
+            return TextSource(
+                text=parsed_doc.full_markdown,
+                page_boundaries=_extract_page_boundaries(content),
+            )
 
         # block
-        blocks = (parsed_doc.content or {}).get("blocks") or []
+        blocks = content.get("blocks") or []
         if not blocks:
             raise ValidationError(
                 f"Parsed document {parsed_document_id} has no blocks"

--- a/backend/tests/cdm/adapters/test_simple_text_adapter.py
+++ b/backend/tests/cdm/adapters/test_simple_text_adapter.py
@@ -78,3 +78,18 @@ def test_empty_raw_produces_single_empty_page():
     assert doc.page_count == 1
     assert len(doc.pages) == 1
     assert len(doc.blocks) == 1
+
+
+def test_pages_carry_char_offsets_when_boundaries_provided():
+    doc = SimpleTextAdapter().adapt(TWO_PAGE_RAW, SOURCE_META)
+    assert doc.pages[0].start_char == 0
+    assert doc.pages[0].end_char == 20
+    assert doc.pages[1].start_char == 22
+    assert doc.pages[1].end_char == 40
+
+
+def test_fallback_page_carries_char_offsets_spanning_full_text():
+    raw = {"text": "some text", "page_count": 1, "page_boundaries": []}
+    doc = SimpleTextAdapter().adapt(raw, SOURCE_META)
+    assert doc.pages[0].start_char == 0
+    assert doc.pages[0].end_char == len("some text")

--- a/backend/tests/cdm/eval/fixtures/multi_column.expected.json
+++ b/backend/tests/cdm/eval/fixtures/multi_column.expected.json
@@ -176,6 +176,7 @@
         "src-eval:p0:b2",
         "src-eval:p0:b3"
       ],
+      "end_char": null,
       "height": 792.0,
       "index": 0,
       "parser_extras": {
@@ -187,6 +188,7 @@
         "notes": null
       },
       "rotation": 0,
+      "start_char": null,
       "unit": "points",
       "width": 612.0
     }

--- a/backend/tests/cdm/eval/fixtures/one_page_text.expected.json
+++ b/backend/tests/cdm/eval/fixtures/one_page_text.expected.json
@@ -94,6 +94,7 @@
         "src-eval:p0:b0",
         "src-eval:p0:b1"
       ],
+      "end_char": null,
       "height": 792.0,
       "index": 0,
       "parser_extras": {
@@ -105,6 +106,7 @@
         "notes": null
       },
       "rotation": 0,
+      "start_char": null,
       "unit": "points",
       "width": 612.0
     }

--- a/backend/tests/cdm/eval/fixtures/table_and_headings.expected.json
+++ b/backend/tests/cdm/eval/fixtures/table_and_headings.expected.json
@@ -135,6 +135,7 @@
         "src-eval:p0:b1",
         "src-eval:p0:b2"
       ],
+      "end_char": null,
       "height": 792.0,
       "index": 0,
       "parser_extras": {
@@ -146,6 +147,7 @@
         "notes": null
       },
       "rotation": 0,
+      "start_char": null,
       "unit": "points",
       "width": 612.0
     }

--- a/backend/tests/cdm/test_models.py
+++ b/backend/tests/cdm/test_models.py
@@ -112,6 +112,18 @@ def test_page_defaults():
     assert p.width is None
 
 
+def test_page_accepts_char_offsets():
+    page = Page(index=0, start_char=0, end_char=500)
+    assert page.start_char == 0
+    assert page.end_char == 500
+
+
+def test_page_char_offsets_default_to_none():
+    page = Page(index=0)
+    assert page.start_char is None
+    assert page.end_char is None
+
+
 def test_label_scope_defaults_to_document():
     lbl = Label(name="annual_report")
     assert lbl.scope == "document"

--- a/backend/tests/services/test_chunking_dispatcher.py
+++ b/backend/tests/services/test_chunking_dispatcher.py
@@ -106,3 +106,44 @@ def test_dispatch_empty_text_returns_empty_list():
         source_document_id=str(uuid4()),
         source_filename=None,
     ) == []
+
+
+def test_text_source_with_page_boundaries_produces_chunks_with_page_numbers():
+    """Full-text chunks from a paged source must have page_numbers in metadata."""
+    # 200 chars on page 1 (0-199), 200 chars on page 2 (200-399)
+    text = "a " * 100 + "b " * 100        # 400 chars total
+    src = TextSource(
+        text=text,
+        page_boundaries=[
+            {"page": 1, "start_char": 0,   "end_char": 200},
+            {"page": 2, "start_char": 200, "end_char": 400},
+        ],
+    )
+    chunks = ChunkingDispatcher().dispatch(
+        source=src,
+        config=_config("full_text"),
+        source_document_id=str(uuid4()),
+        source_filename="paged.pdf",
+    )
+    assert chunks, "expected at least one chunk"
+    for chunk in chunks:
+        assert chunk.metadata.get("page_numbers"), (
+            f"chunk missing page_numbers: {chunk.metadata}"
+        )
+
+
+def test_text_source_without_page_boundaries_produces_chunks_without_page_numbers():
+    """Backward compat: empty page_boundaries → no page_numbers on chunks."""
+    text = "content " * 100
+    src = TextSource(text=text, page_boundaries=[])
+    chunks = ChunkingDispatcher().dispatch(
+        source=src,
+        config=_config("full_text"),
+        source_document_id=str(uuid4()),
+        source_filename="nopages.pdf",
+    )
+    assert chunks
+    for chunk in chunks:
+        assert not chunk.metadata.get("page_numbers"), (
+            f"unexpected page_numbers: {chunk.metadata}"
+        )

--- a/backend/tests/services/test_eval_service.py
+++ b/backend/tests/services/test_eval_service.py
@@ -1,5 +1,6 @@
 """Tests for EvalService — experiment-related functionality."""
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +12,8 @@ from app.models.experiment import Experiment, ExperimentStatus
 from app.repositories.eval_run_repository import EvalRunRepository
 from app.repositories.golden_set_repository import GoldenSetRepository
 from app.repositories.experiment_repository import ExperimentRepository
+from app.schemas.eval_run import EvalRunConfig
+from app.schemas.query import QueryResponse, RetrievalResult, RetrievalResultMetadata
 from app.services.eval_service import EvalService
 from app.services.exceptions import NotFoundError
 
@@ -256,3 +259,113 @@ async def test_to_response_no_experiment(
     assert resp.experiment_id is None
     assert resp.experiment_name is None
     assert resp.variant_label is None
+
+
+# ---------------------------------------------------------------------------
+# _process_single_query metric calculation tests
+# ---------------------------------------------------------------------------
+
+def _make_query_service_mock(doc_id: str, page_numbers: list[int]):
+    """Return a mock query_service whose query_index returns one chunk on the given pages."""
+    meta = RetrievalResultMetadata(
+        documentId=doc_id,
+        documentName="test.pdf",
+        page=page_numbers[0] if page_numbers else None,
+        pageNumbers=page_numbers or None,
+        chunkIndex=0,
+        tokenCount=50,
+        charCount=200,
+    )
+    result = RetrievalResult(
+        chunkId="chunk-1",
+        rank=1,
+        score=0.9,
+        content="relevant content",
+        metadata=meta,
+    )
+    response = QueryResponse(
+        query="test query",
+        results=[result],
+        totalResults=1,
+        searchType="semantic",
+        executionTimeMs=10.0,
+    )
+    mock_qs = MagicMock()
+    mock_qs.query_index = AsyncMock(return_value=response)
+    return mock_qs
+
+
+def _make_eval_service_for_metric_test(eval_run_repo, golden_set_repo, doc_id, page_numbers):
+    """Build an EvalService with mocked query_service and mocked create_result.
+
+    create_result is mocked to avoid a DB insert with a dangling FK —
+    these tests are purely about the metric calculation, not persistence.
+    """
+    query_service = _make_query_service_mock(doc_id=doc_id, page_numbers=page_numbers)
+    svc = EvalService(eval_run_repo, golden_set_repo, query_service=query_service)
+    svc.eval_repo.create_result = AsyncMock()
+    return svc
+
+
+def _make_run_stub(test_index, test_project, test_user):
+    run = MagicMock()
+    run.index_id = test_index.id
+    run.project_id = test_project.id
+    run.created_by = test_user.id
+    run.mode = "retrieval_only"
+    run.generation_config = None
+    run.judge_config = None
+    return run
+
+
+def _make_query_stub(doc_id: str, pages: list[int]):
+    source = MagicMock()
+    source.document_id = doc_id   # str; service calls str() on it
+    source.locator = {"type": "page", "pages": pages}
+    query = MagicMock()
+    query.id = uuid4()
+    query.query_text = "test query"
+    query.sources = [source]
+    return query
+
+
+@pytest.mark.asyncio
+async def test_process_single_query_returns_nonzero_metrics_when_pages_match(
+    eval_run_repo, golden_set_repo, test_project, test_index, test_user
+):
+    """When chunk page_numbers overlap the golden set source locator, metrics must be > 0."""
+    doc_id = str(uuid4())
+    svc = _make_eval_service_for_metric_test(eval_run_repo, golden_set_repo, doc_id, page_numbers=[2])
+    run = _make_run_stub(test_index, test_project, test_user)
+    query = _make_query_stub(doc_id=doc_id, pages=[2])
+    config = EvalRunConfig(searchType="semantic", topK=5, similarityThreshold=0.0)
+
+    result = await svc._process_single_query(
+        run=run, query=query, config=config,
+        run_id=uuid4(), user_id=test_user.id, is_answer_mode=False,
+    )
+
+    assert result["precision"] > 0, "precision should be non-zero when pages match"
+    assert result["recall"] > 0, "recall should be non-zero when pages match"
+    assert result["f1"] > 0, "F1 should be non-zero when pages match"
+
+
+@pytest.mark.asyncio
+async def test_process_single_query_returns_zero_metrics_when_chunk_has_no_page_numbers(
+    eval_run_repo, golden_set_repo, test_project, test_index, test_user
+):
+    """When chunk has no page_numbers, metrics must be zero (documents the bug state)."""
+    doc_id = str(uuid4())
+    svc = _make_eval_service_for_metric_test(eval_run_repo, golden_set_repo, doc_id, page_numbers=[])
+    run = _make_run_stub(test_index, test_project, test_user)
+    query = _make_query_stub(doc_id=doc_id, pages=[2])
+    config = EvalRunConfig(searchType="semantic", topK=5, similarityThreshold=0.0)
+
+    result = await svc._process_single_query(
+        run=run, query=query, config=config,
+        run_id=uuid4(), user_id=test_user.id, is_answer_mode=False,
+    )
+
+    assert result["precision"] == 0.0
+    assert result["recall"] == 0.0
+    assert result["f1"] == 0.0

--- a/backend/tests/services/test_source_resolution_service.py
+++ b/backend/tests/services/test_source_resolution_service.py
@@ -171,3 +171,72 @@ async def test_resolve_full_text_missing_segment_raises_validation(test_db: Asyn
             parsed_document_id=run.id,
             source_representation="full_text",
         )
+
+
+@pytest.fixture
+async def seeded_parsed_document_with_pages(test_db: AsyncSession) -> ParsedDocumentORM:
+    """ParsedDocument whose CDM content includes pages with char offsets."""
+    src, run = await _seed_source_and_run(test_db)
+    blocks = [
+        {"id": "b1", "role": "paragraph", "text": "page one text", "page_index": 0,
+         "native_type": "text", "children_ids": [], "spans": [], "parser_extras": {},
+         "is_continuation": False},
+        {"id": "b2", "role": "paragraph", "text": "page two text", "page_index": 1,
+         "native_type": "text", "children_ids": [], "spans": [], "parser_extras": {},
+         "is_continuation": False},
+    ]
+    pages = [
+        {"index": 0, "start_char": 0, "end_char": 13, "block_ids": ["b1"],
+         "rotation": 0, "parser_extras": {}},
+        {"index": 1, "start_char": 15, "end_char": 28, "block_ids": ["b2"],
+         "rotation": 0, "parser_extras": {}},
+    ]
+    content = {
+        "id": str(uuid4()), "source_document_id": str(src.id),
+        "parse_run_id": str(run.id), "page_count": 2, "block_count": 2,
+        "pages": pages, "blocks": blocks, "labels": [],
+        "schema_version": "1.0",
+    }
+    pd = ParsedDocumentORM(
+        parse_run_id=run.id,
+        source_document_id=src.id,
+        full_text="page one text\npage two text",
+        full_markdown=None,
+        page_count=2,
+        block_count=2,
+        content=content,
+    )
+    test_db.add(pd)
+    await test_db.commit()
+    await test_db.refresh(pd)
+    return pd
+
+
+@pytest.mark.asyncio
+async def test_resolve_full_text_with_pages_populates_page_boundaries(
+    seeded_parsed_document_with_pages, test_db
+):
+    svc = SourceResolutionService(test_db)
+    result = await svc.resolve(
+        parsed_document_id=seeded_parsed_document_with_pages.parse_run_id,
+        source_representation="full_text",
+    )
+    assert isinstance(result, TextSource)
+    assert result.page_boundaries == [
+        {"page": 1, "start_char": 0, "end_char": 13},
+        {"page": 2, "start_char": 15, "end_char": 28},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_full_text_without_page_offsets_returns_empty_boundaries(
+    seeded_parsed_document, test_db
+):
+    """seeded_parsed_document fixture has pages without start_char — empty boundaries expected."""
+    svc = SourceResolutionService(test_db)
+    result = await svc.resolve(
+        parsed_document_id=seeded_parsed_document.parse_run_id,
+        source_representation="full_text",
+    )
+    assert isinstance(result, TextSource)
+    assert result.page_boundaries == []


### PR DESCRIPTION
## Summary

- Adds `start_char`/`end_char` to the CDM `Page` model, making page char-offsets first-class in the parsed document structure
- `SimpleTextAdapter` now populates those fields from the page boundaries already computed by the LlamaIndex extractor (previously computed and discarded)
- `SourceResolutionService` extracts the offsets from stored CDM content and passes them through a new `page_boundaries` field on `TextSource`
- `ChunkingDispatcher` passes `source.page_boundaries` to `chunk_text()` instead of the hardcoded `None` that caused the bug — `chunking_service` already handles this correctly and writes `page_numbers` to each chunk's metadata

## Root cause

`chunking_dispatcher.py` hardcoded `page_boundaries=None` for all `full_text` / `full_markdown` indices. The chunking service only writes `page_numbers` to chunk metadata when page boundaries are provided, so every text chunk was stored without page info. The eval service matches retrieved chunks against golden set sources using `(document_id, page)` tuples — with no pages on chunks, every comparison returned `False`, producing precision = recall = F1 = 0.

Block-based indices (LlamaParse, LandingAI) were unaffected because `block_chunking_service` stores `page_indices` directly on blocks, which the query service converts to 1-based `page_numbers`.

## Test plan

- [ ] Run `uv run python -m pytest -o "addopts=" tests/ -q` in `backend/` — 853 tests, 0 failures
- [ ] New test `test_text_source_with_page_boundaries_produces_chunks_with_page_numbers` confirms chunks carry `page_numbers` after the fix
- [ ] New test `test_process_single_query_returns_nonzero_metrics_when_pages_match` confirms eval precision/recall/F1 are > 0 when chunk pages match golden set source locator
- [ ] Existing indices (parsed before this fix) continue to return zero metrics until re-parsed and re-indexed — no regression, same behaviour as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)