### PR TITLE
feat(extraction-ui): debug panels, chunk details, and FormattedJson renderer

### DIFF
--- a/backend/app/adapters/extraction/chunking/merge.py
+++ b/backend/app/adapters/extraction/chunking/merge.py
@@ -72,6 +72,18 @@ def merge_outputs(
     if scalar_conflicts:
         metadata["scalarConflicts"] = scalar_conflicts
 
+    first_meta = outputs[0].extraction_metadata or {}
+    if first_meta.get("model"):
+        metadata["model"] = first_meta["model"]
+    if first_meta.get("provider"):
+        metadata["provider"] = first_meta["provider"]
+    total_latency = sum(
+        int((out.extraction_metadata or {}).get("latency_ms", 0) or 0)
+        for out in outputs
+    )
+    if total_latency:
+        metadata["latency_ms"] = total_latency
+
     return ExtractionOutput(
         structured_data=merged_data,
         source_parse_run_id=outputs[0].source_parse_run_id,

--- a/backend/app/adapters/extraction/chunking/merge.py
+++ b/backend/app/adapters/extraction/chunking/merge.py
@@ -14,6 +14,7 @@ def merge_outputs(
     outputs: list[ExtractionOutput],
     schema: dict[str, Any],
     dedupe_key: str | None,
+    chunks: list | None = None,
 ) -> ExtractionOutput:
     props = schema.get("properties") or {}
     array_fields = {k for k, v in props.items() if v.get("type") == "array"}
@@ -83,6 +84,20 @@ def merge_outputs(
     )
     if total_latency:
         metadata["latency_ms"] = total_latency
+
+    if chunks is not None:
+        metadata["chunks"] = [
+            {
+                "chunkIndex": chunk.chunk_index,
+                "pageIndices": chunk.page_indices,
+                "promptMessages": (out.extraction_metadata or {}).get("prompt_messages"),
+                "providerResponseRaw": out.provider_response_raw,
+                "structuredData": out.structured_data,
+                "usage": (out.extraction_metadata or {}).get("usage"),
+                "latencyMs": (out.extraction_metadata or {}).get("latency_ms"),
+            }
+            for chunk, out in zip(chunks, outputs)
+        ]
 
     return ExtractionOutput(
         structured_data=merged_data,

--- a/backend/app/adapters/extraction/pipeline.py
+++ b/backend/app/adapters/extraction/pipeline.py
@@ -91,7 +91,7 @@ class PipelineExtractor(DataExtractor):
         # asyncio.gather raises the first ExtractionError -> whole result fails.
         results = await asyncio.gather(*[_run_chunk(c) for c in chunks])
         dedupe_key = self._chunking.get("config", {}).get("dedupeKey")
-        return merge_outputs(list(results), schema, dedupe_key)
+        return merge_outputs(list(results), schema, dedupe_key, chunks=chunks)
 
 
 def _doc_tokens(doc) -> int:

--- a/backend/tests/adapters/extraction/chunking/test_merge.py
+++ b/backend/tests/adapters/extraction/chunking/test_merge.py
@@ -1,6 +1,29 @@
+from dataclasses import dataclass
 from uuid import uuid4
 from app.adapters.extraction.chunking.merge import merge_outputs
 from app.ports.data_extraction import ExtractionOutput, FieldCitation
+
+
+@dataclass
+class _FakeChunk:
+    chunk_index: int
+    page_indices: list
+
+
+def _out_full(data, prompt_messages=None, provider_response=None, latency_ms=500):
+    return ExtractionOutput(
+        structured_data=data,
+        source_parse_run_id=_RUN,
+        citations=[],
+        provider_response_raw=provider_response or {"raw": "ok"},
+        extraction_metadata={
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            "prompt_messages": prompt_messages or [{"role": "system", "content": "sys"}],
+            "latency_ms": latency_ms,
+            "model": "claude-opus-4-7",
+            "provider": "anthropic",
+        },
+    )
 
 _RUN = uuid4()
 _SCHEMA = {
@@ -110,3 +133,38 @@ def test_model_provider_absent_when_not_in_chunk_metadata():
     assert "model" not in merged.extraction_metadata
     assert "provider" not in merged.extraction_metadata
     assert "latency_ms" not in merged.extraction_metadata
+
+
+def test_chunks_array_populated_when_chunks_param_provided():
+    c0 = _FakeChunk(chunk_index=0, page_indices=[0, 1])
+    c1 = _FakeChunk(chunk_index=1, page_indices=[2])
+    o0 = _out_full({"sku": "A"}, latency_ms=1000)
+    o1 = _out_full({"sku": "B"}, latency_ms=2000)
+
+    merged = merge_outputs([o0, o1], _SCHEMA, dedupe_key=None, chunks=[c0, c1])
+
+    assert "chunks" in merged.extraction_metadata
+    chunks = merged.extraction_metadata["chunks"]
+    assert len(chunks) == 2
+
+    assert chunks[0]["chunkIndex"] == 0
+    assert chunks[0]["pageIndices"] == [0, 1]
+    assert chunks[0]["latencyMs"] == 1000
+    assert chunks[0]["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    assert chunks[0]["structuredData"] == {"sku": "A"}
+    assert chunks[0]["providerResponseRaw"] == {"raw": "ok"}
+    assert chunks[0]["promptMessages"] == [{"role": "system", "content": "sys"}]
+
+    assert chunks[1]["chunkIndex"] == 1
+    assert chunks[1]["pageIndices"] == [2]
+    assert chunks[1]["latencyMs"] == 2000
+
+
+def test_chunks_key_absent_when_chunks_param_not_provided():
+    merged = merge_outputs([_out({})], _SCHEMA, dedupe_key=None)
+    assert "chunks" not in merged.extraction_metadata
+
+
+def test_chunks_key_absent_when_chunks_param_is_none():
+    merged = merge_outputs([_out({})], _SCHEMA, dedupe_key=None, chunks=None)
+    assert "chunks" not in merged.extraction_metadata

--- a/backend/tests/adapters/extraction/chunking/test_merge.py
+++ b/backend/tests/adapters/extraction/chunking/test_merge.py
@@ -84,3 +84,29 @@ def test_no_conflicts_key_absent_when_consistent():
         [_out({"currency": "EUR"}), _out({"currency": "EUR"})], _SCHEMA, dedupe_key=None,
     )
     assert "scalarConflicts" not in merged.extraction_metadata
+
+
+def test_model_provider_and_latency_propagated_from_chunks():
+    def _chunk(latency_ms: int) -> ExtractionOutput:
+        return ExtractionOutput(
+            structured_data={}, source_parse_run_id=_RUN,
+            citations=[], provider_response_raw=None,
+            extraction_metadata={
+                "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+                "model": "claude-opus-4-7",
+                "provider": "anthropic",
+                "latency_ms": latency_ms,
+            },
+        )
+
+    merged = merge_outputs([_chunk(1000), _chunk(2000)], _SCHEMA, dedupe_key=None)
+    assert merged.extraction_metadata["model"] == "claude-opus-4-7"
+    assert merged.extraction_metadata["provider"] == "anthropic"
+    assert merged.extraction_metadata["latency_ms"] == 3000
+
+
+def test_model_provider_absent_when_not_in_chunk_metadata():
+    merged = merge_outputs([_out({}), _out({})], _SCHEMA, dedupe_key=None)
+    assert "model" not in merged.extraction_metadata
+    assert "provider" not in merged.extraction_metadata
+    assert "latency_ms" not in merged.extraction_metadata

--- a/docs/superpowers/plans/2026-06-24-chunk-details-panel.md
+++ b/docs/superpowers/plans/2026-06-24-chunk-details-panel.md
@@ -1,0 +1,569 @@
+# Chunk Details Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface full per-chunk LLM prompts, responses, extracted data, and usage stats in a list+detail panel inside `ExtractionResultViewer` for chunked extraction runs.
+
+**Architecture:** Backend zips per-chunk `ExtractionOutput` with `DocumentChunk` metadata in `merge_outputs`, writing a `chunks` array into the merged `extractionMetadata` JSONB field. Frontend adds a `ChunkDetailsPanel` inner component to `ExtractionResultViewer` that renders a two-column layout — scrollable chunk list on the left, full detail pane on the right — collapsed by default, only shown when `chunks` data is present.
+
+**Tech Stack:** Python 3.12, FastAPI backend; React 18, TypeScript, shadcn/ui, Tailwind CSS frontend; Vitest + Testing Library.
+
+## Global Constraints
+
+- No new API endpoints, no DB migrations — all data stored in existing `extractionMetadata` JSONB column.
+- Per-chunk dict uses camelCase top-level keys (`chunkIndex`, `pageIndices`, `promptMessages`, `providerResponseRaw`, `structuredData`, `latencyMs`); `usage` keeps snake_case sub-keys (`prompt_tokens`, `completion_tokens`, `total_tokens`) to match the existing top-level `usage` convention.
+- Page indices in `pageIndices` are 0-based (CDM convention); UI displays them 1-based (`pageIndices[0] + 1`).
+- Chunk list labels: "Chunk N" (1-based: `chunkIndex + 1`); page badge "pp. X–Y" omitted when `pageIndices` is empty.
+- `merge_outputs` signature change is backward-compatible: `chunks` param defaults to `None`; existing call-sites and tests that omit it are unaffected.
+- `UserMessageDisplay` and `parseUserContent` from `ExtractionResultViewer.tsx` are reused in `ChunkDetailsPanel` — do not duplicate.
+- `FormattedJson` imported from `@/components/shared/FormattedJson`.
+- `cn` imported from `@/lib/utils` for conditional class merging.
+- Run backend tests: `uv run --directory backend python -m pytest tests/adapters/extraction/chunking/test_merge.py -v`
+- Run frontend tests: `npx vitest run --reporter verbose src/components/extraction/ExtractionResultViewer.test.tsx` (from `frontend/`)
+- Run frontend lint: `npm run lint` (from `frontend/`)
+
+---
+
+### Task 1: Backend — store per-chunk summaries in extractionMetadata
+
+**Files:**
+- Modify: `backend/app/adapters/extraction/chunking/merge.py`
+- Modify: `backend/app/adapters/extraction/pipeline.py`
+- Test: `backend/tests/adapters/extraction/chunking/test_merge.py`
+
+**Interfaces:**
+- Produces: `merge_outputs(..., chunks: list | None = None)` — when `chunks` is provided, merged `extractionMetadata` gains a `chunks` key containing a list of per-chunk dicts.
+- Per-chunk dict shape (consumed by Task 2):
+  ```python
+  {
+      "chunkIndex": int,          # 0-based
+      "pageIndices": list[int],   # 0-based page numbers
+      "promptMessages": list | None,
+      "providerResponseRaw": dict | None,
+      "structuredData": dict | None,
+      "usage": dict | None,       # {"prompt_tokens", "completion_tokens", "total_tokens"}
+      "latencyMs": int | None,
+  }
+  ```
+
+- [ ] **Step 1: Write failing tests for merge_outputs with chunks**
+
+Add to `backend/tests/adapters/extraction/chunking/test_merge.py`:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass
+class _FakeChunk:
+    chunk_index: int
+    page_indices: list
+
+
+def _out_full(data, prompt_messages=None, provider_response=None, latency_ms=500):
+    return ExtractionOutput(
+        structured_data=data,
+        source_parse_run_id=_RUN,
+        citations=[],
+        provider_response_raw=provider_response or {"raw": "ok"},
+        extraction_metadata={
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            "prompt_messages": prompt_messages or [{"role": "system", "content": "sys"}],
+            "latency_ms": latency_ms,
+            "model": "claude-opus-4-7",
+            "provider": "anthropic",
+        },
+    )
+
+
+def test_chunks_array_populated_when_chunks_param_provided():
+    c0 = _FakeChunk(chunk_index=0, page_indices=[0, 1])
+    c1 = _FakeChunk(chunk_index=1, page_indices=[2])
+    o0 = _out_full({"sku": "A"}, latency_ms=1000)
+    o1 = _out_full({"sku": "B"}, latency_ms=2000)
+
+    merged = merge_outputs([o0, o1], _SCHEMA, dedupe_key=None, chunks=[c0, c1])
+
+    assert "chunks" in merged.extraction_metadata
+    chunks = merged.extraction_metadata["chunks"]
+    assert len(chunks) == 2
+
+    assert chunks[0]["chunkIndex"] == 0
+    assert chunks[0]["pageIndices"] == [0, 1]
+    assert chunks[0]["latencyMs"] == 1000
+    assert chunks[0]["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    assert chunks[0]["structuredData"] == {"sku": "A"}
+    assert chunks[0]["providerResponseRaw"] == {"raw": "ok"}
+    assert chunks[0]["promptMessages"] == [{"role": "system", "content": "sys"}]
+
+    assert chunks[1]["chunkIndex"] == 1
+    assert chunks[1]["pageIndices"] == [2]
+    assert chunks[1]["latencyMs"] == 2000
+
+
+def test_chunks_key_absent_when_chunks_param_not_provided():
+    merged = merge_outputs([_out({})], _SCHEMA, dedupe_key=None)
+    assert "chunks" not in merged.extraction_metadata
+
+
+def test_chunks_key_absent_when_chunks_param_is_none():
+    merged = merge_outputs([_out({})], _SCHEMA, dedupe_key=None, chunks=None)
+    assert "chunks" not in merged.extraction_metadata
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+uv run --directory backend python -m pytest tests/adapters/extraction/chunking/test_merge.py::test_chunks_array_populated_when_chunks_param_provided -v
+```
+
+Expected: FAIL — `merge_outputs() got an unexpected keyword argument 'chunks'`
+
+- [ ] **Step 3: Implement merge_outputs changes**
+
+In `backend/app/adapters/extraction/chunking/merge.py`, update the function signature and add the chunks block after `metadata` is built:
+
+```python
+def merge_outputs(
+    outputs: list[ExtractionOutput],
+    schema: dict[str, Any],
+    dedupe_key: str | None,
+    chunks: list | None = None,
+) -> ExtractionOutput:
+```
+
+After the existing lines that build `metadata` (after the `if scalar_conflicts:` block and the existing model/provider/latency propagation), add:
+
+```python
+    if chunks is not None:
+        metadata["chunks"] = [
+            {
+                "chunkIndex": chunk.chunk_index,
+                "pageIndices": chunk.page_indices,
+                "promptMessages": (out.extraction_metadata or {}).get("prompt_messages"),
+                "providerResponseRaw": out.provider_response_raw,
+                "structuredData": out.structured_data,
+                "usage": (out.extraction_metadata or {}).get("usage"),
+                "latencyMs": (out.extraction_metadata or {}).get("latency_ms"),
+            }
+            for chunk, out in zip(chunks, outputs)
+        ]
+```
+
+- [ ] **Step 4: Update pipeline.py to pass chunks**
+
+In `backend/app/adapters/extraction/pipeline.py`, find the final `return merge_outputs(...)` call (the one inside the multi-chunk path, currently on the last line of the `extract` method):
+
+```python
+        dedupe_key = self._chunking.get("config", {}).get("dedupeKey")
+        return merge_outputs(list(results), schema, dedupe_key)
+```
+
+Change to:
+
+```python
+        dedupe_key = self._chunking.get("config", {}).get("dedupeKey")
+        return merge_outputs(list(results), schema, dedupe_key, chunks=chunks)
+```
+
+`chunks` here is the `list[DocumentChunk]` already in scope from line 75 (`chunks = strategy.split(...)`).
+
+- [ ] **Step 5: Run all merge tests to confirm pass**
+
+```
+uv run --directory backend python -m pytest tests/adapters/extraction/chunking/test_merge.py -v
+```
+
+Expected: All 13 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/adapters/extraction/chunking/merge.py backend/app/adapters/extraction/pipeline.py backend/tests/adapters/extraction/chunking/test_merge.py
+git commit -m "feat(extraction): store per-chunk prompt, response, and usage in extractionMetadata.chunks"
+```
+
+---
+
+### Task 2: Frontend — Chunk Details panel in ExtractionResultViewer
+
+**Files:**
+- Modify: `frontend/src/components/extraction/ExtractionResultViewer.tsx`
+- Modify: `frontend/src/components/extraction/ExtractionResultViewer.test.tsx`
+
+**Interfaces:**
+- Consumes from Task 1: `extractionMetadata.chunks` array with shape described above.
+- Consumes from existing code: `UserMessageDisplay`, `parseUserContent`, `FormattedJson`, `ConfigRow` — all defined earlier in `ExtractionResultViewer.tsx`; do not duplicate.
+- `cn` from `@/lib/utils`.
+- shadcn Badge from `@/components/ui/badge` (already imported).
+
+- [ ] **Step 1: Write failing tests**
+
+Add the following to `frontend/src/components/extraction/ExtractionResultViewer.test.tsx` (after the existing `buildChunkedResult` helper, before the existing `describe` block):
+
+```tsx
+function buildChunkedResultWithDetails(
+  overrides: Partial<ExtractionResult> = {}
+): ExtractionResult {
+  return buildResult({
+    extractionMethod: 'llm',
+    extractionMetadata: {
+      chunkCount: 2,
+      usage: { total_tokens: 6400 },
+      model: 'claude-opus-4-7',
+      provider: 'anthropic',
+      latency_ms: 2700,
+      chunks: [
+        {
+          chunkIndex: 0,
+          pageIndices: [0, 1, 2],
+          promptMessages: [
+            { role: 'system', content: 'Shared system prompt.' },
+            {
+              role: 'user',
+              content:
+                'Extract.\n<schema>{"type":"object"}</schema>\n<document>Page 1 content</document>',
+            },
+          ],
+          providerResponseRaw: { id: 'r1', answer: 'chunk-1-response' },
+          structuredData: { invoice: 'INV-001' },
+          usage: { prompt_tokens: 3000, completion_tokens: 500, total_tokens: 3500 },
+          latencyMs: 1500,
+        },
+        {
+          chunkIndex: 1,
+          pageIndices: [3, 4],
+          promptMessages: [
+            { role: 'system', content: 'Shared system prompt.' },
+            {
+              role: 'user',
+              content:
+                'Extract.\n<schema>{"type":"object"}</schema>\n<document>Page 4 content</document>',
+            },
+          ],
+          providerResponseRaw: { id: 'r2', answer: 'chunk-2-response' },
+          structuredData: { invoice: 'INV-002' },
+          usage: { prompt_tokens: 2500, completion_tokens: 400, total_tokens: 2900 },
+          latencyMs: 1200,
+        },
+      ],
+    },
+    providerResponseRaw: null,
+    ...overrides,
+  })
+}
+```
+
+Add a new `describe` block at the end of the test file:
+
+```tsx
+describe('Chunk Details panel', () => {
+  it('is hidden when extractionMetadata has no chunks array', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.queryByText('Chunk Details')).not.toBeInTheDocument()
+  })
+
+  it('shows chunk list with page range badges', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText('Chunk 1')).toBeInTheDocument()
+    expect(screen.getByText('pp. 1–3')).toBeInTheDocument()
+    expect(screen.getByText('Chunk 2')).toBeInTheDocument()
+    expect(screen.getByText('pp. 4–5')).toBeInTheDocument()
+  })
+
+  it('shows system prompt with shared-across-chunks note by default', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText('Shared system prompt.')).toBeInTheDocument()
+    expect(screen.getByText(/identical across all chunks/i)).toBeInTheDocument()
+  })
+
+  it('shows pre-merge note in extracted section', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText(/pre-merge/i)).toBeInTheDocument()
+    expect(screen.getByText(/conflict resolution and deduplication/i)).toBeInTheDocument()
+  })
+
+  it('shows first chunk document content by default', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText('Page 1 content')).toBeInTheDocument()
+  })
+
+  it('switches detail pane when second chunk row is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    const chunkButtons = screen.getAllByRole('button')
+    const chunk2Btn = chunkButtons.find((b) => b.textContent?.includes('Chunk 2'))!
+    await user.click(chunk2Btn)
+    expect(screen.getByText('Page 4 content')).toBeInTheDocument()
+  })
+
+  it('shows token counts for selected chunk', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    // Chunk 1 total tokens = 3,500
+    expect(screen.getByText('3,500')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+npx vitest run --reporter verbose src/components/extraction/ExtractionResultViewer.test.tsx
+```
+
+Expected: 6 new tests FAIL — "Chunk Details" not found.
+
+- [ ] **Step 3: Add ChunkDetail interface and ChunkDetailsPanel to ExtractionResultViewer.tsx**
+
+Add the `cn` import and `ChunkDetail` interface, then the `ChunkDetailsPanel` component. Place these immediately after the `NotAvailableChunked` component definition (before `UserMessageDisplay`).
+
+**Add to imports at top of file:**
+```tsx
+import { cn } from '@/lib/utils'
+```
+
+**Add after `NotAvailableChunked` component:**
+
+```tsx
+interface ChunkDetail {
+  chunkIndex: number
+  pageIndices: number[]
+  promptMessages: Array<{ role: string; content: string }> | null
+  providerResponseRaw: Record<string, unknown> | null
+  structuredData: Record<string, unknown> | null
+  usage: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+  } | null
+  latencyMs: number | null
+}
+
+function ChunkDetailsPanel({ chunks }: { chunks: ChunkDetail[] }) {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const chunk = chunks[selectedIndex]
+  const systemContent = chunk.promptMessages?.[0]?.content ?? null
+  const userMessage = chunk.promptMessages?.[1] ?? null
+
+  return (
+    <div className="grid grid-cols-[16rem_1fr] divide-x overflow-hidden">
+      {/* Chunk list */}
+      <div className="overflow-y-auto max-h-[32rem]">
+        {chunks.map((c, i) => {
+          const pages = c.pageIndices
+          const pageLabel =
+            pages.length > 0
+              ? `pp. ${pages[0] + 1}–${pages[pages.length - 1] + 1}`
+              : null
+          const tokens = c.usage?.total_tokens?.toLocaleString() ?? '—'
+          const latency =
+            c.latencyMs != null ? `${c.latencyMs.toLocaleString()} ms` : '—'
+          return (
+            <button
+              key={i}
+              onClick={() => setSelectedIndex(i)}
+              className={cn(
+                'w-full text-left px-4 py-3 border-b last:border-b-0 hover:bg-muted/50 transition-colors',
+                selectedIndex === i && 'bg-muted border-l-2 border-l-primary'
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold">
+                  Chunk {c.chunkIndex + 1}
+                </span>
+                {pageLabel && (
+                  <Badge variant="outline" className="text-xs font-normal">
+                    {pageLabel}
+                  </Badge>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {tokens} tokens · {latency}
+              </p>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Detail pane */}
+      <div className="overflow-y-auto max-h-[32rem] px-4 py-3 space-y-4">
+        {/* System */}
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <p className="text-xs font-semibold text-muted-foreground">System</p>
+            <span className="text-xs text-muted-foreground italic">
+              · identical across all chunks
+            </span>
+          </div>
+          <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-48 whitespace-pre-wrap">
+            {systemContent ?? '—'}
+          </pre>
+        </div>
+
+        {/* User */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">User</p>
+          {userMessage ? (
+            <UserMessageDisplay content={userMessage.content} />
+          ) : (
+            <p className="text-sm text-muted-foreground italic">—</p>
+          )}
+        </div>
+
+        {/* LLM Response */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">
+            LLM Response
+          </p>
+          {chunk.providerResponseRaw ? (
+            <FormattedJson value={chunk.providerResponseRaw} maxHeight="20rem" />
+          ) : (
+            <p className="text-sm text-muted-foreground italic">
+              No response recorded for this chunk.
+            </p>
+          )}
+        </div>
+
+        {/* Extracted (pre-merge) */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-0.5">
+            Extracted{' '}
+            <span className="font-normal italic">(pre-merge)</span>
+          </p>
+          <p className="text-xs text-muted-foreground mb-1">
+            Raw output before conflict resolution and deduplication.
+          </p>
+          <FormattedJson value={chunk.structuredData ?? {}} maxHeight="16rem" />
+        </div>
+
+        {/* Usage */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-2">Usage</p>
+          <div className="grid grid-cols-4 gap-3">
+            {(
+              [
+                ['Prompt tokens', chunk.usage?.prompt_tokens],
+                ['Completion tokens', chunk.usage?.completion_tokens],
+                ['Total tokens', chunk.usage?.total_tokens],
+                ['Latency', chunk.latencyMs != null ? `${chunk.latencyMs.toLocaleString()} ms` : null],
+              ] as [string, number | string | null | undefined][]
+            ).map(([label, val]) => (
+              <div key={label}>
+                <p className="text-xs text-muted-foreground">{label}</p>
+                <p className="text-sm">
+                  {val != null
+                    ? typeof val === 'number'
+                      ? val.toLocaleString()
+                      : val
+                    : '—'}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+Note: `useState` is already imported via React in the file. If not, add `import { useState } from 'react'`.
+
+- [ ] **Step 4: Add Chunk Details collapsible to ExtractionResultViewer render**
+
+In the `ExtractionResultViewer` component, after casting `meta` and `cfg`, add:
+
+```tsx
+const chunks = (meta?.chunks ?? null) as ChunkDetail[] | null
+```
+
+Then add the Chunk Details panel as the last item in the returned `<div className="space-y-4">`, after the LLM Response panel:
+
+```tsx
+{/* ── Chunk Details panel (chunked runs only) ────────────────────── */}
+{chunks && chunks.length > 0 && (
+  <Collapsible>
+    <CollapsibleTrigger asChild>
+      <Button variant="outline" size="sm" className="w-full justify-between">
+        <span>Chunk Details</span>
+        <ChevronDown className="h-4 w-4" />
+      </Button>
+    </CollapsibleTrigger>
+    <CollapsibleContent>
+      <Card className="mt-2 overflow-hidden">
+        <ChunkDetailsPanel chunks={chunks} />
+      </Card>
+    </CollapsibleContent>
+  </Collapsible>
+)}
+```
+
+- [ ] **Step 5: Run targeted tests**
+
+```
+npx vitest run --reporter verbose src/components/extraction/ExtractionResultViewer.test.tsx
+```
+
+Expected: All 25 tests PASS (19 existing + 6 new).
+
+- [ ] **Step 6: Run full frontend test suite**
+
+```
+npx vitest run --reporter verbose
+```
+
+Expected: All tests PASS; no regressions.
+
+- [ ] **Step 7: Run lint**
+
+```
+npm run lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/extraction/ExtractionResultViewer.tsx frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+git commit -m "feat(extraction-ui): add Chunk Details panel with list+detail view for per-chunk prompts, responses, and usage"
+```
+
+---
+
+## Self-Review vs Spec
+
+**Spec coverage:**
+
+| Requirement | Task |
+|---|---|
+| `extractionMetadata.chunks` populated with `chunkIndex`, `pageIndices`, `promptMessages`, `providerResponseRaw`, `structuredData`, `usage`, `latencyMs` | Task 1 |
+| `merge_outputs` backward-compatible (`chunks` defaults to `None`) | Task 1 — optional param, existing tests pass |
+| `pipeline.py` passes `chunks=chunks` to `merge_outputs` at multi-chunk call-site | Task 1 Step 4 |
+| Panel hidden when no chunks | Task 2 test + `chunks && chunks.length > 0` guard |
+| Chunk list shows page ranges (1-based, badge omitted when empty) | Task 2 `ChunkDetailsPanel` |
+| Chunk list shows formatted tokens + latency | Task 2 `ChunkDetailsPanel` |
+| Selecting chunk updates detail pane | Task 2 `useState(selectedIndex)` |
+| System prompt + "identical across all chunks" note | Task 2 |
+| User message parsed (instruction/schema/document) via `UserMessageDisplay` | Task 2 — reuses existing helper |
+| LLM Response via `FormattedJson` | Task 2 |
+| Extracted (pre-merge) via `FormattedJson` + note | Task 2 |
+| Usage 4-cell grid (prompt/completion/total/latency) | Task 2 |
+| `parseUserContent` reused, not duplicated | Task 2 — `UserMessageDisplay` component call |
+| All new behaviour covered by unit tests | Tasks 1 + 2 |
+| No regressions | Task 2 Step 6 full suite |
+
+**Placeholder scan:** No TBDs, no "implement later". All code blocks are complete.
+
+**Type consistency:** `ChunkDetail.usage` uses `prompt_tokens` / `completion_tokens` / `total_tokens` (snake_case), matching the backend output from `extraction_metadata.get("usage")`. `ChunkDetail.latencyMs` (camelCase) matches `"latencyMs"` key written by `merge_outputs`. Consistent throughout Tasks 1 and 2.

--- a/docs/superpowers/plans/2026-06-24-extraction-chunking-ui.md
+++ b/docs/superpowers/plans/2026-06-24-extraction-chunking-ui.md
@@ -1,0 +1,572 @@
+# Extraction Chunking UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface chunking config, citation granularity, and chunking result metadata in the extraction UI (frontend only).
+
+**Architecture:** The `/extractions/run` endpoint already accepts `chunking`/`preprocess`. This plan threads those fields through the frontend types + `runExtractionWithParse` hook, adds hand-built LLM-only controls to `ExtractionForm`, and adds a result-side summary to `ExtractionResultViewer`. No backend changes.
+
+**Tech Stack:** React 18, TypeScript, Vite, shadcn/ui (Radix), Tailwind, Vitest + Testing Library + happy-dom.
+
+## Global Constraints
+
+- All frontend commands run from the `frontend/` directory (e.g. `npx vitest run <path>`).
+- Spec: `docs/superpowers/specs/2026-06-24-extraction-chunking-ui-design.md`. Issue: #102.
+- Controls are LLM-method-only; default `strategy: none` + `citationLevel: auto` → request must be byte-identical to today (no `chunking` key sent).
+- Hand-built controls (no schema-driven renderer, no new endpoints). No `preprocess` UI (type is forwarded only).
+- Match existing form/component patterns (shadcn `Select`, `Input`, `Collapsible`, `Badge`).
+
+---
+
+## File Structure
+
+- `frontend/src/types/extraction.ts` — add `ChunkingConfig`, `PreprocessStage`; extend `RunExtractionRequest` and `RunWithParseRequest.extractionConfig`.
+- `frontend/src/hooks/useExtractionResults.ts` — forward `chunking`/`preprocess` in `runExtractionWithParse`.
+- `frontend/src/test/setup.ts` — add Radix pointer-capture/scrollIntoView polyfills for Select tests.
+- `frontend/src/components/extraction/ExtractionForm.tsx` — "Large document handling" controls + request building.
+- `frontend/src/components/extraction/ChunkingSummary.tsx` — new presentational summary component.
+- `frontend/src/components/extraction/ExtractionResultViewer.tsx` — render `ChunkingSummary`.
+
+---
+
+## Task 1: Forward chunking/preprocess through types + hook
+
+**Files:**
+- Modify: `frontend/src/types/extraction.ts:61-68` (and `RunWithParseRequest` at `80-94`)
+- Modify: `frontend/src/hooks/useExtractionResults.ts:223-230`
+- Test: `frontend/src/hooks/useExtractionResults.test.ts`
+
+**Interfaces:**
+- Produces: `ChunkingConfig { strategy: string; config?: Record<string, unknown>; citationLevel?: 'auto'|'full'|'page_only'|'off' }`; `PreprocessStage { stage: string; config: Record<string, unknown> }`. `RunExtractionRequest` and `RunWithParseRequest.extractionConfig` gain optional `chunking?: ChunkingConfig` and `preprocess?: PreprocessStage[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/hooks/useExtractionResults.test.ts` inside the `describe('runExtractionWithParse', ...)` block:
+
+```ts
+it('forwards chunking config to runExtraction', async () => {
+  const existingRun = makeParseRun({
+    id: 'run-match', parser: 'simple', config: { parser: 'simple' }, status: 'succeeded',
+  })
+  mockExtraction.runExtraction.mockResolvedValue(fakeExtractionResult)
+
+  const { result } = renderHook(() => useExtractionResults('doc-1'))
+
+  const requestWithChunking = {
+    ...baseRequest,
+    extractionConfig: {
+      ...baseRequest.extractionConfig,
+      chunking: { strategy: 'token_budget_pages', config: { maxInputTokens: 6000 }, citationLevel: 'auto' as const },
+    },
+  }
+
+  await act(async () => {
+    await result.current.runExtractionWithParse('doc-1', [existingRun], requestWithChunking)
+  })
+
+  expect(mockExtraction.runExtraction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      chunking: { strategy: 'token_budget_pages', config: { maxInputTokens: 6000 }, citationLevel: 'auto' },
+    })
+  )
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `frontend/`): `npx vitest run src/hooks/useExtractionResults.test.ts -t "forwards chunking"`
+Expected: FAIL — `runExtraction` called without a `chunking` property (and a TS error that `chunking` is not assignable to `extractionConfig`).
+
+- [ ] **Step 3: Add the types**
+
+In `frontend/src/types/extraction.ts`, add after `RunExtractionRequest` (around line 68):
+
+```ts
+export interface ChunkingConfig {
+  strategy: string
+  config?: Record<string, unknown>
+  citationLevel?: 'auto' | 'full' | 'page_only' | 'off'
+}
+
+export interface PreprocessStage {
+  stage: string
+  config: Record<string, unknown>
+}
+```
+
+Extend `RunExtractionRequest` (lines 61-68) to:
+
+```ts
+export interface RunExtractionRequest {
+  parseRunId: string
+  extractionSchemaId: string
+  extractionMethod: string
+  config?: Record<string, unknown>
+  llmConfig?: PromptConfig
+  userPromptTemplate?: string
+  chunking?: ChunkingConfig
+  preprocess?: PreprocessStage[]
+}
+```
+
+Extend `RunWithParseRequest.extractionConfig` (lines 87-93) to add the two fields:
+
+```ts
+  extractionConfig: {
+    extractionSchemaId: string
+    extractionMethod: string
+    config?: Record<string, unknown>
+    llmConfig?: PromptConfig
+    userPromptTemplate?: string
+    chunking?: ChunkingConfig
+    preprocess?: PreprocessStage[]
+  }
+```
+
+- [ ] **Step 4: Forward the fields in the hook**
+
+In `frontend/src/hooks/useExtractionResults.ts`, update the `runExtraction` call (lines 223-230) to:
+
+```ts
+        await extractionApi.runExtraction({
+          parseRunId: parseRunId!,
+          extractionSchemaId: extractionConfig.extractionSchemaId,
+          extractionMethod: extractionConfig.extractionMethod,
+          config: extractionConfig.config,
+          llmConfig: extractionConfig.llmConfig,
+          userPromptTemplate: extractionConfig.userPromptTemplate,
+          chunking: extractionConfig.chunking,
+          preprocess: extractionConfig.preprocess,
+        })
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run (from `frontend/`): `npx vitest run src/hooks/useExtractionResults.test.ts`
+Expected: PASS (all existing tests + the new one).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/types/extraction.ts frontend/src/hooks/useExtractionResults.ts frontend/src/hooks/useExtractionResults.test.ts
+git commit -m "feat(extraction-ui): forward chunking/preprocess through types and run hook"
+```
+
+---
+
+## Task 2: "Large document handling" controls in ExtractionForm
+
+**Files:**
+- Modify: `frontend/src/test/setup.ts`
+- Modify: `frontend/src/components/extraction/ExtractionForm.tsx`
+- Test: `frontend/src/components/extraction/ExtractionForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `ChunkingConfig` (Task 1).
+- Produces: form emits `extractionConfig.chunking` per the rules: built only when `strategy !== 'none'` or `citationLevel !== 'auto'`; never for `llamaextract`.
+
+- [ ] **Step 1: Add Radix test polyfills**
+
+Radix `Select` relies on pointer-capture and `scrollIntoView`, which happy-dom lacks. Append to `frontend/src/test/setup.ts`:
+
+```ts
+// Radix UI Select/Dropdown rely on pointer capture + scrollIntoView, absent in happy-dom
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `frontend/src/components/extraction/ExtractionForm.test.tsx`. First add an `llmExtractor` constant near the top (after the existing `extractor` const):
+
+```ts
+const llmExtractor: ExtractorInfo = {
+  extractionMethod: 'llm',
+  name: 'LLM',
+  description: 'Generic LLM extraction',
+  configSchema: null,
+  configured: true,
+}
+```
+
+Then add these tests inside `describe('ExtractionForm', ...)`:
+
+```ts
+it('omits chunking from the request when LLM defaults are unchanged', async () => {
+  const user = userEvent.setup()
+  const onRun = vi.fn().mockResolvedValue(undefined)
+  render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={onRun} />)
+  await act(async () => {})
+  await user.click(screen.getByRole('button', { name: /run extraction/i }))
+  const arg = onRun.mock.calls[0][0]
+  expect(arg.extractionConfig.chunking).toBeUndefined()
+})
+
+it('does not show Large document handling for llamaextract', () => {
+  render(<ExtractionForm {...defaultProps} onRun={vi.fn()} />)
+  expect(screen.queryByText(/large document handling/i)).not.toBeInTheDocument()
+})
+
+it('emits token_budget_pages chunking with default max input tokens', async () => {
+  const user = userEvent.setup()
+  const onRun = vi.fn().mockResolvedValue(undefined)
+  render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={onRun} />)
+  await act(async () => {})
+
+  await user.click(screen.getByRole('button', { name: /large document handling/i }))
+  await user.click(screen.getByRole('combobox', { name: /chunking strategy/i }))
+  await user.click(screen.getByRole('option', { name: /token-budgeted pages/i }))
+  await user.click(screen.getByRole('button', { name: /run extraction/i }))
+
+  const arg = onRun.mock.calls[0][0]
+  expect(arg.extractionConfig.chunking).toEqual({
+    strategy: 'token_budget_pages',
+    config: { maxInputTokens: 8000 },
+    citationLevel: 'auto',
+  })
+})
+
+it('emits citation-only chunking when only citation level changes', async () => {
+  const user = userEvent.setup()
+  const onRun = vi.fn().mockResolvedValue(undefined)
+  render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={onRun} />)
+  await act(async () => {})
+
+  await user.click(screen.getByRole('button', { name: /large document handling/i }))
+  await user.click(screen.getByRole('combobox', { name: /citation detail/i }))
+  await user.click(screen.getByRole('option', { name: /page only/i }))
+  await user.click(screen.getByRole('button', { name: /run extraction/i }))
+
+  const arg = onRun.mock.calls[0][0]
+  expect(arg.extractionConfig.chunking).toEqual({ strategy: 'none', citationLevel: 'page_only' })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run (from `frontend/`): `npx vitest run src/components/extraction/ExtractionForm.test.tsx`
+Expected: FAIL — new tests fail (no "Large document handling" control; `chunking` never set).
+
+- [ ] **Step 4: Add imports, state, and controls**
+
+In `frontend/src/components/extraction/ExtractionForm.tsx`, add imports:
+
+```ts
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Pencil, Play, ChevronDown } from 'lucide-react'
+import type { ExtractionSchema, ExtractorInfo, RunWithParseRequest, ChunkingConfig } from '@/types/extraction'
+```
+
+(Replace the existing `lucide-react` import line and the existing type import line with the versions above.)
+
+Add state alongside the other LLM state (after line 60):
+
+```ts
+  const [chunkStrategy, setChunkStrategy] = useState<'none' | 'token_budget_pages'>('none')
+  const [maxInputTokens, setMaxInputTokens] = useState('8000')
+  const [pageOverlap, setPageOverlap] = useState('0')
+  const [dedupeKey, setDedupeKey] = useState('')
+  const [citationLevel, setCitationLevel] =
+    useState<'auto' | 'full' | 'page_only' | 'off'>('auto')
+```
+
+In `handleRun`, replace the `else if (extractionMethod === 'llm')` branch (lines 131-138) with:
+
+```ts
+    } else if (extractionMethod === 'llm') {
+      let chunking: ChunkingConfig | undefined
+      if (chunkStrategy !== 'none') {
+        const cfg: Record<string, unknown> = {}
+        const max = parseInt(maxInputTokens, 10)
+        if (!Number.isNaN(max)) cfg.maxInputTokens = max
+        const overlap = parseInt(pageOverlap, 10)
+        if (!Number.isNaN(overlap) && overlap > 0) cfg.pageOverlap = overlap
+        if (dedupeKey.trim()) cfg.dedupeKey = dedupeKey.trim()
+        chunking = { strategy: chunkStrategy, config: cfg, citationLevel }
+      } else if (citationLevel !== 'auto') {
+        chunking = { strategy: 'none', citationLevel }
+      }
+      extractionConfig = {
+        extractionSchemaId: schemaId,
+        extractionMethod,
+        config: { structured_output_mode: structuredOutputMode, inject_block_ids: injectBlockIds },
+        llmConfig: promptConfig,
+        userPromptTemplate: userPromptTemplate.trim() || undefined,
+        ...(chunking ? { chunking } : {}),
+      }
+    }
+```
+
+Add the controls inside the LLM config block, immediately before its closing `</div>` (after the output-mode grid that ends at line 309):
+
+```tsx
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="sm" className="w-full justify-between px-0">
+                <span className="text-xs font-medium">Large document handling</span>
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-3 pt-2">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Chunking</Label>
+                  <Select value={chunkStrategy} onValueChange={(v) => setChunkStrategy(v as 'none' | 'token_budget_pages')}>
+                    <SelectTrigger className="h-9" aria-label="Chunking strategy"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">None (single-shot)</SelectItem>
+                      <SelectItem value="token_budget_pages">Token-budgeted pages</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Citation detail</Label>
+                  <Select value={citationLevel} onValueChange={(v) => setCitationLevel(v as 'auto' | 'full' | 'page_only' | 'off')}>
+                    <SelectTrigger className="h-9" aria-label="Citation detail"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="auto">Auto</SelectItem>
+                      <SelectItem value="full">Full</SelectItem>
+                      <SelectItem value="page_only">Page only</SelectItem>
+                      <SelectItem value="off">Off</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              {chunkStrategy === 'token_budget_pages' && (
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Max input tokens</Label>
+                    <Input type="number" value={maxInputTokens} onChange={(e) => setMaxInputTokens(e.target.value)} className="h-9" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Page overlap</Label>
+                    <Input type="number" value={pageOverlap} onChange={(e) => setPageOverlap(e.target.value)} className="h-9" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Dedupe key</Label>
+                    <Input value={dedupeKey} onChange={(e) => setDedupeKey(e.target.value)} placeholder="e.g. sku" className="h-9" />
+                  </div>
+                </div>
+              )}
+              <p className="text-[11px] text-muted-foreground">
+                {citationLevel === 'off'
+                  ? 'No provenance will be captured.'
+                  : 'Auto uses page-level provenance on large documents. Chunking splits big docs to avoid truncation and rate limits.'}
+              </p>
+            </CollapsibleContent>
+          </Collapsible>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run (from `frontend/`): `npx vitest run src/components/extraction/ExtractionForm.test.tsx`
+Expected: PASS (existing + 4 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/test/setup.ts frontend/src/components/extraction/ExtractionForm.tsx frontend/src/components/extraction/ExtractionForm.test.tsx
+git commit -m "feat(extraction-ui): add LLM-only chunking + citation controls to ExtractionForm"
+```
+
+---
+
+## Task 3: Chunking result summary in ExtractionResultViewer
+
+**Files:**
+- Create: `frontend/src/components/extraction/ChunkingSummary.tsx`
+- Create: `frontend/src/components/extraction/ChunkingSummary.test.tsx`
+- Modify: `frontend/src/components/extraction/ExtractionResultViewer.tsx`
+
+**Interfaces:**
+- Produces: `ChunkingSummary({ metadata }: { metadata: Record<string, unknown> | null | undefined })` — renders a chunk-count/usage strip and a scalar-conflicts callout; renders `null` when none present.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/extraction/ChunkingSummary.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChunkingSummary } from './ChunkingSummary'
+
+describe('ChunkingSummary', () => {
+  it('renders chunk count and token usage when present', () => {
+    render(<ChunkingSummary metadata={{ chunkCount: 3, usage: { total_tokens: 4210 } }} />)
+    expect(screen.getByText(/3 chunks/i)).toBeInTheDocument()
+    expect(screen.getByText(/4,210 tokens/i)).toBeInTheDocument()
+  })
+
+  it('renders a conflicts callout when scalarConflicts present', () => {
+    render(
+      <ChunkingSummary
+        metadata={{ chunkCount: 2, scalarConflicts: [{ path: 'currency', kept: 'EUR', discarded: 'USD' }] }}
+      />
+    )
+    expect(screen.getByText(/conflicting values/i)).toBeInTheDocument()
+    expect(screen.getByText(/currency/)).toBeInTheDocument()
+  })
+
+  it('renders nothing when metadata lacks chunking fields', () => {
+    const { container } = render(<ChunkingSummary metadata={{ model: 'x', usage: {} }} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when metadata is null', () => {
+    const { container } = render(<ChunkingSummary metadata={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (from `frontend/`): `npx vitest run src/components/extraction/ChunkingSummary.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/extraction/ChunkingSummary.tsx`:
+
+```tsx
+import { Badge } from '@/components/ui/badge'
+
+interface ScalarConflict {
+  path: string
+  kept: unknown
+  discarded: unknown
+}
+
+interface ChunkingSummaryProps {
+  metadata: Record<string, unknown> | null | undefined
+}
+
+export function ChunkingSummary({ metadata }: ChunkingSummaryProps) {
+  if (!metadata) return null
+
+  const chunkCount = typeof metadata.chunkCount === 'number' ? metadata.chunkCount : undefined
+  const usage = metadata.usage as { total_tokens?: number } | undefined
+  const totalTokens =
+    usage && typeof usage.total_tokens === 'number' ? usage.total_tokens : undefined
+  const conflicts: ScalarConflict[] = Array.isArray(metadata.scalarConflicts)
+    ? (metadata.scalarConflicts as ScalarConflict[])
+    : []
+
+  if (chunkCount === undefined && totalTokens === undefined && conflicts.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {chunkCount !== undefined && (
+          <Badge variant="secondary">
+            {chunkCount} chunk{chunkCount === 1 ? '' : 's'}
+          </Badge>
+        )}
+        {totalTokens !== undefined && (
+          <Badge variant="outline">{totalTokens.toLocaleString()} tokens</Badge>
+        )}
+      </div>
+      {conflicts.length > 0 && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-800">
+          <p className="font-medium">Conflicting values across chunks ({conflicts.length})</p>
+          <ul className="mt-1 space-y-0.5">
+            {conflicts.map((c, i) => (
+              <li key={i}>
+                <code>{c.path}</code>: kept {String(c.kept)} ≠ {String(c.discarded)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run (from `frontend/`): `npx vitest run src/components/extraction/ChunkingSummary.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Render it in the viewer**
+
+In `frontend/src/components/extraction/ExtractionResultViewer.tsx`, add the import:
+
+```ts
+import { ChunkingSummary } from './ChunkingSummary'
+```
+
+Render it as the first child of the outer container, just after `if (!result) return null` — change the opening of the returned JSX from:
+
+```tsx
+  return (
+    <div className="space-y-4">
+      <Card>
+```
+
+to:
+
+```tsx
+  return (
+    <div className="space-y-4">
+      <ChunkingSummary metadata={result.extractionMetadata} />
+      <Card>
+```
+
+- [ ] **Step 6: Run the full extraction component suite**
+
+Run (from `frontend/`): `npx vitest run src/components/extraction`
+Expected: PASS (ChunkingSummary, ExtractionForm, ExtractionResultViewer suites all green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/extraction/ChunkingSummary.tsx frontend/src/components/extraction/ChunkingSummary.test.tsx frontend/src/components/extraction/ExtractionResultViewer.tsx
+git commit -m "feat(extraction-ui): show chunk count, usage, and scalar conflicts in result viewer"
+```
+
+---
+
+## Task 4: Type-check + build gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type-check**
+
+Run (from `frontend/`): `npx tsc --noEmit`
+Expected: exit 0 (no type errors).
+
+- [ ] **Step 2: Lint**
+
+Run (from `frontend/`): `npm run lint`
+Expected: no new errors in the changed files. Fix any introduced.
+
+- [ ] **Step 3: Build**
+
+Run (from `frontend/`): `npm run build`
+Expected: success.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** controls LLM-only + collapsible + default none (T2); strategy/params/citation controls (T2); type + hook forwarding (T1); request built only when non-default and never for llamaextract (T2 + tests); result summary with chunk count/usage/conflicts (T3); truncation via existing `statusMessage` (no change needed, noted in spec); tests across all three (every task). All spec sections map to a task.
+- **Backward compatibility:** `chunking` omitted when defaults unchanged (T2 test `omits chunking ...`); `preprocess` type forwarded but no UI.
+- **Type consistency:** `ChunkingConfig` shape (T1) matches the object built in `ExtractionForm.handleRun` (T2) and the hook forwarding (T1). `ChunkingSummary` prop type `Record<string, unknown> | null | undefined` matches `ExtractionResult.extractionMetadata` (`Record<string, unknown> | null`).
+- **Radix test reliability:** pointer-capture/scrollIntoView polyfills added in T2 (setup.ts); selects targeted by `aria-label` so option-clicks are unambiguous.

--- a/docs/superpowers/plans/2026-06-24-extraction-result-debug-panel.md
+++ b/docs/superpowers/plans/2026-06-24-extraction-result-debug-panel.md
@@ -1,0 +1,965 @@
+# Extraction Result Debug Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace two raw-JSON collapsibles in `ExtractionResultViewer` with three structured debug panels (Run Config, Prompt, LLM Response) and a shared `FormattedJson` syntax-coloured renderer.
+
+**Architecture:** New `FormattedJson` shared component does syntax colouring via regex (no external deps). `ExtractionResultViewer` gains three `Collapsible` panels that read from `result.extractionMetadata` and `result.config`; chunked runs show muted placeholders for absent fields.
+
+**Tech Stack:** React 18, TypeScript, shadcn/ui (`Tabs`, `Separator`, `Collapsible`, `Card`), Tailwind CSS, Vitest + Testing Library.
+
+## Global Constraints
+
+- No new API fields, no backend changes — frontend only.
+- All JSON values rendered via `FormattedJson`; no raw `JSON.stringify` in `<pre>` blocks visible to users.
+- All new behaviour must be covered by unit tests.
+- `shadcn/ui` components used for all UI; `tabs.tsx` and `separator.tsx` already installed at `frontend/src/components/ui/`.
+- Run tests with: `npx vitest run --reporter verbose <file>` from `frontend/` directory (absolute path: `C:\Repos\rag-admin\frontend`).
+- Lint with: `npm run lint` from `frontend/` directory.
+
+---
+
+### Task 1: FormattedJson shared component
+
+**Files:**
+- Create: `frontend/src/components/shared/FormattedJson.tsx`
+- Create: `frontend/src/components/shared/FormattedJson.test.tsx`
+
+**Interfaces:**
+- Produces: `FormattedJson({ value: unknown; maxHeight?: string }): JSX.Element` — exported named export used by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/shared/FormattedJson.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FormattedJson } from './FormattedJson'
+
+describe('FormattedJson', () => {
+  it('renders JSON string keys and values', () => {
+    const { container } = render(<FormattedJson value={{ name: 'Alice' }} />)
+    // "name" as key and "Alice" as string value should appear in the pre
+    expect(container.querySelector('pre')).toHaveTextContent('"name"')
+    expect(container.querySelector('pre')).toHaveTextContent('"Alice"')
+  })
+
+  it('renders JSON number values', () => {
+    render(<FormattedJson value={{ count: 42 }} />)
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  it('renders JSON boolean values', () => {
+    render(<FormattedJson value={{ active: true, disabled: false }} />)
+    expect(screen.getByText('true')).toBeInTheDocument()
+    expect(screen.getByText('false')).toBeInTheDocument()
+  })
+
+  it('renders null JSON value as literal text', () => {
+    render(<FormattedJson value={{ x: null }} />)
+    expect(screen.getByText('null')).toBeInTheDocument()
+  })
+
+  it('applies maxHeight style to pre element', () => {
+    const { container } = render(<FormattedJson value={{ x: 1 }} maxHeight="10rem" />)
+    expect(container.querySelector('pre')?.style.maxHeight).toBe('10rem')
+  })
+
+  it('uses default maxHeight of 24rem when prop omitted', () => {
+    const { container } = render(<FormattedJson value={{ x: 1 }} />)
+    expect(container.querySelector('pre')?.style.maxHeight).toBe('24rem')
+  })
+
+  it('handles null value prop gracefully without crashing', () => {
+    const { container } = render(<FormattedJson value={null} />)
+    expect(container.querySelector('pre')).toBeInTheDocument()
+  })
+
+  it('handles undefined value prop gracefully without crashing', () => {
+    const { container } = render(<FormattedJson value={undefined} />)
+    expect(container.querySelector('pre')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx vitest run --reporter verbose src/components/shared/FormattedJson.test.tsx
+```
+
+Expected: FAIL — "Cannot find module './FormattedJson'"
+
+- [ ] **Step 3: Implement FormattedJson**
+
+Create `frontend/src/components/shared/FormattedJson.tsx`:
+
+```tsx
+interface FormattedJsonProps {
+  value: unknown
+  maxHeight?: string
+}
+
+function highlight(json: string): React.ReactNode[] {
+  // Groups: (1) quoted string + optional colon (key vs. value), (2) bool/null, (3) number
+  const regex =
+    /("(?:[^\\"]|\\.)*")(\s*:)?|(\btrue\b|\bfalse\b|\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g
+  const nodes: React.ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(json)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(json.slice(lastIndex, match.index))
+    }
+    if (match[1] !== undefined) {
+      const isKey = match[2] !== undefined
+      nodes.push(
+        <span
+          key={match.index}
+          className={
+            isKey
+              ? 'text-blue-700 dark:text-blue-400'
+              : 'text-green-700 dark:text-green-400'
+          }
+        >
+          {match[1]}
+        </span>
+      )
+      if (match[2]) nodes.push(match[2])
+    } else if (match[3] !== undefined) {
+      nodes.push(
+        <span key={match.index} className="text-amber-600 dark:text-amber-400">
+          {match[3]}
+        </span>
+      )
+    } else if (match[4] !== undefined) {
+      nodes.push(
+        <span key={match.index} className="text-amber-600 dark:text-amber-400">
+          {match[4]}
+        </span>
+      )
+    }
+    lastIndex = match.index + match[0].length
+  }
+  if (lastIndex < json.length) nodes.push(json.slice(lastIndex))
+  return nodes
+}
+
+export function FormattedJson({ value, maxHeight = '24rem' }: FormattedJsonProps) {
+  if (value === null || value === undefined) {
+    return (
+      <pre
+        className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto text-muted-foreground"
+        style={{ maxHeight }}
+      >
+        {String(value)}
+      </pre>
+    )
+  }
+  const json = JSON.stringify(value, null, 2)
+  return (
+    <pre
+      className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto"
+      style={{ maxHeight }}
+    >
+      {highlight(json)}
+    </pre>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npx vitest run --reporter verbose src/components/shared/FormattedJson.test.tsx
+```
+
+Expected: All 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/shared/FormattedJson.tsx frontend/src/components/shared/FormattedJson.test.tsx
+git commit -m "feat(extraction-ui): add FormattedJson syntax-coloured JSON renderer"
+```
+
+---
+
+### Task 2: Replace ExtractionResultViewer debug panels
+
+**Files:**
+- Modify: `frontend/src/components/extraction/ExtractionResultViewer.tsx`
+- Modify: `frontend/src/components/extraction/ExtractionResultViewer.test.tsx`
+
+**Interfaces:**
+- Consumes: `FormattedJson({ value, maxHeight })` from Task 1.
+- `ExtractionResult.extractionMetadata` cast as `{ model?, provider?, latency_ms?, usage?: { prompt_tokens?, completion_tokens?, total_tokens? }, chunkCount?, prompt_messages?: Array<{ role: string; content: string }> } | null`
+- `ExtractionResult.config` cast as `{ structured_output_mode?, inject_block_ids?, chunking?: { strategy?, config?: Record<string, unknown>, citationLevel? } } | null`
+
+- [ ] **Step 1: Write/update failing tests**
+
+Replace the full content of `frontend/src/components/extraction/ExtractionResultViewer.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ExtractionResultViewer } from './ExtractionResultViewer'
+import type { ExtractionResult } from '@/types/extraction'
+
+function buildResult(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return {
+    id: 'result-1',
+    documentId: 'doc-1',
+    extractionSchemaId: 'schema-1',
+    schemaDefinitionSnapshot: {},
+    extractionMethod: 'llamaextract',
+    config: null,
+    structuredData: { invoice_number: 'INV-001' },
+    extractionMetadata: { latency_ms: 1234, file_id: 'f-abc' },
+    citations: null,
+    providerResponseRaw: null,
+    sourceParseRunId: 'run-1',
+    status: 'completed',
+    statusMessage: null,
+    startedAt: '2026-01-01T00:00:00Z',
+    createdBy: 'user-1',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function buildLlmResult(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return buildResult({
+    extractionMethod: 'llm',
+    extractionMetadata: {
+      model: 'claude-opus-4-7',
+      provider: 'anthropic',
+      latency_ms: 17794,
+      usage: { prompt_tokens: 3712, completion_tokens: 1830, total_tokens: 5542 },
+      prompt_messages: [
+        { role: 'system', content: 'You are an extraction assistant.' },
+        {
+          role: 'user',
+          content:
+            'Extract the following.\n<schema>{"type":"object"}</schema>\n<document>Invoice #001</document>',
+        },
+      ],
+    },
+    config: {
+      structured_output_mode: 'json_schema',
+      inject_block_ids: false,
+      chunking: { strategy: 'none', citationLevel: 'auto' },
+    },
+    providerResponseRaw: { id: 'msg_001', content: [{ type: 'text', text: '{}' }] },
+    ...overrides,
+  })
+}
+
+function buildChunkedResult(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return buildResult({
+    extractionMethod: 'llm',
+    extractionMetadata: {
+      chunkCount: 3,
+      usage: { total_tokens: 12000 },
+      scalarConflicts: [],
+      // no model, provider, latency_ms, prompt_messages
+    },
+    config: {
+      structured_output_mode: 'json_schema',
+      chunking: { strategy: 'token_budget_pages', config: { max_input_tokens: 4000 }, citationLevel: 'auto' },
+    },
+    providerResponseRaw: null,
+    ...overrides,
+  })
+}
+
+describe('ExtractionResultViewer', () => {
+  // ── Run Config panel ──────────────────────────────────────────────────────
+  it('shows Run Config panel for all results', () => {
+    render(<ExtractionResultViewer result={buildResult()} />)
+    expect(screen.getByText('Run Config')).toBeInTheDocument()
+  })
+
+  it('shows model and provider in Run Config for LLM results', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('claude-opus-4-7')).toBeInTheDocument()
+    expect(screen.getByText('anthropic')).toBeInTheDocument()
+  })
+
+  it('shows formatted latency in Run Config for LLM results', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('17,794 ms')).toBeInTheDocument()
+  })
+
+  it('shows token counts in Run Config for LLM results', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('3,712')).toBeInTheDocument()
+    expect(screen.getByText('1,830')).toBeInTheDocument()
+    expect(screen.getByText('5,542')).toBeInTheDocument()
+  })
+
+  it('shows chunked run placeholder for model when model is absent', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getAllByText('Not available for chunked runs').length).toBeGreaterThan(0)
+  })
+
+  it('shows chunk count in Run Config for chunked results', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('shows chunking strategy in Run Config settings', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getByText('token_budget_pages')).toBeInTheDocument()
+  })
+
+  it('shows max input tokens when chunking strategy is not none', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getByText('4,000')).toBeInTheDocument()
+  })
+
+  // ── Prompt panel ──────────────────────────────────────────────────────────
+  it('shows Prompt panel for all results', () => {
+    render(<ExtractionResultViewer result={buildResult()} />)
+    expect(screen.getByText('Prompt')).toBeInTheDocument()
+  })
+
+  it('shows System and User tabs in Prompt panel for LLM results with prompt_messages', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByRole('tab', { name: 'System' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'User' })).toBeInTheDocument()
+  })
+
+  it('shows system prompt content in System tab', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('You are an extraction assistant.')).toBeInTheDocument()
+  })
+
+  it('shows chunking unavailable message in Prompt panel for chunked results', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(
+      screen.getByText(/Prompt not available.*chunking/i)
+    ).toBeInTheDocument()
+  })
+
+  // ── LLM Response panel ────────────────────────────────────────────────────
+  it('shows LLM Response panel when providerResponseRaw is present', () => {
+    render(
+      <ExtractionResultViewer
+        result={buildResult({ providerResponseRaw: { data: { invoice_number: 'INV-001' } } })}
+      />
+    )
+    expect(screen.getByText('LLM Response')).toBeInTheDocument()
+  })
+
+  it('does not show LLM Response panel when providerResponseRaw is null', () => {
+    render(<ExtractionResultViewer result={buildResult({ providerResponseRaw: null })} />)
+    expect(screen.queryByText('LLM Response')).not.toBeInTheDocument()
+  })
+
+  it('does not show LLM Response panel for chunked runs', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.queryByText('LLM Response')).not.toBeInTheDocument()
+  })
+
+  it('shows Raw label when providerResponseRaw contains raw_content string', () => {
+    render(
+      <ExtractionResultViewer
+        result={buildResult({
+          providerResponseRaw: { raw_content: 'this is not json' },
+        })}
+      />
+    )
+    expect(screen.getByText('Raw (non-JSON) response')).toBeInTheDocument()
+    expect(screen.getByText('this is not json')).toBeInTheDocument()
+  })
+
+  // ── Legacy panel absence ──────────────────────────────────────────────────
+  it('does not render old "Extraction Metadata" panel text', () => {
+    render(<ExtractionResultViewer result={buildResult()} />)
+    expect(screen.queryByText('Extraction Metadata')).not.toBeInTheDocument()
+  })
+
+  it('does not render old "Provider Response" panel text', () => {
+    render(
+      <ExtractionResultViewer
+        result={buildResult({ providerResponseRaw: { data: {} } })}
+      />
+    )
+    expect(screen.queryByText('Provider Response')).not.toBeInTheDocument()
+  })
+
+  it('does not show old metadata label', () => {
+    render(<ExtractionResultViewer result={buildResult()} />)
+    expect(screen.queryByText(/citations \/ reasoning/i)).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx vitest run --reporter verbose src/components/extraction/ExtractionResultViewer.test.tsx
+```
+
+Expected: Many failures — "Run Config", "LLM Response" text not found; "Extraction Metadata"/"Provider Response" assertions now reversed.
+
+- [ ] **Step 3: Implement the new ExtractionResultViewer**
+
+Replace the full contents of `frontend/src/components/extraction/ExtractionResultViewer.tsx`:
+
+```tsx
+import type { ExtractionResult } from '@/types/extraction'
+import { ChunkingSummary } from './ChunkingSummary'
+import { FormattedJson } from '@/components/shared/FormattedJson'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Separator } from '@/components/ui/separator'
+import { Button } from '@/components/ui/button'
+import { ChevronDown, Loader2 } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface ExtractionResultViewerProps {
+  result: ExtractionResult | null
+  isLoading?: boolean
+}
+
+// ── Internal types for casting extractionMetadata and config ─────────────────
+
+interface ExtractionMeta {
+  model?: string
+  provider?: string
+  latency_ms?: number
+  usage?: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+  }
+  chunkCount?: number
+  prompt_messages?: Array<{ role: string; content: string }>
+}
+
+interface ExtractionConfig {
+  structured_output_mode?: string
+  inject_block_ids?: boolean
+  chunking?: {
+    strategy?: string
+    config?: Record<string, unknown>
+    citationLevel?: string
+  }
+}
+
+// ── Helper components ─────────────────────────────────────────────────────────
+
+function StructuredDataDisplay({ data }: { data: Record<string, unknown> }) {
+  const entries = Object.entries(data)
+
+  return (
+    <div className="space-y-4">
+      {entries.map(([key, value]) => {
+        if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'object') {
+          return <ArrayTable key={key} label={key} items={value as Record<string, unknown>[]} />
+        }
+
+        if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+          return (
+            <Collapsible key={key}>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" className="w-full justify-between px-3 py-2 h-auto">
+                  <span className="font-medium text-sm">{formatLabel(key)}</span>
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="pl-4 border-l-2 border-muted ml-3">
+                <StructuredDataDisplay data={value as Record<string, unknown>} />
+              </CollapsibleContent>
+            </Collapsible>
+          )
+        }
+
+        return (
+          <div key={key} className="flex justify-between items-start py-1.5 px-3 rounded hover:bg-muted/50">
+            <span className="text-sm text-muted-foreground">{formatLabel(key)}</span>
+            <span className="text-sm text-right max-w-[60%]">{formatValue(value)}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function ArrayTable({ label, items }: { label: string; items: Record<string, unknown>[] }) {
+  if (items.length === 0) return null
+
+  const columns = Object.keys(items[0])
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium px-3">{formatLabel(label)}</h4>
+      <div className="rounded-md border overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {columns.map((col) => (
+                <TableHead key={col} className="text-xs">
+                  {formatLabel(col)}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item, i) => (
+              <TableRow key={i}>
+                {columns.map((col) => (
+                  <TableCell key={col} className="text-sm">
+                    {formatValue(item[col])}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}
+
+function ConfigRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[12rem_1fr] gap-4 py-0.5 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span>{value ?? '—'}</span>
+    </div>
+  )
+}
+
+function NotAvailableChunked() {
+  return (
+    <span className="text-muted-foreground italic text-xs">
+      Not available for chunked runs
+    </span>
+  )
+}
+
+function UserMessageDisplay({ content }: { content: string }) {
+  const parsed = parseUserContent(content)
+  if (!parsed.schema) {
+    return (
+      <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-48 whitespace-pre-wrap">
+        {content}
+      </pre>
+    )
+  }
+  let schemaJson: unknown
+  try {
+    schemaJson = JSON.parse(parsed.schema)
+  } catch {
+    schemaJson = parsed.schema
+  }
+  return (
+    <div className="space-y-3">
+      {parsed.instruction && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">Instruction</p>
+          <pre className="text-xs font-mono bg-muted p-2 rounded border whitespace-pre-wrap">
+            {parsed.instruction}
+          </pre>
+        </div>
+      )}
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground mb-1">Schema</p>
+        <FormattedJson value={schemaJson} maxHeight="12rem" />
+      </div>
+      {parsed.document && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">Document</p>
+          <pre className="text-xs font-mono bg-muted p-2 rounded border overflow-auto max-h-48 whitespace-pre-wrap">
+            {parsed.document}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+function formatLabel(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^\w/, (c) => c.toUpperCase())
+    .trim()
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+interface ParsedUserContent {
+  instruction: string
+  schema: string | null
+  document: string | null
+}
+
+function parseUserContent(content: string): ParsedUserContent {
+  const schemaOpen = '<schema>'
+  const schemaClose = '</schema>'
+  const docOpen = '<document>'
+  const docClose = '</document>'
+  const s0 = content.indexOf(schemaOpen)
+  const s1 = content.indexOf(schemaClose)
+  const d0 = content.indexOf(docOpen)
+  const d1 = content.indexOf(docClose)
+  if (s0 === -1 || d0 === -1) {
+    return { instruction: content, schema: null, document: null }
+  }
+  return {
+    instruction: content.slice(0, s0).trim(),
+    schema: content.slice(s0 + schemaOpen.length, s1).trim(),
+    document: content.slice(d0 + docOpen.length, d1).trim(),
+  }
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function ExtractionResultViewer({
+  result,
+  isLoading,
+}: ExtractionResultViewerProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!result) return null
+
+  const meta = result.extractionMetadata as ExtractionMeta | null
+  const cfg = result.config as ExtractionConfig | null
+  const chunkingConfig = cfg?.chunking
+  const promptMessages = meta?.prompt_messages
+  const systemMessage = promptMessages?.[0]
+  const userMessage = promptMessages?.[1]
+
+  const hasProviderResponse =
+    result.providerResponseRaw !== null &&
+    result.providerResponseRaw !== undefined &&
+    Object.keys(result.providerResponseRaw).length > 0
+  const isRawContent =
+    typeof result.providerResponseRaw?.['raw_content'] === 'string'
+
+  const statusColor =
+    result.status === 'completed'
+      ? 'default'
+      : result.status === 'pending'
+        ? 'secondary'
+        : 'destructive'
+
+  return (
+    <div className="space-y-4">
+      <ChunkingSummary metadata={result.extractionMetadata} />
+
+      {/* ── Result card ─────────────────────────────────────────────────── */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">Extraction Result</CardTitle>
+            <div className="flex items-center gap-2">
+              <Badge variant={statusColor}>
+                {result.status === 'pending' && (
+                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                )}
+                {result.status}
+              </Badge>
+              <Badge variant="outline">{result.extractionMethod}</Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {result.status === 'pending' && (
+            <p className="text-sm text-muted-foreground">Extraction is in progress...</p>
+          )}
+
+          {result.status === 'failed' && (
+            <div className="space-y-3">
+              {result.statusMessage && (
+                <p className="text-sm text-destructive">{result.statusMessage}</p>
+              )}
+              {isRawContent && (
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-muted-foreground">LLM Response</p>
+                  <pre className="text-xs bg-muted p-3 rounded-md overflow-x-auto whitespace-pre-wrap max-h-64">
+                    {result.providerResponseRaw!['raw_content'] as string}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+
+          {result.status === 'completed' && result.structuredData && (
+            <StructuredDataDisplay data={result.structuredData} />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Run Config panel ─────────────────────────────────────────────── */}
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <Button variant="outline" size="sm" className="w-full justify-between">
+            <span>Run Config</span>
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <Card className="mt-2">
+            <CardContent className="pt-4 space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Model
+              </p>
+              <div className="space-y-0.5">
+                <ConfigRow
+                  label="Model"
+                  value={meta?.model ?? <NotAvailableChunked />}
+                />
+                <ConfigRow
+                  label="Provider"
+                  value={meta?.provider ?? <NotAvailableChunked />}
+                />
+                <ConfigRow
+                  label="Latency"
+                  value={
+                    meta?.latency_ms !== undefined
+                      ? `${meta.latency_ms.toLocaleString()} ms`
+                      : <NotAvailableChunked />
+                  }
+                />
+              </div>
+              <Separator />
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Tokens
+              </p>
+              <div className="space-y-0.5">
+                <ConfigRow
+                  label="Prompt tokens"
+                  value={meta?.usage?.prompt_tokens?.toLocaleString() ?? '—'}
+                />
+                <ConfigRow
+                  label="Completion tokens"
+                  value={meta?.usage?.completion_tokens?.toLocaleString() ?? '—'}
+                />
+                <ConfigRow
+                  label="Total tokens"
+                  value={meta?.usage?.total_tokens?.toLocaleString() ?? '—'}
+                />
+              </div>
+              <Separator />
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Settings
+              </p>
+              <div className="space-y-0.5">
+                <ConfigRow label="Extraction method" value={result.extractionMethod} />
+                <ConfigRow
+                  label="Structured output mode"
+                  value={cfg?.structured_output_mode ?? '—'}
+                />
+                <ConfigRow
+                  label="Inject block IDs"
+                  value={
+                    typeof cfg?.inject_block_ids === 'boolean'
+                      ? cfg.inject_block_ids
+                        ? 'Yes'
+                        : 'No'
+                      : '—'
+                  }
+                />
+                <ConfigRow
+                  label="Chunking strategy"
+                  value={chunkingConfig?.strategy ?? '—'}
+                />
+                {chunkingConfig?.strategy && chunkingConfig.strategy !== 'none' && (
+                  <ConfigRow
+                    label="Max input tokens"
+                    value={
+                      (chunkingConfig.config?.['max_input_tokens'] as number | undefined)?.toLocaleString() ??
+                      '—'
+                    }
+                  />
+                )}
+                <ConfigRow
+                  label="Citation level"
+                  value={chunkingConfig?.citationLevel ?? '—'}
+                />
+                {meta?.chunkCount !== undefined && (
+                  <ConfigRow label="Chunk count" value={String(meta.chunkCount)} />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* ── Prompt panel ─────────────────────────────────────────────────── */}
+      <Collapsible>
+        <CollapsibleTrigger asChild>
+          <Button variant="outline" size="sm" className="w-full justify-between">
+            <span>Prompt</span>
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <Card className="mt-2">
+            <CardContent className="pt-4">
+              {!promptMessages ? (
+                <p className="text-sm text-muted-foreground italic">
+                  Prompt not available — this run used chunking. Individual chunk prompts
+                  are not yet preserved.
+                </p>
+              ) : (
+                <Tabs defaultValue="system">
+                  <TabsList>
+                    <TabsTrigger value="system">System</TabsTrigger>
+                    <TabsTrigger value="user">User</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="system" className="mt-3">
+                    <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-48 whitespace-pre-wrap">
+                      {systemMessage?.content ?? '—'}
+                    </pre>
+                  </TabsContent>
+                  <TabsContent value="user" className="mt-3">
+                    {userMessage ? (
+                      <UserMessageDisplay content={userMessage.content} />
+                    ) : (
+                      <p className="text-sm text-muted-foreground">—</p>
+                    )}
+                  </TabsContent>
+                </Tabs>
+              )}
+            </CardContent>
+          </Card>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* ── LLM Response panel (hidden for chunked/null) ──────────────────── */}
+      {hasProviderResponse && (
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm" className="w-full justify-between">
+              <span>LLM Response</span>
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <Card className="mt-2">
+              <CardContent className="pt-4">
+                {isRawContent ? (
+                  <div className="space-y-1">
+                    <p className="text-xs text-muted-foreground">Raw (non-JSON) response</p>
+                    <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-96 whitespace-pre-wrap">
+                      {result.providerResponseRaw!['raw_content'] as string}
+                    </pre>
+                  </div>
+                ) : (
+                  <FormattedJson value={result.providerResponseRaw} maxHeight="24rem" />
+                )}
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npx vitest run --reporter verbose src/components/extraction/ExtractionResultViewer.test.tsx
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run full frontend test suite to catch regressions**
+
+```bash
+npx vitest run --reporter verbose
+```
+
+Expected: All tests PASS with no regressions.
+
+- [ ] **Step 6: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/extraction/ExtractionResultViewer.tsx frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+git commit -m "feat(extraction-ui): replace raw JSON collapsibles with Run Config, Prompt, and LLM Response debug panels"
+```
+
+---
+
+## Self-Review vs Spec
+
+**Spec coverage check:**
+
+| Requirement | Task |
+|---|---|
+| Run Config panel — model, provider, latency | Task 2 ConfigRow rows |
+| Run Config — token counts | Task 2 Tokens section |
+| Run Config — extraction settings (method, output mode, inject, chunking, citations) | Task 2 Settings section |
+| Prompt panel — System/User tabs | Task 2 Tabs |
+| Prompt User tab — parse instruction/schema/document sections | Task 2 `parseUserContent` + `UserMessageDisplay` |
+| LLM Response — FormattedJson rendering | Task 2 LLM Response collapsible |
+| LLM Response — raw_content fallback label | Task 2 `isRawContent` branch |
+| LLM Response hidden when providerResponseRaw null | Task 2 `hasProviderResponse` guard |
+| Chunked run placeholders (model/provider/latency) | Task 2 `NotAvailableChunked` |
+| Chunked run — Prompt unavailable message | Task 2 `!promptMessages` branch |
+| FormattedJson — syntax colouring (strings, keys, numbers, booleans) | Task 1 `highlight()` |
+| FormattedJson — no external deps | Task 1 pure regex implementation |
+| All JSON via FormattedJson; no raw JSON.stringify in pre | Tasks 1 + 2 |
+| Unit tests for all new behaviour | Tasks 1 + 2 test files |
+| No regressions in existing tests | Task 2 Step 5 full suite run |
+
+**No gaps found.**
+
+**Placeholder scan:** No TBDs, no "implement later", no incomplete steps.
+
+**Type consistency:** `ExtractionMeta`, `ExtractionConfig` defined in Task 2 and used consistently throughout. `FormattedJson` props defined in Task 1, consumed in Task 2 with matching signature.

--- a/docs/superpowers/specs/2026-06-23-extraction-parse-config-design.md
+++ b/docs/superpowers/specs/2026-06-23-extraction-parse-config-design.md
@@ -117,7 +117,7 @@ New "Parse Configuration" section rendered above the schema selector:
 </div>
 ```
 
-`representationKind` is fixed to `"extract_rich"` and not exposed in the UI — same default as the documents parse form.
+`representationKind` is fixed to `"extract_rich"` — the documents parse form never sends it either, so all existing parse runs carry this value via the backend default. It is not a user-facing concept anywhere in the app and fixing it here keeps the match check consistent with existing parse runs.
 
 `onRun` callback type changes from `RunExtractionRequest` to `RunWithParseRequest`:
 
@@ -236,4 +236,4 @@ The Run Extraction button is disabled while `extractionPhase !== 'idle'`.
 - Existing extraction result polling behaviour
 - `ParseMethodSelector`, `LlamaParseConfig`, `LandingAIConfig` components — reused as-is
 - `useParseRuns` hook — read-only consumer, not involved in orchestration
-- The `representationKind` field — fixed to `"extract_rich"`, not configurable in this iteration
+- The `representationKind` field — fixed to `"extract_rich"`, consistent with how the documents parse form works (it never sends this field, relying on the backend default)

--- a/docs/superpowers/specs/2026-06-24-chunk-details-panel-design.md
+++ b/docs/superpowers/specs/2026-06-24-chunk-details-panel-design.md
@@ -1,0 +1,201 @@
+# Chunk Details Panel — Design
+
+**Date:** 2026-06-24
+**Status:** Draft
+**Related files:** `backend/app/adapters/extraction/pipeline.py`,
+`backend/app/adapters/extraction/chunking/merge.py`,
+`frontend/src/components/extraction/ExtractionResultViewer.tsx`
+
+## Problem
+
+For chunked LLM extraction runs the debug panels in `ExtractionResultViewer` show
+only aggregate information — total tokens, chunk count, merged structured data — and
+placeholder messages for prompt and LLM response. There is no way to inspect what
+was sent to the model for each individual chunk or what it returned, making it
+impractical to diagnose extraction quality or prompt behaviour in a multi-chunk run.
+
+## Goals
+
+- Surface all per-chunk information (prompts, LLM responses, pre-merge extracted
+  data, token usage, latency) in a structured, scannable panel.
+- Use a list + detail layout: chunk selector on the left, full detail on the right,
+  so depth of information does not compete with navigation for vertical space.
+- No new API endpoints, no database migrations — store per-chunk summaries inside the
+  existing `extractionMetadata` JSONB column.
+- Backend change is additive: existing non-chunked and chunked runs without the new
+  field degrade gracefully (panel hidden).
+
+## Non-goals
+
+- Streaming or live per-chunk updates during an in-progress extraction.
+- Diff / comparison across chunks (e.g., "what changed between chunk 1 and 2").
+- Editing or re-running individual chunks.
+
+---
+
+## Data model
+
+### Backend: `extractionMetadata.chunks`
+
+`pipeline.py` currently discards per-chunk `ExtractionOutput` after merging. After
+the `asyncio.gather`, zip `results: list[ExtractionOutput]` with
+`chunks: list[DocumentChunk]` (which carry `page_indices`) before calling
+`merge_outputs`.
+
+`merge_outputs` gains an optional `chunks` parameter and adds a `chunks` key to the
+merged metadata dict:
+
+```python
+metadata["chunks"] = [
+    {
+        "chunkIndex": chunk.chunk_index,          # int, 0-based
+        "pageIndices": chunk.page_indices,        # list[int]
+        "promptMessages": out.extraction_metadata.get("prompt_messages", []),
+        "providerResponseRaw": out.provider_response_raw,
+        "structuredData": out.structured_data,
+        "usage": out.extraction_metadata.get("usage"),
+        "latencyMs": out.extraction_metadata.get("latency_ms"),
+    }
+    for chunk, out in zip(chunks, results)
+]
+```
+
+Key naming uses camelCase to match the existing `extractionMetadata` convention
+(`chunkCount`, `latencyMs`, etc.).
+
+`merge_outputs` signature change:
+
+```python
+def merge_outputs(
+    outputs: list[ExtractionOutput],
+    schema: dict[str, Any],
+    dedupe_key: str | None,
+    chunks: list | None = None,      # list[DocumentChunk] | None
+) -> ExtractionOutput:
+```
+
+`chunks` is optional (defaults to `None`) so existing call-sites and tests that pass
+only `outputs` continue to work unchanged.
+
+`pipeline.py` call-site:
+
+```python
+return merge_outputs(list(results), schema, dedupe_key, chunks=chunks)
+```
+
+where `chunks` is the `list[DocumentChunk]` returned by `strategy.split(...)`.
+
+---
+
+## UI design
+
+### Placement
+
+A new "Chunk Details" `Collapsible` panel rendered below the existing three panels
+(Run Config, Prompt, LLM Response), collapsed by default. Only rendered when
+`meta?.chunks` exists and has length > 0.
+
+```
+[ Run Config ▾ ]
+[ Prompt ▾ ]
+[ LLM Response ▾ ]          ← hidden for chunked runs (no providerResponseRaw)
+[ Chunk Details ▾ ]         ← new; chunked runs only
+```
+
+The existing panels are unchanged. The Chunk Details panel is purely additive.
+
+### Layout: list + detail
+
+When opened, the panel body is a two-column CSS grid:
+
+```
+┌─────────────────────┬────────────────────────────────────────────┐
+│  Chunk list (16rem) │  Detail pane (flex 1)                      │
+│  ─────────────────  │  ──────────────────────────────────────── │
+│  ● Chunk 1          │  System ────────────────────────────────── │
+│    pp. 1–3          │  <pre> system prompt (shared across chunks)│
+│    4,542 tok · 1.2s │                                            │
+│                     │  User ──────────────────────────────────── │
+│  ○ Chunk 2          │  Instruction / Schema (FormattedJson) /    │
+│    pp. 4–7          │  Document sections                         │
+│    3,901 tok · 1.0s │                                            │
+│                     │  LLM Response ──────────────────────────── │
+│  ○ Chunk 3          │  FormattedJson of providerResponseRaw      │
+│    pp. 8–10         │                                            │
+│    4,100 tok · 1.1s │  Extracted (pre-merge) ─────────────────── │
+│                     │  FormattedJson of structuredData           │
+│                     │                                            │
+│                     │  Usage ────────────────────────────────────│
+│                     │  Prompt · Completion · Total · Latency     │
+└─────────────────────┴────────────────────────────────────────────┘
+```
+
+**Chunk list (left column, `w-64`, `overflow-y-auto`, sticky within panel):**
+
+Each row is a button:
+- First line: `Chunk N` (semibold, 1-based display: `chunkIndex + 1`) + page-range
+  badge (`pp. 1–3`, 1-based: `pageIndices[0] + 1`–`pageIndices[last] + 1`).
+  Badge omitted when `pageIndices` is empty.
+- Second line: `4,542 tokens · 1.2 s` (muted, small). Latency formatted as
+  `toLocaleString() + ' ms'`; missing values show `—`.
+- Selected row: `bg-muted` background, left border accent
+
+State: `selectedChunkIndex: number` (React `useState`, initialised to `0`).
+
+**Detail pane (right column, `flex-1`, `overflow-y-auto`, `pl-4`):**
+
+Vertically stacked, labelled sections (no sub-tabs — show everything at once):
+
+1. **System** — `<pre>` of `chunk.promptMessages[0].content`; muted footnote
+   *"Identical across all chunks"*. `max-h-48`, `overflow-y-auto`.
+
+2. **User** — parsed via the existing `parseUserContent` helper (reused from the
+   Prompt panel):
+   - **Instruction** — plain `<pre>`
+   - **Schema** — `<FormattedJson>` (`max-h-48`)
+   - **Document** — plain `<pre>`, `max-h-48`, `overflow-y-auto`
+   - Falls back to full-content `<pre>` if tags absent.
+
+3. **LLM Response** — `<FormattedJson value={chunk.providerResponseRaw} maxHeight="20rem" />`
+   If null: muted italics *"No response recorded for this chunk."*
+
+4. **Extracted (pre-merge)** — `<FormattedJson value={chunk.structuredData} maxHeight="16rem" />`
+   Label includes a note: *"Raw output before conflict resolution and deduplication."*
+
+5. **Usage** — four-cell inline grid:
+   - Prompt tokens / Completion tokens / Total tokens / Latency
+   - Values formatted with `toLocaleString()` / `ms` suffix. Missing values show `—`.
+
+---
+
+## Component changes
+
+| File | Change |
+|---|---|
+| `backend/app/adapters/extraction/pipeline.py` | Pass `chunks` list to `merge_outputs` at the chunked call-site. |
+| `backend/app/adapters/extraction/chunking/merge.py` | Add optional `chunks` param; build `metadata["chunks"]` when provided. |
+| `backend/tests/adapters/extraction/chunking/test_merge.py` | Add: chunks array populated with correct fields when `chunks` param passed; existing tests unaffected. |
+| `frontend/src/components/extraction/ExtractionResultViewer.tsx` | Add `ChunkDetailsPanel` inner component and render it below LLM Response when `meta?.chunks` present. |
+| `frontend/src/components/extraction/ExtractionResultViewer.test.tsx` | Add: panel hidden when no chunks; chunk list renders correct labels; selecting a chunk updates detail pane; system prompt shows shared note. |
+
+No changes to `ExtractionResult` type, API layer, or database schema.
+
+---
+
+## Acceptance criteria
+
+- [ ] For a completed chunked LLM run, `extractionMetadata.chunks` contains one entry
+  per chunk with `chunkIndex`, `pageIndices`, `promptMessages`, `providerResponseRaw`,
+  `structuredData`, `usage`, and `latencyMs`.
+- [ ] Chunk Details panel is hidden for non-chunked runs and for runs where
+  `extractionMetadata.chunks` is absent.
+- [ ] Chunk list shows correct page ranges and formatted token/latency counts for
+  each chunk.
+- [ ] Selecting a chunk updates the detail pane to show that chunk's system prompt,
+  parsed user message, LLM response, pre-merge extracted data, and usage.
+- [ ] System prompt section carries the *"Identical across all chunks"* note.
+- [ ] Extracted pre-merge section carries the *"Raw output before conflict resolution
+  and deduplication"* note.
+- [ ] `parseUserContent` helper is reused; no duplication.
+- [ ] Existing non-chunked run tests are unaffected.
+- [ ] All new behaviour is covered by unit tests.

--- a/docs/superpowers/specs/2026-06-24-extraction-chunking-ui-design.md
+++ b/docs/superpowers/specs/2026-06-24-extraction-chunking-ui-design.md
@@ -1,0 +1,193 @@
+# Surface Chunking & Citation Granularity in the Extraction UI — Design
+
+**Date:** 2026-06-24
+**Status:** Approved (design); pending implementation plan
+**Depends on:** backend chunking pipeline (PR #101, merged) — `chunking` / `preprocess` fields on `/extractions/run`.
+**Related files:** `frontend/src/components/extraction/ExtractionForm.tsx`,
+`frontend/src/components/extraction/ExtractionResultViewer.tsx`,
+`frontend/src/hooks/useExtractionResults.ts`, `frontend/src/types/extraction.ts`,
+`frontend/src/api/extraction.ts`.
+
+## Problem
+
+The backend extraction pipeline now accepts a `chunking` config (strategy +
+params + citation level) and returns richer `extractionMetadata` (chunk count,
+token usage, scalar conflicts) plus precise truncation errors. None of this is
+reachable from the app: `ExtractionForm` has no controls, and
+`runExtractionWithParse` does not forward the fields. Users can only exercise
+chunking via direct API calls.
+
+## Goals
+
+- Let users configure **chunking** (strategy + params) and **citation
+  granularity** for LLM extractions from the form.
+- Surface **result-side metadata** (chunk count, token usage, scalar conflicts)
+  and truncation failures in a readable way.
+- Preserve current behavior exactly when the new controls are left at defaults.
+
+## Non-goals (this spec)
+
+- Preprocess / `block_filter` controls.
+- A schema-driven generic form renderer + backend `config_schema` GET endpoints
+  (controls are hand-built, matching the existing form).
+- Saved pipeline presets.
+- Per-field citation visualization in the result data table.
+
+## Approach
+
+Purely frontend. The `/extractions/run` endpoint already accepts `chunking` and
+`preprocess`; only the request types, the orchestration hook, and the form/
+result components change. Controls are hand-built (like the existing
+`llamaextract` / `llm` sections) rather than schema-driven — simplest, matches
+current code, no new endpoints. Trade-off: adding a future chunking strategy
+means editing the form. This is acceptable for the current two strategies
+(`none`, `token_budget_pages`); a schema-driven renderer remains a future
+option if strategies proliferate.
+
+## Input controls — `ExtractionForm`
+
+A new collapsible **"Large document handling"** subsection, rendered **only when
+`extractionMethod === 'llm'`**, default **collapsed**, default **`strategy:
+none`** (so default behavior is unchanged):
+
+- **Chunking strategy** — `Select`: `None (single-shot)` | `Token-budgeted pages`.
+- When `token_budget_pages` is selected, reveal:
+  - **Max input tokens** — number `Input`, default `8000`.
+  - **Page overlap** — number `Input`, default `0`.
+  - **Dedupe key** — text `Input`, optional (placeholder `sku`).
+- **Citation detail** — `Select`: `Auto` | `Full` | `Page only` | `Off`,
+  default `Auto`. Rendered whenever method is `llm` (applies to single-shot too,
+  since it controls `__source` augmentation on the request schema).
+
+Each control carries one line of helper text (e.g. citation: "Auto = page-level
+provenance on large documents; Off = no provenance captured").
+
+New local state in the form:
+
+```ts
+const [chunkStrategy, setChunkStrategy] = useState<'none' | 'token_budget_pages'>('none')
+const [maxInputTokens, setMaxInputTokens] = useState('8000')
+const [pageOverlap, setPageOverlap] = useState('0')
+const [dedupeKey, setDedupeKey] = useState('')
+const [citationLevel, setCitationLevel] = useState<'auto' | 'full' | 'page_only' | 'off'>('auto')
+```
+
+`handleRun` builds the `chunking` object for the `llm` branch only, and only
+when it differs from defaults, keeping requests minimal:
+
+```ts
+let chunking: ChunkingConfig | undefined
+if (chunkStrategy !== 'none') {
+  const cfg: Record<string, unknown> = {}
+  const max = parseInt(maxInputTokens, 10)
+  if (!Number.isNaN(max)) cfg.maxInputTokens = max
+  const overlap = parseInt(pageOverlap, 10)
+  if (!Number.isNaN(overlap) && overlap > 0) cfg.pageOverlap = overlap
+  if (dedupeKey.trim()) cfg.dedupeKey = dedupeKey.trim()
+  chunking = { strategy: chunkStrategy, config: cfg, citationLevel }
+} else if (citationLevel !== 'auto') {
+  chunking = { strategy: 'none', citationLevel }
+}
+// included in the llm extractionConfig as `chunking`
+```
+
+Switching the method away from `llm` hides the subsection; `chunking` is never
+sent for `llamaextract` (which has its own page handling and where citation
+level does not apply).
+
+## Types + hook wiring
+
+`frontend/src/types/extraction.ts` — extend `RunWithParseRequest.extractionConfig`:
+
+```ts
+export interface ChunkingConfig {
+  strategy: string
+  config?: Record<string, unknown>
+  citationLevel?: 'auto' | 'full' | 'page_only' | 'off'
+}
+
+export interface PreprocessStage {
+  stage: string
+  config: Record<string, unknown>
+}
+
+// inside RunWithParseRequest.extractionConfig:
+  chunking?: ChunkingConfig
+  preprocess?: PreprocessStage[]   // forwarded for future use; no UI yet
+```
+
+`frontend/src/api/extraction.ts` — the `runExtraction` request type gains the
+same optional `chunking` and `preprocess` fields.
+
+`frontend/src/hooks/useExtractionResults.ts` — `runExtractionWithParse` forwards
+them into the `runExtraction` body (around line 223):
+
+```ts
+await extractionApi.runExtraction({
+  parseRunId: parseRunId!,
+  extractionSchemaId: extractionConfig.extractionSchemaId,
+  extractionMethod: extractionConfig.extractionMethod,
+  config: extractionConfig.config,
+  llmConfig: extractionConfig.llmConfig,
+  userPromptTemplate: extractionConfig.userPromptTemplate,
+  chunking: extractionConfig.chunking,
+  preprocess: extractionConfig.preprocess,
+})
+```
+
+## Result-side metadata — `ExtractionResultViewer`
+
+Today the component renders `extractionMetadata` as a raw JSON collapsible and
+shows `statusMessage` on failure. Add a **summary strip** above the raw block,
+shown only when chunking-relevant metadata is present:
+
+- **Chunk count** badge from `extractionMetadata.chunkCount`.
+- **Token usage** from `extractionMetadata.usage.total_tokens`.
+- **Scalar conflicts** — when `extractionMetadata.scalarConflicts` is a non-empty
+  array, an amber callout listing each `path: kept ≠ discarded`. This is the HITL
+  signal that two chunks disagreed on a scalar value. Hidden when absent.
+
+Failure handling needs no new work: failed runs already render `statusMessage`,
+through which the backend truncation message ("LLM response truncated at
+max_tokens … Lower chunking maxInputTokens or raise max_tokens") flows verbatim.
+The raw `extractionMetadata` / provider-response collapsibles remain unchanged
+for power users.
+
+Render the summary as a small, self-contained presentational subcomponent
+(e.g. `ChunkingSummary`) so the viewer stays readable and the piece is testable
+in isolation.
+
+## Defaults, validation, edge cases
+
+- Numeric inputs parse to integers; blank/invalid `maxInputTokens` omits the key
+  so the backend default applies. `pageOverlap` only sent when `> 0`.
+- `dedupeKey` is optional and trimmed; omitted when blank.
+- `citationLevel: 'off'` shows a subtle "no provenance captured" hint.
+- The subsection state is local to the form; no persistence (per-run only),
+  consistent with the backend's per-run config.
+- Strategy options are hardcoded (two entries); documented as the trade-off
+  against a schema-driven renderer.
+
+## Testing (vitest)
+
+- **`ExtractionForm`:**
+  - Selecting `Token-budgeted pages` and setting params yields a `chunking`
+    object (with `maxInputTokens` etc.) in the `onRun` request.
+  - `strategy: none` + `citationLevel: auto` omits `chunking` entirely.
+  - Changing only citation level to `page_only` sends
+    `chunking: { strategy: 'none', citationLevel: 'page_only' }`.
+  - The "Large document handling" section is absent when method is
+    `llamaextract`.
+- **`useExtractionResults`:** `runExtractionWithParse` forwards `chunking` to
+  `extractionApi.runExtraction`.
+- **`ExtractionResultViewer`:** renders the chunk-count/usage summary when
+  present; renders the conflicts callout when `scalarConflicts` is non-empty;
+  renders neither when `extractionMetadata` lacks them.
+
+## Out of scope (follow-ups)
+
+- Preprocess / `block_filter` controls.
+- Schema-driven generic form renderer + backend `config_schema` GET endpoints
+  for chunking strategies and preprocess stages.
+- Saved pipeline presets / profiles.
+- Per-field citation visualization in the result data table.

--- a/docs/superpowers/specs/2026-06-24-extraction-result-debug-panel-design.md
+++ b/docs/superpowers/specs/2026-06-24-extraction-result-debug-panel-design.md
@@ -1,0 +1,236 @@
+# Extraction Result Debug Panel — Design
+
+**Date:** 2026-06-24
+**Status:** Draft
+**Related files:** `frontend/src/components/extraction/ExtractionResultViewer.tsx`,
+`frontend/src/components/extraction/ExtractionResultViewer.test.tsx`,
+`frontend/src/types/extraction.ts`.
+
+## Problem
+
+The current "Extraction Metadata" and "Provider Response" collapsibles in
+`ExtractionResultViewer` dump raw `JSON.stringify` into a `<pre>` block. This
+makes it impractical to inspect a run:
+
+- **Config is not surfaced** — model, provider, chunking settings, structured
+  output mode, and citation level are buried in a flat JSON blob.
+- **Prompt messages are unreadable** — the embedded schema (~3 kB) and
+  document text are crammed into a single `user.content` string with no
+  visual separation.
+- **LLM response is a raw string** — `providerResponseRaw` contains JSON but
+  is displayed as an opaque pre-formatted dump.
+- **Chunked runs lose everything** — the merge step discards `model`,
+  `provider`, `latency_ms`, and `prompt_messages` from per-chunk outputs,
+  leaving only `{usage, chunkCount, scalarConflicts}` (separate backend fix
+  tracked below).
+
+## Goals
+
+- Replace the two raw-JSON collapsibles with three structured, scannable panels:
+  **Run Config**, **Prompt**, and **LLM Response**.
+- Render all JSON values (schemas, extracted objects, response payloads) with
+  proper indentation and syntax colouring so they are legible without copy-paste.
+- No new backend endpoints; frontend-only change.
+- Panels are collapsed by default; opening them is a deliberate debug action.
+
+## Non-goals (this spec)
+
+- Per-chunk prompt / response drill-down for chunked runs (requires backend
+  changes to preserve per-chunk context; tracked as a follow-on).
+- A full interactive JSON tree (expand/collapse nodes, copy paths). A
+  scrollable, syntax-coloured `pre` block is sufficient.
+- Exporting or diffing across runs.
+
+---
+
+## Data sources
+
+All data is already on `ExtractionResult` (no new API fields needed):
+
+| UI section | Source field(s) |
+|---|---|
+| Run Config — method / mode / flags | `result.config` (stored on the result) |
+| Run Config — model / provider / latency | `result.extractionMetadata.model`, `.provider`, `.latency_ms` |
+| Run Config — usage | `result.extractionMetadata.usage` |
+| Run Config — chunking | `result.extractionMetadata.chunkCount` + `result.config.chunking` |
+| Prompt — system | `result.extractionMetadata.prompt_messages[0].content` |
+| Prompt — user (schema + document) | `result.extractionMetadata.prompt_messages[1].content` |
+| LLM Response | `result.providerResponseRaw` |
+
+For **chunked runs** `prompt_messages`, `model`, `provider`, and `latency_ms`
+are absent from `extractionMetadata` (they are stripped by `merge_outputs`).
+Each absent field is replaced with a muted placeholder: *"Not available for
+chunked runs"*. A follow-on backend task should propagate first-chunk model/
+provider and aggregate latency into the merged metadata.
+
+---
+
+## UI design
+
+### Layout
+
+Replace the current two collapsibles (`Extraction Metadata`, `Provider
+Response`) with three collapsible panels, stacked below the result card, each
+following the existing `Collapsible` + `Button` trigger pattern:
+
+```
+[ Run Config ▾ ]
+[ Prompt ▾ ]
+[ LLM Response ▾ ]
+```
+
+All collapsed by default. Only the panels for which data exists are rendered
+(e.g. `LLM Response` is hidden when `providerResponseRaw` is null — chunked
+runs).
+
+---
+
+### Panel 1 — Run Config
+
+A two-column key-value grid (label left, value right), divided by a `Separator`
+into three logical groups:
+
+**Model**
+- Model: `claude-opus-4-7`
+- Provider: `anthropic`
+- Latency: `17,794 ms`
+
+**Tokens** (from `extractionMetadata.usage`)
+- Prompt tokens: `3,712`
+- Completion tokens: `1,830`
+- Total tokens: `5,542`
+
+**Settings** (from `result.config`)
+- Extraction method: `llm`
+- Structured output mode: `json_schema`
+- Inject block IDs: `No`
+- Chunking strategy: `token_budget_pages` | `none` | `—` (if absent)
+- Max input tokens: `4,000` (shown only when strategy ≠ none)
+- Citation level: `auto`
+- Chunk count: `3` (shown only when `chunkCount` is present)
+
+Numbers formatted with `toLocaleString()`. Missing fields show `—`.
+
+Implementation: no new component; inline JSX inside
+`ExtractionResultViewer`. Values read directly from `result.extractionMetadata`
+and `result.config`.
+
+---
+
+### Panel 2 — Prompt
+
+Two tabs using shadcn `Tabs` / `TabsList` / `TabsContent`:
+
+**System tab**
+- Renders `prompt_messages[0].content` as plain text in a scrollable `pre`
+  block (max-height `12rem`, overflow-y auto).
+
+**User tab**
+- The user message content is a long string containing the schema JSON and
+  document text. Parse it into three labelled sub-sections:
+
+  1. **Instruction** — text before `<schema>` tag (one or two lines).
+  2. **Schema** — content of `<schema>…</schema>` tag, rendered via
+     `<FormattedJson>` (see below).
+  3. **Document** — content of `<document>…</document>` tag, rendered as
+     plain text in a scrollable `pre` block.
+
+  Parse with simple string indexOf / slice on the known tag boundaries
+  (`<schema>`, `</schema>`, `<document>`, `</document>`). If the tags are
+  absent (non-standard prompt), fall back to rendering the full content as
+  plain pre-formatted text.
+
+When `prompt_messages` is absent (chunked run), render a single muted line:
+*"Prompt not available — this run used chunking. Individual chunk prompts are
+not yet preserved."*
+
+---
+
+### Panel 3 — LLM Response
+
+Renders `result.providerResponseRaw` via `<FormattedJson>` (see below) in a
+scrollable container (max-height `24rem`).
+
+When `providerResponseRaw` is null (chunked run) or contains a `raw_content`
+string key (truncation error), show the raw string in a plain `pre` block with
+a muted label *"Raw (non-JSON) response"* instead.
+
+---
+
+## `FormattedJson` component
+
+A new small utility component:
+
+```
+frontend/src/components/shared/FormattedJson.tsx
+```
+
+Props: `{ value: unknown; maxHeight?: string }`.
+
+Renders `JSON.stringify(value, null, 2)` inside a scrollable `<pre>` block
+with:
+
+- Tailwind classes for monospace, small font, muted background, rounded border,
+  horizontal and vertical overflow scroll.
+- Syntax colouring via inline `<span>` wrapping, using a simple regex pass over
+  the stringified output:
+  - JSON string values → `text-green-700 dark:text-green-400`
+  - JSON keys (`"key":`) → `text-blue-700 dark:text-blue-400`
+  - Numbers and booleans → `text-amber-600 dark:text-amber-400`
+  - Punctuation (`{}[],:`) → default `text-foreground`
+- No external dependency (no `react-json-view` or Prism); the regex approach
+  is sufficient for well-formed JSON and keeps the bundle unchanged.
+
+`FormattedJson` is also used in place of the existing raw `pre` blocks in the
+current `Extraction Metadata` / `Provider Response` panels that are being
+replaced.
+
+---
+
+## Component changes
+
+| File | Change |
+|---|---|
+| `frontend/src/components/extraction/ExtractionResultViewer.tsx` | Replace two raw collapsibles with three structured panels; add Tabs import; add inline Run Config grid; call `FormattedJson` and prompt parser. |
+| `frontend/src/components/shared/FormattedJson.tsx` | New component (see above). |
+| `frontend/src/components/shared/FormattedJson.test.tsx` | Unit tests: renders JSON string, numbers, booleans; respects maxHeight prop; handles null/undefined gracefully. |
+| `frontend/src/components/extraction/ExtractionResultViewer.test.tsx` | Add: Run Config panel shows model/provider/tokens; Prompt panel shows system/user tabs; LLM Response panel renders JSON; chunked-run placeholders render correctly. |
+
+No changes to `ExtractionResult` type, API layer, or backend.
+
+---
+
+## Chunked-run limitations (follow-on backend task)
+
+`merge_outputs` in `backend/app/adapters/extraction/chunking/merge.py`
+currently builds the merged metadata as `{usage, chunkCount, scalarConflicts}`
+only. The following should be added to the merged metadata so that Run Config
+has complete data even for chunked runs:
+
+- `model` and `provider` — taken from `outputs[0].extraction_metadata`
+  (identical across all chunks).
+- `latency_ms` — sum of per-chunk latencies.
+
+`prompt_messages` intentionally remains absent from merged metadata (N
+identical schemas would be noise); the placeholder message in the Prompt panel
+is the correct UX for this case.
+
+---
+
+## Acceptance criteria
+
+- [ ] Run Config panel shows model, provider, latency, token counts, and
+  extraction settings (method, output mode, chunking) for a completed LLM run.
+- [ ] Prompt panel System tab shows the system prompt text.
+- [ ] Prompt panel User tab separates instruction, schema (formatted JSON), and
+  document sections.
+- [ ] LLM Response panel renders `providerResponseRaw` as formatted,
+  syntax-coloured JSON.
+- [ ] All JSON values use `FormattedJson`; no raw `JSON.stringify` in `pre`
+  blocks visible to the user.
+- [ ] For chunked runs: Run Config shows `chunkCount`; Prompt and LLM Response
+  show the "not available" placeholder.
+- [ ] For failed runs with truncation: LLM Response shows the raw string
+  content with a "Raw (non-JSON) response" label.
+- [ ] All new behaviour covered by unit tests.
+- [ ] No regressions in existing `ExtractionResultViewer` tests.

--- a/frontend/src/components/extraction/ChunkingSummary.test.tsx
+++ b/frontend/src/components/extraction/ChunkingSummary.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChunkingSummary } from './ChunkingSummary'
+
+describe('ChunkingSummary', () => {
+  it('renders chunk count and token usage when present', () => {
+    render(<ChunkingSummary metadata={{ chunkCount: 3, usage: { total_tokens: 4210 } }} />)
+    expect(screen.getByText(/3 chunks/i)).toBeInTheDocument()
+    expect(screen.getByText(/4,210 tokens/i)).toBeInTheDocument()
+  })
+
+  it('renders a conflicts callout when scalarConflicts present', () => {
+    render(
+      <ChunkingSummary
+        metadata={{ chunkCount: 2, scalarConflicts: [{ path: 'currency', kept: 'EUR', discarded: 'USD' }] }}
+      />
+    )
+    expect(screen.getByText(/conflicting values/i)).toBeInTheDocument()
+    expect(screen.getByText(/currency/)).toBeInTheDocument()
+  })
+
+  it('renders nothing when metadata lacks chunking fields', () => {
+    const { container } = render(<ChunkingSummary metadata={{ model: 'x', usage: {} }} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when metadata is null', () => {
+    const { container } = render(<ChunkingSummary metadata={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/components/extraction/ChunkingSummary.tsx
+++ b/frontend/src/components/extraction/ChunkingSummary.tsx
@@ -1,0 +1,54 @@
+import { Badge } from '@/components/ui/badge'
+
+interface ScalarConflict {
+  path: string
+  kept: unknown
+  discarded: unknown
+}
+
+interface ChunkingSummaryProps {
+  metadata: Record<string, unknown> | null | undefined
+}
+
+export function ChunkingSummary({ metadata }: ChunkingSummaryProps) {
+  if (!metadata) return null
+
+  const chunkCount = typeof metadata.chunkCount === 'number' ? metadata.chunkCount : undefined
+  const usage = metadata.usage as { total_tokens?: number } | undefined
+  const totalTokens =
+    usage && typeof usage.total_tokens === 'number' ? usage.total_tokens : undefined
+  const conflicts: ScalarConflict[] = Array.isArray(metadata.scalarConflicts)
+    ? (metadata.scalarConflicts as ScalarConflict[])
+    : []
+
+  if (chunkCount === undefined && totalTokens === undefined && conflicts.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {chunkCount !== undefined && (
+          <Badge variant="secondary">
+            {chunkCount} chunk{chunkCount === 1 ? '' : 's'}
+          </Badge>
+        )}
+        {totalTokens !== undefined && (
+          <Badge variant="outline">{totalTokens.toLocaleString()} tokens</Badge>
+        )}
+      </div>
+      {conflicts.length > 0 && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-800">
+          <p className="font-medium">Conflicting values across chunks ({conflicts.length})</p>
+          <ul className="mt-1 space-y-0.5">
+            {conflicts.map((c, i) => (
+              <li key={i}>
+                <code>{c.path}</code>: kept {String(c.kept)} ≠ {String(c.discarded)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/extraction/ExtractionForm.test.tsx
+++ b/frontend/src/components/extraction/ExtractionForm.test.tsx
@@ -31,6 +31,14 @@ const extractor: ExtractorInfo = {
   configured: true,
 }
 
+const llmExtractor: ExtractorInfo = {
+  extractionMethod: 'llm',
+  name: 'LLM',
+  description: 'Generic LLM extraction',
+  configSchema: null,
+  configured: true,
+}
+
 const defaultProps = {
   defaultParser: 'simple',
   defaultParserConfig: {},
@@ -96,18 +104,60 @@ describe('ExtractionForm', () => {
   })
 
   it('pre-fills system prompt and user prompt template with fetched LLM defaults', async () => {
-    const llmExtractor: ExtractorInfo = {
-      extractionMethod: 'llm',
-      name: 'LLM',
-      description: 'Generic LLM extraction',
-      configSchema: null,
-      configured: true,
-    }
     render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={vi.fn()} />)
 
     await act(async () => {})
 
     expect(screen.getByDisplayValue('Default system prompt text')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Default user prompt template text')).toBeInTheDocument()
+  })
+
+  it('omits chunking from the request when LLM defaults are unchanged', async () => {
+    const user = userEvent.setup()
+    const onRun = vi.fn().mockResolvedValue(undefined)
+    render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={onRun} />)
+    await act(async () => {})
+    await user.click(screen.getByRole('button', { name: /run extraction/i }))
+    const arg = onRun.mock.calls[0][0]
+    expect(arg.extractionConfig.chunking).toBeUndefined()
+  })
+
+  it('does not show Large document handling for llamaextract', () => {
+    render(<ExtractionForm {...defaultProps} onRun={vi.fn()} />)
+    expect(screen.queryByText(/large document handling/i)).not.toBeInTheDocument()
+  })
+
+  it('emits token_budget_pages chunking with default max input tokens', async () => {
+    const user = userEvent.setup()
+    const onRun = vi.fn().mockResolvedValue(undefined)
+    render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={onRun} />)
+    await act(async () => {})
+
+    await user.click(screen.getByRole('button', { name: /large document handling/i }))
+    await user.click(screen.getByRole('combobox', { name: /chunking strategy/i }))
+    await user.click(screen.getByRole('option', { name: /token-budgeted pages/i }))
+    await user.click(screen.getByRole('button', { name: /run extraction/i }))
+
+    const arg = onRun.mock.calls[0][0]
+    expect(arg.extractionConfig.chunking).toEqual({
+      strategy: 'token_budget_pages',
+      config: { maxInputTokens: 8000 },
+      citationLevel: 'auto',
+    })
+  })
+
+  it('emits citation-only chunking when only citation level changes', async () => {
+    const user = userEvent.setup()
+    const onRun = vi.fn().mockResolvedValue(undefined)
+    render(<ExtractionForm {...defaultProps} extractors={[llmExtractor]} onRun={onRun} />)
+    await act(async () => {})
+
+    await user.click(screen.getByRole('button', { name: /large document handling/i }))
+    await user.click(screen.getByRole('combobox', { name: /citation detail/i }))
+    await user.click(screen.getByRole('option', { name: /page only/i }))
+    await user.click(screen.getByRole('button', { name: /run extraction/i }))
+
+    const arg = onRun.mock.calls[0][0]
+    expect(arg.extractionConfig.chunking).toEqual({ strategy: 'none', citationLevel: 'page_only' })
   })
 })

--- a/frontend/src/components/extraction/ExtractionForm.tsx
+++ b/frontend/src/components/extraction/ExtractionForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import type { ExtractionSchema, ExtractorInfo, RunWithParseRequest } from '@/types/extraction'
+import type { ExtractionSchema, ExtractorInfo, RunWithParseRequest, ChunkingConfig } from '@/types/extraction'
 import type { ParseConfig } from '@/types/parsing'
 import { getLlmDefaults } from '@/api/extraction'
 import { Button } from '@/components/ui/button'
@@ -14,8 +14,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { Separator } from '@/components/ui/separator'
-import { Pencil, Play } from 'lucide-react'
+import { Pencil, Play, ChevronDown } from 'lucide-react'
 import { PromptConfigEditor } from '@/components/shared/PromptConfigEditor'
 import { usePromptConfig } from '@/hooks/usePromptConfig'
 import { ParseMethodSelector } from '@/components/documents/ParseMethodSelector'
@@ -58,6 +63,12 @@ export function ExtractionForm({
   const [userPromptTemplate, setUserPromptTemplate] = useState('')
   const [structuredOutputMode, setStructuredOutputMode] = useState('json_schema')
   const [injectBlockIds, setInjectBlockIds] = useState(false)
+  const [chunkStrategy, setChunkStrategy] = useState<'none' | 'token_budget_pages'>('none')
+  const [maxInputTokens, setMaxInputTokens] = useState('8000')
+  const [pageOverlap, setPageOverlap] = useState('0')
+  const [dedupeKey, setDedupeKey] = useState('')
+  const [citationLevel, setCitationLevel] =
+    useState<'auto' | 'full' | 'page_only' | 'off'>('auto')
 
   const [isRunning, setIsRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -129,12 +140,25 @@ export function ExtractionForm({
       if (confidenceScores) config.confidence_scores = true
       extractionConfig = { extractionSchemaId: schemaId, extractionMethod, config }
     } else if (extractionMethod === 'llm') {
+      let chunking: ChunkingConfig | undefined
+      if (chunkStrategy !== 'none') {
+        const cfg: Record<string, unknown> = {}
+        const max = parseInt(maxInputTokens, 10)
+        if (!Number.isNaN(max)) cfg.maxInputTokens = max
+        const overlap = parseInt(pageOverlap, 10)
+        if (!Number.isNaN(overlap) && overlap > 0) cfg.pageOverlap = overlap
+        if (dedupeKey.trim()) cfg.dedupeKey = dedupeKey.trim()
+        chunking = { strategy: chunkStrategy, config: cfg, citationLevel }
+      } else if (citationLevel !== 'auto') {
+        chunking = { strategy: 'none', citationLevel }
+      }
       extractionConfig = {
         extractionSchemaId: schemaId,
         extractionMethod,
         config: { structured_output_mode: structuredOutputMode, inject_block_ids: injectBlockIds },
         llmConfig: promptConfig,
         userPromptTemplate: userPromptTemplate.trim() || undefined,
+        ...(chunking ? { chunking } : {}),
       }
     } else {
       extractionConfig = { extractionSchemaId: schemaId, extractionMethod, config: {} }
@@ -307,6 +331,61 @@ export function ExtractionForm({
               </div>
             </div>
           </div>
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="sm" className="w-full justify-between px-0">
+                <span className="text-xs font-medium">Large document handling</span>
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-3 pt-2">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Chunking</Label>
+                  <Select value={chunkStrategy} onValueChange={(v) => setChunkStrategy(v as 'none' | 'token_budget_pages')}>
+                    <SelectTrigger className="h-9" aria-label="Chunking strategy"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">None (single-shot)</SelectItem>
+                      <SelectItem value="token_budget_pages">Token-budgeted pages</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Citation detail</Label>
+                  <Select value={citationLevel} onValueChange={(v) => setCitationLevel(v as 'auto' | 'full' | 'page_only' | 'off')}>
+                    <SelectTrigger className="h-9" aria-label="Citation detail"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="auto">Auto</SelectItem>
+                      <SelectItem value="full">Full</SelectItem>
+                      <SelectItem value="page_only">Page only</SelectItem>
+                      <SelectItem value="off">Off</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              {chunkStrategy === 'token_budget_pages' && (
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Max input tokens</Label>
+                    <Input type="number" value={maxInputTokens} onChange={(e) => setMaxInputTokens(e.target.value)} className="h-9" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Page overlap</Label>
+                    <Input type="number" value={pageOverlap} onChange={(e) => setPageOverlap(e.target.value)} className="h-9" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Dedupe key</Label>
+                    <Input value={dedupeKey} onChange={(e) => setDedupeKey(e.target.value)} placeholder="e.g. sku" className="h-9" />
+                  </div>
+                </div>
+              )}
+              <p className="text-[11px] text-muted-foreground">
+                {citationLevel === 'off'
+                  ? 'No provenance will be captured.'
+                  : 'Auto uses page-level provenance on large documents. Chunking splits big docs to avoid truncation and rate limits.'}
+              </p>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       )}
 

--- a/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
@@ -215,3 +215,102 @@ describe('ExtractionResultViewer', () => {
     expect(screen.queryByText(/citations \/ reasoning/i)).not.toBeInTheDocument()
   })
 })
+
+// ── Chunk Details fixtures ────────────────────────────────────────────────────
+
+function buildChunkedResultWithDetails(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return buildResult({
+    extractionMethod: 'llm',
+    extractionMetadata: {
+      chunkCount: 2,
+      usage: { total_tokens: 6400 },
+      model: 'claude-opus-4-7',
+      provider: 'anthropic',
+      latency_ms: 2700,
+      chunks: [
+        {
+          chunkIndex: 0,
+          pageIndices: [0, 1, 2],
+          promptMessages: [
+            { role: 'system', content: 'Shared system prompt.' },
+            {
+              role: 'user',
+              content:
+                'Extract.\n<schema>{"type":"object"}</schema>\n<document>Page 1 content</document>',
+            },
+          ],
+          providerResponseRaw: { id: 'r1', answer: 'chunk-1-response' },
+          structuredData: { invoice: 'INV-001' },
+          usage: { prompt_tokens: 3000, completion_tokens: 500, total_tokens: 3500 },
+          latencyMs: 1500,
+        },
+        {
+          chunkIndex: 1,
+          pageIndices: [3, 4],
+          promptMessages: [
+            { role: 'system', content: 'Shared system prompt.' },
+            {
+              role: 'user',
+              content:
+                'Extract.\n<schema>{"type":"object"}</schema>\n<document>Page 2 content</document>',
+            },
+          ],
+          providerResponseRaw: { id: 'r2', answer: 'chunk-2-response' },
+          structuredData: { invoice: 'INV-002' },
+          usage: { prompt_tokens: 2400, completion_tokens: 500, total_tokens: 2900 },
+          latencyMs: 1200,
+        },
+      ],
+    },
+    providerResponseRaw: null,
+    ...overrides,
+  })
+}
+
+describe('Chunk Details panel', () => {
+  it('does not show Chunk Details panel when no chunks in metadata', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.queryByRole('button', { name: /chunk details/i })).not.toBeInTheDocument()
+  })
+
+  it('shows Chunk Details panel trigger when chunks are present', () => {
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    expect(screen.getByRole('button', { name: /chunk details/i })).toBeInTheDocument()
+  })
+
+  it('chunk list shows page range and token count for each chunk', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText('Chunk 1')).toBeInTheDocument()
+    expect(screen.getByText(/pp\. 1–3/)).toBeInTheDocument()
+    expect(screen.getByText(/3,500 tokens/)).toBeInTheDocument()
+    expect(screen.getByText('Chunk 2')).toBeInTheDocument()
+    expect(screen.getByText(/pp\. 4–5/)).toBeInTheDocument()
+  })
+
+  it('system prompt section carries identical-across-all-chunks note', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText(/Identical across all chunks/i)).toBeInTheDocument()
+  })
+
+  it('extracted pre-merge section carries raw-output note', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    expect(screen.getByText(/Raw output before conflict resolution/i)).toBeInTheDocument()
+  })
+
+  it('selecting a different chunk updates the detail pane', async () => {
+    const user = userEvent.setup()
+    render(<ExtractionResultViewer result={buildChunkedResultWithDetails()} />)
+    await user.click(screen.getByRole('button', { name: /chunk details/i }))
+    // Chunk 1 is selected by default
+    expect(screen.getByText('Page 1 content')).toBeInTheDocument()
+    // Click chunk 2 in the list
+    await user.click(screen.getByRole('button', { name: /chunk 2/i }))
+    expect(screen.getByText('Page 2 content')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
@@ -26,23 +26,164 @@ function buildResult(overrides: Partial<ExtractionResult> = {}): ExtractionResul
   }
 }
 
+function buildLlmResult(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return buildResult({
+    extractionMethod: 'llm',
+    extractionMetadata: {
+      model: 'claude-opus-4-7',
+      provider: 'anthropic',
+      latency_ms: 17794,
+      usage: { prompt_tokens: 3712, completion_tokens: 1830, total_tokens: 5542 },
+      prompt_messages: [
+        { role: 'system', content: 'You are an extraction assistant.' },
+        {
+          role: 'user',
+          content:
+            'Extract the following.\n<schema>{"type":"object"}</schema>\n<document>Invoice #001</document>',
+        },
+      ],
+    },
+    config: {
+      structured_output_mode: 'json_schema',
+      inject_block_ids: false,
+      chunking: { strategy: 'none', citationLevel: 'auto' },
+    },
+    providerResponseRaw: { id: 'msg_001', content: [{ type: 'text', text: '{}' }] },
+    ...overrides,
+  })
+}
+
+function buildChunkedResult(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return buildResult({
+    extractionMethod: 'llm',
+    extractionMetadata: {
+      chunkCount: 3,
+      usage: { total_tokens: 12000 },
+      scalarConflicts: [],
+      // no model, provider, latency_ms, prompt_messages
+    },
+    config: {
+      structured_output_mode: 'json_schema',
+      chunking: { strategy: 'token_budget_pages', config: { max_input_tokens: 4000 }, citationLevel: 'auto' },
+    },
+    providerResponseRaw: null,
+    ...overrides,
+  })
+}
+
 describe('ExtractionResultViewer', () => {
-  it('shows extraction metadata collapsible when extractionMetadata is present', () => {
+  // ── Run Config panel ──────────────────────────────────────────────────────
+  it('shows Run Config panel for all results', () => {
     render(<ExtractionResultViewer result={buildResult()} />)
-    expect(screen.getByText('Extraction Metadata')).toBeInTheDocument()
+    expect(screen.getByText('Run Config')).toBeInTheDocument()
   })
 
-  it('shows provider response collapsible when providerResponseRaw is present', () => {
+  it('shows model and provider in Run Config for LLM results', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('claude-opus-4-7')).toBeInTheDocument()
+    expect(screen.getByText('anthropic')).toBeInTheDocument()
+  })
+
+  it('shows formatted latency in Run Config for LLM results', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('17,794 ms')).toBeInTheDocument()
+  })
+
+  it('shows token counts in Run Config for LLM results', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('3,712')).toBeInTheDocument()
+    expect(screen.getByText('1,830')).toBeInTheDocument()
+    expect(screen.getByText('5,542')).toBeInTheDocument()
+  })
+
+  it('shows chunked run placeholder for model when model is absent', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getAllByText('Not available for chunked runs').length).toBeGreaterThan(0)
+  })
+
+  it('shows chunk count in Run Config for chunked results', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('shows chunking strategy in Run Config settings', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getByText('token_budget_pages')).toBeInTheDocument()
+  })
+
+  it('shows max input tokens when chunking strategy is not none', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.getByText('4,000')).toBeInTheDocument()
+  })
+
+  // ── Prompt panel ──────────────────────────────────────────────────────────
+  it('shows Prompt panel for all results', () => {
+    render(<ExtractionResultViewer result={buildResult()} />)
+    expect(screen.getByText('Prompt')).toBeInTheDocument()
+  })
+
+  it('shows System and User tabs in Prompt panel for LLM results with prompt_messages', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByRole('tab', { name: 'System' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'User' })).toBeInTheDocument()
+  })
+
+  it('shows system prompt content in System tab', () => {
+    render(<ExtractionResultViewer result={buildLlmResult()} />)
+    expect(screen.getByText('You are an extraction assistant.')).toBeInTheDocument()
+  })
+
+  it('shows chunking unavailable message in Prompt panel for chunked results', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(
+      screen.getByText(/Prompt not available.*chunking/i)
+    ).toBeInTheDocument()
+  })
+
+  // ── LLM Response panel ────────────────────────────────────────────────────
+  it('shows LLM Response panel when providerResponseRaw is present', () => {
     render(
       <ExtractionResultViewer
         result={buildResult({ providerResponseRaw: { data: { invoice_number: 'INV-001' } } })}
       />
     )
-    expect(screen.getByText('Provider Response')).toBeInTheDocument()
+    expect(screen.getByText('LLM Response')).toBeInTheDocument()
   })
 
-  it('does not show provider response collapsible when providerResponseRaw is null', () => {
+  it('does not show LLM Response panel when providerResponseRaw is null', () => {
     render(<ExtractionResultViewer result={buildResult({ providerResponseRaw: null })} />)
+    expect(screen.queryByText('LLM Response')).not.toBeInTheDocument()
+  })
+
+  it('does not show LLM Response panel for chunked runs', () => {
+    render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    expect(screen.queryByText('LLM Response')).not.toBeInTheDocument()
+  })
+
+  it('shows Raw label when providerResponseRaw contains raw_content string', () => {
+    render(
+      <ExtractionResultViewer
+        result={buildResult({
+          providerResponseRaw: { raw_content: 'this is not json' },
+        })}
+      />
+    )
+    expect(screen.getByText('Raw (non-JSON) response')).toBeInTheDocument()
+    expect(screen.getByText('this is not json')).toBeInTheDocument()
+  })
+
+  // ── Legacy panel absence ──────────────────────────────────────────────────
+  it('does not render old "Extraction Metadata" panel text', () => {
+    render(<ExtractionResultViewer result={buildResult()} />)
+    expect(screen.queryByText('Extraction Metadata')).not.toBeInTheDocument()
+  })
+
+  it('does not render old "Provider Response" panel text', () => {
+    render(
+      <ExtractionResultViewer
+        result={buildResult({ providerResponseRaw: { data: {} } })}
+      />
+    )
     expect(screen.queryByText('Provider Response')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ExtractionResultViewer } from './ExtractionResultViewer'
 import type { ExtractionResult } from '@/types/extraction'
 
@@ -78,41 +79,55 @@ describe('ExtractionResultViewer', () => {
     expect(screen.getByText('Run Config')).toBeInTheDocument()
   })
 
-  it('shows model and provider in Run Config for LLM results', () => {
+  it('shows model and provider in Run Config for LLM results', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildLlmResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getByText('claude-opus-4-7')).toBeInTheDocument()
     expect(screen.getByText('anthropic')).toBeInTheDocument()
   })
 
-  it('shows formatted latency in Run Config for LLM results', () => {
+  it('shows formatted latency in Run Config for LLM results', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildLlmResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getByText('17,794 ms')).toBeInTheDocument()
   })
 
-  it('shows token counts in Run Config for LLM results', () => {
+  it('shows token counts in Run Config for LLM results', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildLlmResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getByText('3,712')).toBeInTheDocument()
     expect(screen.getByText('1,830')).toBeInTheDocument()
     expect(screen.getByText('5,542')).toBeInTheDocument()
   })
 
-  it('shows chunked run placeholder for model when model is absent', () => {
+  it('shows chunked run placeholder for model when model is absent', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getAllByText('Not available for chunked runs').length).toBeGreaterThan(0)
   })
 
-  it('shows chunk count in Run Config for chunked results', () => {
+  it('shows chunk count in Run Config for chunked results', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 
-  it('shows chunking strategy in Run Config settings', () => {
+  it('shows chunking strategy in Run Config settings', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getByText('token_budget_pages')).toBeInTheDocument()
   })
 
-  it('shows max input tokens when chunking strategy is not none', () => {
+  it('shows max input tokens when chunking strategy is not none', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    await user.click(screen.getByRole('button', { name: /run config/i }))
     expect(screen.getByText('4,000')).toBeInTheDocument()
   })
 
@@ -122,19 +137,25 @@ describe('ExtractionResultViewer', () => {
     expect(screen.getByText('Prompt')).toBeInTheDocument()
   })
 
-  it('shows System and User tabs in Prompt panel for LLM results with prompt_messages', () => {
+  it('shows System and User tabs in Prompt panel for LLM results with prompt_messages', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildLlmResult()} />)
+    await user.click(screen.getByRole('button', { name: /^prompt$/i }))
     expect(screen.getByRole('tab', { name: 'System' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'User' })).toBeInTheDocument()
   })
 
-  it('shows system prompt content in System tab', () => {
+  it('shows system prompt content in System tab', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildLlmResult()} />)
+    await user.click(screen.getByRole('button', { name: /^prompt$/i }))
     expect(screen.getByText('You are an extraction assistant.')).toBeInTheDocument()
   })
 
-  it('shows chunking unavailable message in Prompt panel for chunked results', () => {
+  it('shows chunking unavailable message in Prompt panel for chunked results', async () => {
+    const user = userEvent.setup()
     render(<ExtractionResultViewer result={buildChunkedResult()} />)
+    await user.click(screen.getByRole('button', { name: /^prompt$/i }))
     expect(
       screen.getByText(/Prompt not available.*chunking/i)
     ).toBeInTheDocument()
@@ -160,7 +181,8 @@ describe('ExtractionResultViewer', () => {
     expect(screen.queryByText('LLM Response')).not.toBeInTheDocument()
   })
 
-  it('shows Raw label when providerResponseRaw contains raw_content string', () => {
+  it('shows Raw label when providerResponseRaw contains raw_content string', async () => {
+    const user = userEvent.setup()
     render(
       <ExtractionResultViewer
         result={buildResult({
@@ -168,6 +190,7 @@ describe('ExtractionResultViewer', () => {
         })}
       />
     )
+    await user.click(screen.getByRole('button', { name: /llm response/i }))
     expect(screen.getByText('Raw (non-JSON) response')).toBeInTheDocument()
     expect(screen.getByText('this is not json')).toBeInTheDocument()
   })

--- a/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
@@ -65,7 +65,7 @@ function buildChunkedResult(overrides: Partial<ExtractionResult> = {}): Extracti
     },
     config: {
       structured_output_mode: 'json_schema',
-      chunking: { strategy: 'token_budget_pages', config: { max_input_tokens: 4000 }, citationLevel: 'auto' },
+      chunking: { strategy: 'token_budget_pages', config: { maxInputTokens: 4000 }, citationLevel: 'auto' },
     },
     providerResponseRaw: null,
     ...overrides,

--- a/frontend/src/components/extraction/ExtractionResultViewer.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.tsx
@@ -321,7 +321,7 @@ export function ExtractionResultViewer({
       </Card>
 
       {/* ── Run Config panel ─────────────────────────────────────────────── */}
-      <Collapsible defaultOpen>
+      <Collapsible>
         <CollapsibleTrigger asChild>
           <Button variant="outline" size="sm" className="w-full justify-between">
             <span>Run Config</span>
@@ -417,7 +417,7 @@ export function ExtractionResultViewer({
       </Collapsible>
 
       {/* ── Prompt panel ─────────────────────────────────────────────────── */}
-      <Collapsible defaultOpen>
+      <Collapsible>
         <CollapsibleTrigger asChild>
           <Button variant="outline" size="sm" className="w-full justify-between">
             <span>Prompt</span>
@@ -459,7 +459,7 @@ export function ExtractionResultViewer({
 
       {/* ── LLM Response panel (hidden for chunked/null) ──────────────────── */}
       {hasProviderResponse && (
-        <Collapsible defaultOpen>
+        <Collapsible>
           <CollapsibleTrigger asChild>
             <Button variant="outline" size="sm" className="w-full justify-between">
               <span>LLM Response</span>

--- a/frontend/src/components/extraction/ExtractionResultViewer.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.tsx
@@ -1,5 +1,6 @@
 import type { ExtractionResult } from '@/types/extraction'
 import { ChunkingSummary } from './ChunkingSummary'
+import { FormattedJson } from '@/components/shared/FormattedJson'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -15,6 +16,8 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import { ChevronDown, Loader2 } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -23,6 +26,33 @@ interface ExtractionResultViewerProps {
   result: ExtractionResult | null
   isLoading?: boolean
 }
+
+// ── Internal types for casting extractionMetadata and config ─────────────────
+
+interface ExtractionMeta {
+  model?: string
+  provider?: string
+  latency_ms?: number
+  usage?: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+  }
+  chunkCount?: number
+  prompt_messages?: Array<{ role: string; content: string }>
+}
+
+interface ExtractionConfig {
+  structured_output_mode?: string
+  inject_block_ids?: boolean
+  chunking?: {
+    strategy?: string
+    config?: Record<string, unknown>
+    citationLevel?: string
+  }
+}
+
+// ── Helper components ─────────────────────────────────────────────────────────
 
 function StructuredDataDisplay({ data }: { data: Record<string, unknown> }) {
   const entries = Object.entries(data)
@@ -97,6 +127,66 @@ function ArrayTable({ label, items }: { label: string; items: Record<string, unk
   )
 }
 
+function ConfigRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[12rem_1fr] gap-4 py-0.5 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span>{value ?? '—'}</span>
+    </div>
+  )
+}
+
+function NotAvailableChunked() {
+  return (
+    <span className="text-muted-foreground italic text-xs">
+      Not available for chunked runs
+    </span>
+  )
+}
+
+function UserMessageDisplay({ content }: { content: string }) {
+  const parsed = parseUserContent(content)
+  if (!parsed.schema) {
+    return (
+      <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-48 whitespace-pre-wrap">
+        {content}
+      </pre>
+    )
+  }
+  let schemaJson: unknown
+  try {
+    schemaJson = JSON.parse(parsed.schema)
+  } catch {
+    schemaJson = parsed.schema
+  }
+  return (
+    <div className="space-y-3">
+      {parsed.instruction && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">Instruction</p>
+          <pre className="text-xs font-mono bg-muted p-2 rounded border whitespace-pre-wrap">
+            {parsed.instruction}
+          </pre>
+        </div>
+      )}
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground mb-1">Schema</p>
+        <FormattedJson value={schemaJson} maxHeight="12rem" />
+      </div>
+      {parsed.document && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">Document</p>
+          <pre className="text-xs font-mono bg-muted p-2 rounded border overflow-auto max-h-48 whitespace-pre-wrap">
+            {parsed.document}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
 function formatLabel(key: string): string {
   return key
     .replace(/_/g, ' ')
@@ -111,6 +201,33 @@ function formatValue(value: unknown): string {
   if (typeof value === 'object') return JSON.stringify(value)
   return String(value)
 }
+
+interface ParsedUserContent {
+  instruction: string
+  schema: string | null
+  document: string | null
+}
+
+function parseUserContent(content: string): ParsedUserContent {
+  const schemaOpen = '<schema>'
+  const schemaClose = '</schema>'
+  const docOpen = '<document>'
+  const docClose = '</document>'
+  const s0 = content.indexOf(schemaOpen)
+  const s1 = content.indexOf(schemaClose)
+  const d0 = content.indexOf(docOpen)
+  const d1 = content.indexOf(docClose)
+  if (s0 === -1 || d0 === -1) {
+    return { instruction: content, schema: null, document: null }
+  }
+  return {
+    instruction: content.slice(0, s0).trim(),
+    schema: content.slice(s0 + schemaOpen.length, s1).trim(),
+    document: content.slice(d0 + docOpen.length, d1).trim(),
+  }
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
 
 export function ExtractionResultViewer({
   result,
@@ -135,6 +252,20 @@ export function ExtractionResultViewer({
 
   if (!result) return null
 
+  const meta = result.extractionMetadata as ExtractionMeta | null
+  const cfg = result.config as ExtractionConfig | null
+  const chunkingConfig = cfg?.chunking
+  const promptMessages = meta?.prompt_messages
+  const systemMessage = promptMessages?.[0]
+  const userMessage = promptMessages?.[1]
+
+  const hasProviderResponse =
+    result.providerResponseRaw !== null &&
+    result.providerResponseRaw !== undefined &&
+    Object.keys(result.providerResponseRaw).length > 0
+  const isRawContent =
+    typeof result.providerResponseRaw?.['raw_content'] === 'string'
+
   const statusColor =
     result.status === 'completed'
       ? 'default'
@@ -145,6 +276,8 @@ export function ExtractionResultViewer({
   return (
     <div className="space-y-4">
       <ChunkingSummary metadata={result.extractionMetadata} />
+
+      {/* ── Result card ─────────────────────────────────────────────────── */}
       <Card>
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
@@ -170,11 +303,11 @@ export function ExtractionResultViewer({
               {result.statusMessage && (
                 <p className="text-sm text-destructive">{result.statusMessage}</p>
               )}
-              {typeof result.providerResponseRaw?.['raw_content'] === 'string' && (
+              {isRawContent && (
                 <div className="space-y-1">
                   <p className="text-xs font-medium text-muted-foreground">LLM Response</p>
                   <pre className="text-xs bg-muted p-3 rounded-md overflow-x-auto whitespace-pre-wrap max-h-64">
-                    {result.providerResponseRaw['raw_content'] as string}
+                    {result.providerResponseRaw!['raw_content'] as string}
                   </pre>
                 </div>
               )}
@@ -187,42 +320,165 @@ export function ExtractionResultViewer({
         </CardContent>
       </Card>
 
-      {result.extractionMetadata && Object.keys(result.extractionMetadata).length > 0 && (
-        <Collapsible>
-          <CollapsibleTrigger asChild>
-            <Button variant="outline" size="sm" className="w-full justify-between">
-              <span>Extraction Metadata</span>
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <Card className="mt-2">
-              <CardContent className="pt-4">
-                <pre className="text-xs overflow-x-auto whitespace-pre-wrap">
-                  {JSON.stringify(result.extractionMetadata, null, 2)}
-                </pre>
-              </CardContent>
-            </Card>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+      {/* ── Run Config panel ─────────────────────────────────────────────── */}
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger asChild>
+          <Button variant="outline" size="sm" className="w-full justify-between">
+            <span>Run Config</span>
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <Card className="mt-2">
+            <CardContent className="pt-4 space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Model
+              </p>
+              <div className="space-y-0.5">
+                <ConfigRow
+                  label="Model"
+                  value={meta?.model ?? <NotAvailableChunked />}
+                />
+                <ConfigRow
+                  label="Provider"
+                  value={meta?.provider ?? <NotAvailableChunked />}
+                />
+                <ConfigRow
+                  label="Latency"
+                  value={
+                    meta?.latency_ms !== undefined
+                      ? `${meta.latency_ms.toLocaleString()} ms`
+                      : <NotAvailableChunked />
+                  }
+                />
+              </div>
+              <Separator />
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Tokens
+              </p>
+              <div className="space-y-0.5">
+                <ConfigRow
+                  label="Prompt tokens"
+                  value={meta?.usage?.prompt_tokens?.toLocaleString() ?? '—'}
+                />
+                <ConfigRow
+                  label="Completion tokens"
+                  value={meta?.usage?.completion_tokens?.toLocaleString() ?? '—'}
+                />
+                <ConfigRow
+                  label="Total tokens"
+                  value={meta?.usage?.total_tokens?.toLocaleString() ?? '—'}
+                />
+              </div>
+              <Separator />
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Settings
+              </p>
+              <div className="space-y-0.5">
+                <ConfigRow label="Extraction method" value={result.extractionMethod} />
+                <ConfigRow
+                  label="Structured output mode"
+                  value={cfg?.structured_output_mode ?? '—'}
+                />
+                <ConfigRow
+                  label="Inject block IDs"
+                  value={
+                    typeof cfg?.inject_block_ids === 'boolean'
+                      ? cfg.inject_block_ids
+                        ? 'Yes'
+                        : 'No'
+                      : '—'
+                  }
+                />
+                <ConfigRow
+                  label="Chunking strategy"
+                  value={chunkingConfig?.strategy ?? '—'}
+                />
+                {chunkingConfig?.strategy && chunkingConfig.strategy !== 'none' && (
+                  <ConfigRow
+                    label="Max input tokens"
+                    value={
+                      (chunkingConfig.config?.['max_input_tokens'] as number | undefined)?.toLocaleString() ??
+                      '—'
+                    }
+                  />
+                )}
+                <ConfigRow
+                  label="Citation level"
+                  value={chunkingConfig?.citationLevel ?? '—'}
+                />
+                {meta?.chunkCount !== undefined && (
+                  <ConfigRow label="Chunk count" value={String(meta.chunkCount)} />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </CollapsibleContent>
+      </Collapsible>
 
-      {result.providerResponseRaw &&
-        Object.keys(result.providerResponseRaw).length > 0 &&
-        typeof result.providerResponseRaw['raw_content'] !== 'string' && (
-        <Collapsible>
+      {/* ── Prompt panel ─────────────────────────────────────────────────── */}
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger asChild>
+          <Button variant="outline" size="sm" className="w-full justify-between">
+            <span>Prompt</span>
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <Card className="mt-2">
+            <CardContent className="pt-4">
+              {!promptMessages ? (
+                <p className="text-sm text-muted-foreground italic">
+                  Prompt not available — this run used chunking. Individual chunk prompts
+                  are not yet preserved.
+                </p>
+              ) : (
+                <Tabs defaultValue="system">
+                  <TabsList>
+                    <TabsTrigger value="system">System</TabsTrigger>
+                    <TabsTrigger value="user">User</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="system" className="mt-3">
+                    <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-48 whitespace-pre-wrap">
+                      {systemMessage?.content ?? '—'}
+                    </pre>
+                  </TabsContent>
+                  <TabsContent value="user" className="mt-3">
+                    {userMessage ? (
+                      <UserMessageDisplay content={userMessage.content} />
+                    ) : (
+                      <p className="text-sm text-muted-foreground">—</p>
+                    )}
+                  </TabsContent>
+                </Tabs>
+              )}
+            </CardContent>
+          </Card>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* ── LLM Response panel (hidden for chunked/null) ──────────────────── */}
+      {hasProviderResponse && (
+        <Collapsible defaultOpen>
           <CollapsibleTrigger asChild>
             <Button variant="outline" size="sm" className="w-full justify-between">
-              <span>Provider Response</span>
+              <span>LLM Response</span>
               <ChevronDown className="h-4 w-4" />
             </Button>
           </CollapsibleTrigger>
           <CollapsibleContent>
             <Card className="mt-2">
               <CardContent className="pt-4">
-                <pre className="text-xs overflow-x-auto whitespace-pre-wrap">
-                  {JSON.stringify(result.providerResponseRaw, null, 2)}
-                </pre>
+                {isRawContent ? (
+                  <div className="space-y-1">
+                    <p className="text-xs text-muted-foreground">Raw (non-JSON) response</p>
+                    <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-96 whitespace-pre-wrap">
+                      {result.providerResponseRaw!['raw_content'] as string}
+                    </pre>
+                  </div>
+                ) : (
+                  <FormattedJson value={result.providerResponseRaw} maxHeight="24rem" />
+                )}
               </CardContent>
             </Card>
           </CollapsibleContent>

--- a/frontend/src/components/extraction/ExtractionResultViewer.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.tsx
@@ -1,4 +1,5 @@
 import type { ExtractionResult } from '@/types/extraction'
+import { ChunkingSummary } from './ChunkingSummary'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -143,6 +144,7 @@ export function ExtractionResultViewer({
 
   return (
     <div className="space-y-4">
+      <ChunkingSummary metadata={result.extractionMetadata} />
       <Card>
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">

--- a/frontend/src/components/extraction/ExtractionResultViewer.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { ExtractionResult } from '@/types/extraction'
 import { ChunkingSummary } from './ChunkingSummary'
 import { FormattedJson } from '@/components/shared/FormattedJson'
@@ -21,6 +22,7 @@ import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import { ChevronDown, Loader2 } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
 
 interface ExtractionResultViewerProps {
   result: ExtractionResult | null
@@ -28,6 +30,20 @@ interface ExtractionResultViewerProps {
 }
 
 // ── Internal types for casting extractionMetadata and config ─────────────────
+
+interface ChunkDetail {
+  chunkIndex: number
+  pageIndices: number[]
+  promptMessages: Array<{ role: string; content: string }> | null
+  providerResponseRaw: unknown
+  structuredData: unknown
+  usage: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+  } | null
+  latencyMs: number | null
+}
 
 interface ExtractionMeta {
   model?: string
@@ -40,6 +56,7 @@ interface ExtractionMeta {
   }
   chunkCount?: number
   prompt_messages?: Array<{ role: string; content: string }>
+  chunks?: ChunkDetail[]
 }
 
 interface ExtractionConfig {
@@ -185,6 +202,126 @@ function UserMessageDisplay({ content }: { content: string }) {
   )
 }
 
+function ChunkDetailsPanel({ chunks }: { chunks: ChunkDetail[] }) {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const chunk = chunks[selectedIndex]
+  const systemMsg = chunk.promptMessages?.[0]
+  const userMsg = chunk.promptMessages?.[1]
+
+  return (
+    <div className="grid grid-cols-[16rem_1fr] divide-x overflow-hidden">
+      {/* Left: chunk list */}
+      <div className="overflow-y-auto">
+        {chunks.map((c, i) => {
+          const pageFirst = c.pageIndices.length > 0 ? c.pageIndices[0] + 1 : null
+          const pageLast =
+            c.pageIndices.length > 0 ? c.pageIndices[c.pageIndices.length - 1] + 1 : null
+          const pageRange = pageFirst !== null ? `pp. ${pageFirst}–${pageLast}` : null
+          const tokens = c.usage?.total_tokens?.toLocaleString() ?? '—'
+          const latency = c.latencyMs !== null ? `${c.latencyMs?.toLocaleString()} ms` : '—'
+
+          return (
+            <button
+              key={c.chunkIndex}
+              onClick={() => setSelectedIndex(i)}
+              className={cn(
+                'w-full text-left px-3 py-2 border-b text-sm transition-colors',
+                i === selectedIndex
+                  ? 'bg-muted border-l-2 border-l-primary'
+                  : 'hover:bg-muted/50',
+              )}
+            >
+              <div className="font-semibold">
+                Chunk {c.chunkIndex + 1}
+                {pageRange && (
+                  <span className="ml-2 text-muted-foreground text-xs font-normal">
+                    {pageRange}
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {tokens} tokens · {latency}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Right: detail pane */}
+      <div className="overflow-y-auto pl-4 space-y-4">
+        {/* System */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">System</p>
+          <pre className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto max-h-48 whitespace-pre-wrap">
+            {systemMsg?.content ?? '—'}
+          </pre>
+          <p className="text-xs text-muted-foreground italic mt-1">
+            Identical across all chunks
+          </p>
+        </div>
+
+        {/* User */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">User</p>
+          {userMsg ? (
+            <UserMessageDisplay content={userMsg.content} />
+          ) : (
+            <p className="text-sm text-muted-foreground">—</p>
+          )}
+        </div>
+
+        {/* LLM Response */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">LLM Response</p>
+          {chunk.providerResponseRaw !== null && chunk.providerResponseRaw !== undefined ? (
+            <FormattedJson value={chunk.providerResponseRaw} maxHeight="20rem" />
+          ) : (
+            <p className="text-sm text-muted-foreground italic">
+              No response recorded for this chunk.
+            </p>
+          )}
+        </div>
+
+        {/* Extracted (pre-merge) */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">
+            Extracted (pre-merge)
+          </p>
+          <p className="text-xs text-muted-foreground italic mb-1">
+            Raw output before conflict resolution and deduplication.
+          </p>
+          <FormattedJson value={chunk.structuredData} maxHeight="16rem" />
+        </div>
+
+        {/* Usage */}
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1">Usage</p>
+          <div className="grid grid-cols-4 gap-2 text-sm">
+            <div>
+              <p className="text-xs text-muted-foreground">Prompt</p>
+              <p>{chunk.usage?.prompt_tokens?.toLocaleString() ?? '—'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Completion</p>
+              <p>{chunk.usage?.completion_tokens?.toLocaleString() ?? '—'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Total</p>
+              <p>{chunk.usage?.total_tokens?.toLocaleString() ?? '—'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Latency</p>
+              <p>
+                {chunk.latencyMs !== null ? `${chunk.latencyMs?.toLocaleString()} ms` : '—'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ── Pure helpers ──────────────────────────────────────────────────────────────
 
 function formatLabel(key: string): string {
@@ -253,6 +390,7 @@ export function ExtractionResultViewer({
   if (!result) return null
 
   const meta = result.extractionMetadata as ExtractionMeta | null
+  const chunks = (meta?.chunks ?? null) as ChunkDetail[] | null
   const cfg = result.config as ExtractionConfig | null
   const chunkingConfig = cfg?.chunking
   const promptMessages = meta?.prompt_messages
@@ -479,6 +617,25 @@ export function ExtractionResultViewer({
                 ) : (
                   <FormattedJson value={result.providerResponseRaw} maxHeight="24rem" />
                 )}
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
+      {/* ── Chunk Details panel (chunked runs only) ───────────────────────── */}
+      {chunks && chunks.length > 0 && (
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm" className="w-full justify-between">
+              <span>Chunk Details</span>
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <Card className="mt-2">
+              <CardContent className="pt-4">
+                <ChunkDetailsPanel chunks={chunks} />
               </CardContent>
             </Card>
           </CollapsibleContent>

--- a/frontend/src/components/extraction/ExtractionResultViewer.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.tsx
@@ -398,7 +398,7 @@ export function ExtractionResultViewer({
                   <ConfigRow
                     label="Max input tokens"
                     value={
-                      (chunkingConfig.config?.['max_input_tokens'] as number | undefined)?.toLocaleString() ??
+                      (chunkingConfig.config?.['maxInputTokens'] as number | undefined)?.toLocaleString() ??
                       '—'
                     }
                   />

--- a/frontend/src/components/shared/FormattedJson.test.tsx
+++ b/frontend/src/components/shared/FormattedJson.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FormattedJson } from './FormattedJson'
+
+describe('FormattedJson', () => {
+  it('renders JSON string keys and values', () => {
+    const { container } = render(<FormattedJson value={{ name: 'Alice' }} />)
+    // "name" as key and "Alice" as string value should appear in the pre
+    expect(container.querySelector('pre')).toHaveTextContent('"name"')
+    expect(container.querySelector('pre')).toHaveTextContent('"Alice"')
+  })
+
+  it('renders JSON number values', () => {
+    render(<FormattedJson value={{ count: 42 }} />)
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  it('renders JSON boolean values', () => {
+    render(<FormattedJson value={{ active: true, disabled: false }} />)
+    expect(screen.getByText('true')).toBeInTheDocument()
+    expect(screen.getByText('false')).toBeInTheDocument()
+  })
+
+  it('renders null JSON value as literal text', () => {
+    render(<FormattedJson value={{ x: null }} />)
+    expect(screen.getByText('null')).toBeInTheDocument()
+  })
+
+  it('applies maxHeight style to pre element', () => {
+    const { container } = render(<FormattedJson value={{ x: 1 }} maxHeight="10rem" />)
+    expect(container.querySelector('pre')?.style.maxHeight).toBe('10rem')
+  })
+
+  it('uses default maxHeight of 24rem when prop omitted', () => {
+    const { container } = render(<FormattedJson value={{ x: 1 }} />)
+    expect(container.querySelector('pre')?.style.maxHeight).toBe('24rem')
+  })
+
+  it('handles null value prop gracefully without crashing', () => {
+    const { container } = render(<FormattedJson value={null} />)
+    expect(container.querySelector('pre')).toBeInTheDocument()
+  })
+
+  it('handles undefined value prop gracefully without crashing', () => {
+    const { container } = render(<FormattedJson value={undefined} />)
+    expect(container.querySelector('pre')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/FormattedJson.tsx
+++ b/frontend/src/components/shared/FormattedJson.tsx
@@ -1,0 +1,72 @@
+interface FormattedJsonProps {
+  value: unknown
+  maxHeight?: string
+}
+
+function highlight(json: string): React.ReactNode[] {
+  // Groups: (1) quoted string + optional colon (key vs. value), (2) bool/null, (3) number
+  const regex =
+    /("(?:[^\\"]|\\.)*")(\s*:)?|(\btrue\b|\bfalse\b|\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g
+  const nodes: React.ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(json)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(json.slice(lastIndex, match.index))
+    }
+    if (match[1] !== undefined) {
+      const isKey = match[2] !== undefined
+      nodes.push(
+        <span
+          key={match.index}
+          className={
+            isKey
+              ? 'text-blue-700 dark:text-blue-400'
+              : 'text-green-700 dark:text-green-400'
+          }
+        >
+          {match[1]}
+        </span>
+      )
+      if (match[2]) nodes.push(match[2])
+    } else if (match[3] !== undefined) {
+      nodes.push(
+        <span key={match.index} className="text-amber-600 dark:text-amber-400">
+          {match[3]}
+        </span>
+      )
+    } else if (match[4] !== undefined) {
+      nodes.push(
+        <span key={match.index} className="text-amber-600 dark:text-amber-400">
+          {match[4]}
+        </span>
+      )
+    }
+    lastIndex = match.index + match[0].length
+  }
+  if (lastIndex < json.length) nodes.push(json.slice(lastIndex))
+  return nodes
+}
+
+export function FormattedJson({ value, maxHeight = '24rem' }: FormattedJsonProps) {
+  if (value === null || value === undefined) {
+    return (
+      <pre
+        className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto text-muted-foreground"
+        style={{ maxHeight }}
+      >
+        {String(value)}
+      </pre>
+    )
+  }
+  const json = JSON.stringify(value, null, 2)
+  return (
+    <pre
+      className="text-xs font-mono bg-muted p-3 rounded-md border overflow-auto"
+      style={{ maxHeight }}
+    >
+      {highlight(json)}
+    </pre>
+  )
+}

--- a/frontend/src/hooks/useExtractionResults.test.ts
+++ b/frontend/src/hooks/useExtractionResults.test.ts
@@ -178,4 +178,31 @@ describe('runExtractionWithParse', () => {
 
     expect(result.current.extractionPhase).toBe('done')
   })
+
+  it('forwards chunking config to runExtraction', async () => {
+    const existingRun = makeParseRun({
+      id: 'run-match', parser: 'simple', config: { parser: 'simple' }, status: 'succeeded',
+    })
+    mockExtraction.runExtraction.mockResolvedValue(fakeExtractionResult)
+
+    const { result } = renderHook(() => useExtractionResults('doc-1'))
+
+    const requestWithChunking = {
+      ...baseRequest,
+      extractionConfig: {
+        ...baseRequest.extractionConfig,
+        chunking: { strategy: 'token_budget_pages', config: { maxInputTokens: 6000 }, citationLevel: 'auto' as const },
+      },
+    }
+
+    await act(async () => {
+      await result.current.runExtractionWithParse('doc-1', [existingRun], requestWithChunking)
+    })
+
+    expect(mockExtraction.runExtraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunking: { strategy: 'token_budget_pages', config: { maxInputTokens: 6000 }, citationLevel: 'auto' },
+      })
+    )
+  })
 })

--- a/frontend/src/hooks/useExtractionResults.ts
+++ b/frontend/src/hooks/useExtractionResults.ts
@@ -227,6 +227,8 @@ export function useExtractionResults(
           config: extractionConfig.config,
           llmConfig: extractionConfig.llmConfig,
           userPromptTemplate: extractionConfig.userPromptTemplate,
+          chunking: extractionConfig.chunking,
+          preprocess: extractionConfig.preprocess,
         })
         await fetchResults()
         setExtractionPhase('done')

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -13,3 +13,17 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
+
+// Radix UI Select/Dropdown rely on pointer capture + scrollIntoView, absent in happy-dom
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}

--- a/frontend/src/types/extraction.ts
+++ b/frontend/src/types/extraction.ts
@@ -58,6 +58,17 @@ export interface ExtractionResultListItem {
   createdAt: string
 }
 
+export interface ChunkingConfig {
+  strategy: string
+  config?: Record<string, unknown>
+  citationLevel?: 'auto' | 'full' | 'page_only' | 'off'
+}
+
+export interface PreprocessStage {
+  stage: string
+  config: Record<string, unknown>
+}
+
 export interface RunExtractionRequest {
   parseRunId: string
   extractionSchemaId: string
@@ -65,6 +76,8 @@ export interface RunExtractionRequest {
   config?: Record<string, unknown>
   llmConfig?: PromptConfig
   userPromptTemplate?: string
+  chunking?: ChunkingConfig
+  preprocess?: PreprocessStage[]
 }
 
 export interface ExtractorInfo {
@@ -90,5 +103,7 @@ export interface RunWithParseRequest {
     config?: Record<string, unknown>
     llmConfig?: PromptConfig
     userPromptTemplate?: string
+    chunking?: ChunkingConfig
+    preprocess?: PreprocessStage[]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `FormattedJson` shared component with syntax colouring (keys/strings/numbers/booleans) via inline regex — no external deps
- Adds three structured debug panels to `ExtractionResultViewer` (Run Config, Prompt, LLM Response) replacing old raw-JSON collapsibles; all panels collapsed by default
- Adds **Chunk Details** panel for chunked LLM runs: left chunk-list (page range, tokens, latency) + right detail pane (system prompt, parsed user message, LLM response, pre-merge extracted data, usage per chunk)
- Backend: `merge_outputs` now propagates `model`, `provider`, summed `latency_ms`, and per-chunk summaries into `extractionMetadata.chunks` — stored in the existing JSONB column, no migration needed

Closes #102
Closes #104
Closes #105

## Test plan

- [ ] Run a non-chunked LLM extraction — verify Run Config shows model/provider/latency/tokens, Prompt shows System+User tabs, LLM Response shows formatted JSON; all panels collapsed by default
- [ ] Run a chunked LLM extraction — verify Run Config shows chunk count, model, provider, and summed latency; Prompt shows chunking unavailable message; LLM Response is hidden; Chunk Details panel appears
- [ ] Open Chunk Details — verify left list shows correct page ranges and token/latency counts; clicking a chunk updates the right pane (system prompt, schema, document, LLM response, pre-merge data, usage)
- [ ] Run a non-LLM extraction (e.g. llamaextract) — verify Chunk Details and LLM Response panels are hidden
- [ ] `npx vitest run src/components/extraction/ExtractionResultViewer.test.tsx` → 25/25 pass
- [ ] `npx vitest run src/components/shared/FormattedJson.test.tsx` → all pass
- [ ] `uv run --directory backend python -m pytest backend/tests/adapters/extraction/chunking/test_merge.py` → 13/13 pass
- [ ] `npm run lint` → no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)