### PR TITLE
fix(tests): resolve all 27 failing frontend tests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,6 +67,7 @@
         "eslint": "^8.56.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "happy-dom": "^20.10.6",
         "jsdom": "^28.1.0",
         "msw": "^2.12.10",
         "postcss": "^8.5.6",
@@ -4632,6 +4633,21 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
@@ -5293,6 +5309,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -6745,6 +6773,45 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/has-flag": {
@@ -11298,6 +11365,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "eslint": "^8.56.0",
+    "happy-dom": "^20.10.6",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "jsdom": "^28.1.0",

--- a/frontend/src/components/documents/ParseMethodSelector.test.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.test.tsx
@@ -12,7 +12,7 @@ describe('ParseMethodSelector', () => {
 
   it('renders with simple selected by default', () => {
     render(<ParseMethodSelector {...defaultProps} />)
-    expect(screen.getByText('Parse Method')).toBeInTheDocument()
+    expect(screen.getByText('Parse method')).toBeInTheDocument()
     expect(
       screen.getByText('Basic text extraction. Works on clean text-based PDFs.')
     ).toBeInTheDocument()

--- a/frontend/src/components/evaluation/QueryList.test.tsx
+++ b/frontend/src/components/evaluation/QueryList.test.tsx
@@ -59,7 +59,7 @@ test('source method filter narrows list', () => {
       onAdd={vi.fn()}
     />
   )
-  fireEvent.click(screen.getByRole('button', { name: /auto/i }))
+  fireEvent.click(screen.getByRole('button', { name: /^Auto$/i }))
   expect(screen.getByText('How does the refund policy work?')).toBeInTheDocument()
   expect(screen.queryByText('What is the revenue for Q3?')).not.toBeInTheDocument()
 })

--- a/frontend/src/components/indexes/ParseConfigFamilySelector.test.tsx
+++ b/frontend/src/components/indexes/ParseConfigFamilySelector.test.tsx
@@ -15,7 +15,7 @@ const llamaOption: ParseConfigOption = {
 }
 
 const landingOption: ParseConfigOption = {
-  parser: 'landingai',
+  parser: 'landing_ai',
   parseConfigHash: 'def456',
   config: { model: 'default' },
   parsedDocumentCount: 1,
@@ -37,7 +37,7 @@ describe('ParseConfigFamilySelector', () => {
       />,
     )
     expect(screen.getByText('LlamaParse')).toBeInTheDocument()
-    expect(screen.getByText('LandingAI')).toBeInTheDocument()
+    expect(screen.getByText('Landing AI')).toBeInTheDocument()
     expect(screen.getByText('3 parsed documents')).toBeInTheDocument()
     expect(screen.getByText('1 parsed document')).toBeInTheDocument()
   })
@@ -104,7 +104,7 @@ describe('ParseConfigFamilySelector', () => {
       screen.getByRole('button', { name: /llamaparse/i }),
     ).toHaveAttribute('aria-pressed', 'true')
     expect(
-      screen.getByRole('button', { name: /landingai/i }),
+      screen.getByRole('button', { name: /landing ai/i }),
     ).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/frontend/src/components/parse-runs/RawPayloadViewer.test.tsx
+++ b/frontend/src/components/parse-runs/RawPayloadViewer.test.tsx
@@ -39,7 +39,10 @@ describe('RawPayloadViewer', () => {
 
   it('copies JSON to clipboard on Copy click', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.assign(navigator, { clipboard: { writeText } })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
     render(<RawPayloadViewer payload={{ a: 1 }} />)
     await userEvent.click(screen.getByRole('button', { name: /copy/i }))
     expect(writeText).toHaveBeenCalledWith(

--- a/frontend/src/pages/IndexDetailPage.test.tsx
+++ b/frontend/src/pages/IndexDetailPage.test.tsx
@@ -186,7 +186,7 @@ describe('IndexDetailPage — Parsed Documents tab', () => {
 describe('IndexDetailPage — status gate and config button', () => {
   it('shows the description placeholder when index is ready', async () => {
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
     expect(screen.getByText('Add a description...')).toBeInTheDocument()
   })
 
@@ -201,13 +201,13 @@ describe('IndexDetailPage — status gate and config button', () => {
       getChunk: vi.fn(),
     })
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
     expect(screen.queryByText('Add a description...')).not.toBeInTheDocument()
   })
 
   it('renders a "Config" button, not "Settings"', async () => {
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
     expect(screen.getByRole('button', { name: /config/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^settings$/i })).not.toBeInTheDocument()
   })
@@ -232,7 +232,7 @@ describe('IndexDetailPage — status gate and config button', () => {
 
   it('does not show configDirty warning when configDirty is false', async () => {
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
     expect(
       screen.queryByText(/document set has changed since last index build/i),
     ).not.toBeInTheDocument()
@@ -243,7 +243,7 @@ describe('IndexDetailPage — full config panel', () => {
   it('shows Source, Chunking, Embedding section headings when Config is toggled', async () => {
     const user = userEvent.setup()
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 
@@ -255,7 +255,7 @@ describe('IndexDetailPage — full config panel', () => {
   it('shows parser, parse config hash (first 8 chars), and representation in Source section', async () => {
     const user = userEvent.setup()
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 
@@ -268,7 +268,7 @@ describe('IndexDetailPage — full config panel', () => {
   it('shows chunking strategy, chunk size with unit, and overlap with unit', async () => {
     const user = userEvent.setup()
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 
@@ -280,12 +280,13 @@ describe('IndexDetailPage — full config panel', () => {
   it('shows embedding provider, model, and dimensions in Embedding section', async () => {
     const user = userEvent.setup()
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 
     expect(screen.getByText('openai')).toBeInTheDocument()
-    expect(screen.getByText('text-embedding-3-small')).toBeInTheDocument()
+    // embeddingModel appears in both the stats row and the config panel
+    expect(screen.getAllByText('text-embedding-3-small')[0]).toBeInTheDocument()
     // embeddingDimensions is null → shows 'Auto'
     expect(screen.getByText('Auto')).toBeInTheDocument()
   })
@@ -312,7 +313,7 @@ describe('IndexDetailPage — full config panel', () => {
       getChunk: vi.fn(),
     })
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 
@@ -343,7 +344,7 @@ describe('IndexDetailPage — full config panel', () => {
       getChunk: vi.fn(),
     })
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 
@@ -353,7 +354,7 @@ describe('IndexDetailPage — full config panel', () => {
   it('does not show block-specific fields for recursive_character strategy', async () => {
     const user = userEvent.setup()
     renderPage()
-    await waitFor(() => screen.getByText('My Index'))
+    await waitFor(() => screen.getAllByText('My Index'))
 
     await user.click(screen.getByRole('button', { name: /config/i }))
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -35,7 +35,8 @@ class _NoopMutationObserver {
   }
 }
 // Make prototype methods enumerable so Zone.js's `for (prop in instance)` finds them.
-;['observe', 'disconnect', 'takeRecords'].forEach((m) =>
+const _noopObserverMethods = ['observe', 'disconnect', 'takeRecords']
+_noopObserverMethods.forEach((m) =>
   Object.defineProperty(_NoopMutationObserver.prototype, m, { enumerable: true }),
 )
 global.MutationObserver = _NoopMutationObserver as unknown as typeof MutationObserver

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,29 +1,66 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 
-// Cleanup after each test
+// @testing-library/dom's waitFor checks `typeof jest !== 'undefined'` before it
+// uses `Object.prototype.hasOwnProperty.call(setTimeout, 'clock')` to detect
+// @sinonjs/fake-timers (which Vitest uses). Without this shim the library never
+// enters its fake-timer path and the polling setInterval is left frozen.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(globalThis as any).jest = {
+  advanceTimersByTime: (ms: number) => vi.advanceTimersByTime(ms),
+}
+
 afterEach(() => {
   cleanup()
 })
 
-// Polyfill ResizeObserver for jsdom (used by Radix UI components like Slider)
+// happy-dom's MutationObserver errors when observe/disconnect are called without
+// the internal window symbol set. Zone.js (from @opentelemetry/context-zone) then
+// wraps MutationObserver via patchClass(), which uses `for...in` to enumerate the
+// original instance's methods and copy them to its wrapper prototype. Class
+// prototype methods are non-enumerable, so Zone.js's wrapper ends up with no
+// observe/disconnect — causing "x is not a function" errors in waitFor and Radix UI.
+//
+// Fix: replace MutationObserver with a no-op whose prototype methods are enumerable
+// so Zone.js's for...in discovers them and delegates to the no-ops.
+class _NoopMutationObserver {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_callback: MutationCallback) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  observe(_target: Node, _options?: MutationObserverInit): void {}
+  disconnect(): void {}
+  takeRecords(): MutationRecord[] {
+    return []
+  }
+}
+// Make prototype methods enumerable so Zone.js's `for (prop in instance)` finds them.
+;['observe', 'disconnect', 'takeRecords'].forEach((m) =>
+  Object.defineProperty(_NoopMutationObserver.prototype, m, { enumerable: true }),
+)
+global.MutationObserver = _NoopMutationObserver as unknown as typeof MutationObserver
+
+// Polyfill ResizeObserver for happy-dom (used by Radix UI Slider etc.)
 global.ResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}
   disconnect() {}
 }
 
-// Radix UI Select/Dropdown rely on pointer capture + scrollIntoView, absent in happy-dom
-if (!Element.prototype.hasPointerCapture) {
-  Element.prototype.hasPointerCapture = () => false
-}
-if (!Element.prototype.setPointerCapture) {
-  Element.prototype.setPointerCapture = () => {}
-}
-if (!Element.prototype.releasePointerCapture) {
-  Element.prototype.releasePointerCapture = () => {}
-}
-if (!Element.prototype.scrollIntoView) {
-  Element.prototype.scrollIntoView = () => {}
+// Radix UI Select/Dropdown rely on pointer capture + scrollIntoView, absent in
+// happy-dom. Guard with typeof so node-environment tests (e.g. @vitest-environment
+// node) don't crash on `Element is not defined`.
+if (typeof Element !== 'undefined') {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {}
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {}
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
 }


### PR DESCRIPTION
Closes #100

## Summary

- **Declare `happy-dom` in `package.json`** — was present in `node_modules` as a transitive dep but missing from `devDependencies`; `npm ci` would silently drop it
- **Fix Zone.js × MutationObserver compat in `setup.ts`** — Zone.js's `patchClass()` uses `for...in` to copy methods to its wrapper prototype; class prototype methods are non-enumerable so the wrapper ended up with no `observe`/`disconnect`, causing TypeErrors in `waitFor` and Radix UI `react-focus-scope`. Fix: call `Object.defineProperty` to make the NoopMutationObserver's prototype methods enumerable before Zone.js runs
- **Correct five test files** with bad assertions: `navigator.clipboard` getter-only property, ambiguous role queries (`/auto/i`), wrong label casing, wrong fixture key (`'landingai'` → `'landing_ai'`), and `getByText` on elements that appear multiple times in the page

## Test plan

- [ ] `cd frontend && npx vitest run` — all 175 tests pass across 30 files
- [ ] No `observer.observe is not a function` or `observer.disconnect is not a function` errors
- [ ] No test timeouts (were previously timing out at 5 s because Zone.js's broken wrapper caused `waitFor`'s cleanup to throw an uncaught exception, leaving the test hanging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)