### PR TITLE
fix(llamaparse): populate Block.text for table blocks from markdown field

### DIFF
--- a/backend/app/cdm/adapters/llamaparse.py
+++ b/backend/app/cdm/adapters/llamaparse.py
@@ -81,6 +81,28 @@ def _mint_block_id(source_document_id: str, page_index: int, reading_order: int)
     return f"{source_document_id}:p{page_index}:b{reading_order}"
 
 
+def _md_table_to_text(md: str) -> str:
+    """Flatten a GFM markdown table into a pipe-joined cell string for Block.text.
+
+    LlamaParse leaves Block.value empty for table items and puts all content
+    in the 'md' field. This extracts cell text so the chunker can embed it.
+    """
+    cells = []
+    for line in md.strip().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Skip separator rows — after removing pipes, spaces, dashes, colons, nothing remains
+        inner = stripped.strip("|").replace(" ", "").replace("-", "").replace(":", "").replace("|", "")
+        if not inner:
+            continue
+        for part in stripped.strip("|").split("|"):
+            cell = part.strip().replace("<br/>", " ").replace("<br>", " ").strip()
+            if cell:
+                cells.append(cell)
+    return " | ".join(cells)
+
+
 def _flatten_pages(value: Any, *, key: str) -> Optional[str]:
     """LlamaParse returns either a string (legacy) or a dict ``{"pages": [{key: ...}]}``
     (current SDK). Normalize both into a single string, joining pages on blank lines.
@@ -164,13 +186,21 @@ class LlamaParseAdapter:
                     children_ids = _walk(child_items, parent_id=block_id, depth=depth + 1) \
                         if child_items else []
 
+                    raw_value = str(item.get("value") or "")
+                    md_value = item.get("md")
+                    text = (
+                        _md_table_to_text(md_value)
+                        if native_type == "table" and not raw_value and md_value
+                        else raw_value
+                    )
+
                     block = Block(
                         id=block_id,
                         role=role,
                         native_type=native_type,
                         native_label=native_label,
-                        text=str(item.get("value") or ""),
-                        markdown=item.get("md"),
+                        text=text,
+                        markdown=md_value,
                         page_index=page_index,
                         bbox=block_bbox,
                         reading_order=reading_order - 1,

--- a/backend/app/services/block_chunking_service.py
+++ b/backend/app/services/block_chunking_service.py
@@ -33,6 +33,28 @@ _NEVER_SPLIT = {BlockRole.TABLE, BlockRole.FIGURE}
 _LAYOUT_SKIP = {BlockRole.HEADER, BlockRole.FOOTER, BlockRole.MARGINALIA}
 
 
+def _md_table_to_text(md: str) -> str:
+    """Flatten a GFM markdown table into a pipe-joined cell string.
+
+    Used when Block.text is empty but Block.markdown has content (LlamaParse
+    stores table data only in the markdown field, not in text/value).
+    """
+    cells = []
+    for line in md.strip().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Skip separator rows — after removing pipes, spaces, dashes, colons, nothing remains
+        inner = stripped.strip("|").replace(" ", "").replace("-", "").replace(":", "").replace("|", "")
+        if not inner:
+            continue
+        for part in stripped.strip("|").split("|"):
+            cell = part.strip().replace("<br/>", " ").replace("<br>", " ").strip()
+            if cell:
+                cells.append(cell)
+    return " | ".join(cells)
+
+
 class BlockChunkingService:
     """Groups CDM blocks into chunks per the block-chunking spec."""
 
@@ -140,7 +162,13 @@ class BlockChunkingService:
         source_document_id: str | None,
         source_filename: str | None,
     ) -> ChunkResult:
-        body = "\n\n".join(b.text for b in blocks if b.text)
+        parts = []
+        for b in blocks:
+            if b.text:
+                parts.append(b.text)
+            elif b.role == BlockRole.TABLE and b.markdown:
+                parts.append(_md_table_to_text(b.markdown))
+        body = "\n\n".join(parts)
         if context_heading:
             content = f"[context: {context_heading}]\n\n{body}"
         else:

--- a/backend/tests/cdm/adapters/test_llamaparse_adapter.py
+++ b/backend/tests/cdm/adapters/test_llamaparse_adapter.py
@@ -189,3 +189,83 @@ def test_adapter_page_block_ids_in_reading_order():
         SourceMeta(source_document_id="src-1", parse_run_id="run-1"),
     )
     assert doc.pages[0].block_ids == [b.id for b in doc.blocks]
+
+
+# ---------------------------------------------------------------------------
+# Table text extraction
+# ---------------------------------------------------------------------------
+
+_TABLE_RAW = {
+    "items": {
+        "pages": [
+            {
+                "page_number": 1,
+                "page_width": 100.0,
+                "page_height": 200.0,
+                "items": [
+                    {
+                        "type": "table",
+                        "value": "",  # LlamaParse always leaves this empty for tables
+                        "md": "| Name | Date |\n| --- | --- |\n| Alice | 2024-01-01 |\n| Bob | 2024-06-01 |",
+                        "bbox": [{"x": 0, "y": 0, "w": 100, "h": 50}],
+                    },
+                ],
+            }
+        ]
+    },
+}
+
+
+def test_adapter_table_text_populated_from_markdown():
+    """Table blocks have empty 'value'; Block.text must be built from 'md'."""
+    doc = LlamaParseAdapter().adapt(
+        _TABLE_RAW,
+        SourceMeta(source_document_id="src-1", parse_run_id="run-1"),
+    )
+    block = doc.blocks[0]
+    assert block.role == BlockRole.TABLE
+    assert block.markdown == "| Name | Date |\n| --- | --- |\n| Alice | 2024-01-01 |\n| Bob | 2024-06-01 |"
+    assert "Name" in block.text
+    assert "Date" in block.text
+    assert "Alice" in block.text
+    assert "Bob" in block.text
+    assert "2024-01-01" in block.text
+
+
+def test_adapter_table_text_excludes_separator_rows():
+    """Markdown separator rows (| --- |) must not appear in Block.text."""
+    doc = LlamaParseAdapter().adapt(
+        _TABLE_RAW,
+        SourceMeta(source_document_id="src-1", parse_run_id="run-1"),
+    )
+    assert "---" not in doc.blocks[0].text
+
+
+def test_adapter_table_text_strips_html_br_tags():
+    """<br/> within table cells must be replaced so text is clean."""
+    raw = {
+        "items": {
+            "pages": [
+                {
+                    "page_number": 1,
+                    "page_width": 100.0,
+                    "page_height": 200.0,
+                    "items": [
+                        {
+                            "type": "table",
+                            "value": "",
+                            "md": "| Note | 2024<br/>KShs 000 |\n| --- | --- |\n| Revenue | 100 |",
+                            "bbox": [{"x": 0, "y": 0, "w": 100, "h": 50}],
+                        },
+                    ],
+                }
+            ]
+        },
+    }
+    doc = LlamaParseAdapter().adapt(
+        raw,
+        SourceMeta(source_document_id="src-1", parse_run_id="run-1"),
+    )
+    block = doc.blocks[0]
+    assert "<br/>" not in block.text
+    assert "KShs 000" in block.text

--- a/backend/tests/services/test_block_chunking_service.py
+++ b/backend/tests/services/test_block_chunking_service.py
@@ -248,3 +248,46 @@ def test_block_chunking_skips_chunk_when_table_has_no_text():
     assert all(c.content.strip() for c in chunks), "empty-content chunk produced"
     assert len(chunks) == 1
     assert "caption text" in chunks[0].content
+
+
+def test_block_chunking_table_uses_markdown_when_text_empty():
+    """TABLE with empty text but non-empty markdown (LlamaParse) must contribute content."""
+    svc = BlockChunkingService()
+    table_block = Block(
+        id="t1",
+        role=BlockRole.TABLE,
+        native_type="table",
+        page_index=0,
+        bbox=_bbox(y0=0.1),
+        text="",
+        markdown="| Name | Value |\n| --- | --- |\n| Revenue | 1,081,557 |",
+    ).model_dump()
+    blocks = [
+        _block("h1", BlockRole.HEADING, "Financials", y0=0.0).model_dump(),
+        table_block,
+    ]
+    chunks = svc.chunk_blocks(blocks=blocks, config=_config())
+
+    assert len(chunks) == 1
+    assert "Revenue" in chunks[0].content
+    assert "1,081,557" in chunks[0].content
+    assert "---" not in chunks[0].content
+
+
+def test_block_chunking_table_markdown_strips_html_br():
+    """<br/> tags within markdown table cells must not appear in chunk content."""
+    svc = BlockChunkingService()
+    table_block = Block(
+        id="t1",
+        role=BlockRole.TABLE,
+        native_type="table",
+        page_index=0,
+        bbox=_bbox(y0=0.0),
+        text="",
+        markdown="| Note | 2024<br/>KShs 000 |\n| --- | --- |\n| Revenue | 1,081,557 |",
+    ).model_dump()
+    chunks = svc.chunk_blocks(blocks=[table_block], config=_config(group_by_heading=False))
+
+    assert len(chunks) == 1
+    assert "<br/>" not in chunks[0].content
+    assert "KShs 000" in chunks[0].content


### PR DESCRIPTION
## Summary

- LlamaParse leaves `item['value']` empty for table items and puts all content in `item['md']` (GFM markdown). The adapter was assigning `text=str(item.get('value') or '')`, which silently dropped every table from chunk content — financial tables, audit tables, directorate tables, all invisible to embeddings.
- Adds `_md_table_to_text()` that strips GFM separator rows and `<br/>` tags, then returns a pipe-joined flat string of cell values (matching the LandingAI adapter's approach).
- Falls back to this function only when `native_type == 'table'`, `value` is empty, and `md` has content — no change in behaviour for non-table blocks.

## Root cause

Diagnosed against index `ec9bb675` (Acorn PBSA I-REIT 2024 Annual Report): all 12 table blocks had `text_len = 0` and `md_len` ranging from 293–6,560 chars. The chunker's `_build_chunk` uses `b.text`, so all table data was silently omitted from every chunk.

## Test plan

- [ ] `test_adapter_table_text_populated_from_markdown` — cell values appear in `Block.text`
- [ ] `test_adapter_table_text_excludes_separator_rows` — `---` separator rows not included
- [ ] `test_adapter_table_text_strips_html_br_tags` — `<br/>` cleaned, adjacent text preserved
- [ ] Full CDM + block chunking suite: 137 tests pass

**Note:** Existing indexes built from LlamaParse parse runs need to be re-indexed to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)