### PR TITLE
feat(extraction): proactive TPM rate limiter for PipelineExtractor

### DIFF
--- a/backend/app/adapters/extraction/pipeline.py
+++ b/backend/app/adapters/extraction/pipeline.py
@@ -90,6 +90,12 @@ async def run_with_retry(
             await asyncio.sleep(delay)
 
 
+def _extract_total_tokens(output: ExtractionOutput) -> int:
+    meta = output.extraction_metadata or {}
+    usage = meta.get("usage") or {}
+    return int(usage.get("total_tokens") or 0)
+
+
 class PipelineExtractor(DataExtractor):
     """Wraps an inner DataExtractor with preprocess, chunking, and merge."""
 
@@ -102,12 +108,16 @@ class PipelineExtractor(DataExtractor):
         chunking: dict | None = None,
         max_concurrency: int = 3,
         max_retries: int = 3,
+        max_tokens_per_minute: int | None = None,
     ) -> None:
         self._inner = inner
         self._preprocess = preprocess or []
         self._chunking = chunking or {}
         self._max_concurrency = max_concurrency
         self._max_retries = max_retries
+        self._throttle: TpmThrottle | None = (
+            TpmThrottle(max_tokens_per_minute) if max_tokens_per_minute else None
+        )
 
     async def extract(
         self,
@@ -142,11 +152,20 @@ class PipelineExtractor(DataExtractor):
         sem = asyncio.Semaphore(self._max_concurrency)
 
         async def _run_chunk(chunk) -> ExtractionOutput:
+            reservation = None
+            estimated = 0
+            if self._throttle is not None:
+                estimated = self._throttle.rolling_estimate
+                reservation = await self._throttle.throttle(estimated)
             async with sem:
-                return await run_with_retry(
+                result = await run_with_retry(
                     lambda: self._inner.extract(chunk.document, schema, cfg),
                     self._max_retries,
                 )
+            if self._throttle is not None and reservation is not None:
+                actual = _extract_total_tokens(result)
+                self._throttle.replace_reservation(reservation, actual or estimated)
+            return result
 
         # asyncio.gather raises the first ExtractionError -> whole result fails.
         results = await asyncio.gather(*[_run_chunk(c) for c in chunks])

--- a/backend/app/adapters/extraction/pipeline.py
+++ b/backend/app/adapters/extraction/pipeline.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from collections import deque
 from typing import Any, Awaitable, Callable
 
 from app.adapters.extraction.chunking.citation_policy import resolve_level
@@ -11,6 +13,64 @@ from app.adapters.extraction.chunking.token_budget import estimate_tokens
 from app.adapters.extraction.preprocess.base import apply_preprocess
 from app.ports.data_extraction import DataExtractor, ExtractionOutput
 from app.services.llm.types import LLMRateLimitError
+
+
+class _Reservation:
+    """Mutable entry in the TPM sliding window."""
+    __slots__ = ('ts', 'tokens')
+
+    def __init__(self, ts: float, tokens: int) -> None:
+        self.ts = ts
+        self.tokens = tokens
+
+
+class TpmThrottle:
+    """Sliding-window tokens-per-minute rate limiter for async chunk dispatch.
+
+    Call `await throttle(estimated)` before dispatching a chunk to reserve
+    capacity. Call `replace_reservation(r, actual)` once the chunk completes
+    to swap the estimate for real usage and keep the rolling average calibrated.
+    """
+
+    def __init__(self, max_tpm: int, default_estimate: int = 8_000) -> None:
+        self._max = max_tpm
+        self._default = default_estimate
+        self._log: deque[_Reservation] = deque()
+        self._lock = asyncio.Lock()
+        self._actuals: list[int] = []
+
+    @property
+    def rolling_estimate(self) -> int:
+        if not self._actuals:
+            return self._default
+        return int(sum(self._actuals) / len(self._actuals))
+
+    def _evict(self, now: float) -> None:
+        while self._log and now - self._log[0].ts >= 60.0:
+            self._log.popleft()
+
+    def _used(self) -> int:
+        return sum(r.tokens for r in self._log)
+
+    async def throttle(self, estimated_tokens: int) -> _Reservation:
+        """Block until capacity exists, then reserve estimated_tokens."""
+        while True:
+            async with self._lock:
+                now = time.monotonic()
+                self._evict(now)
+                if not self._log or self._used() + estimated_tokens <= self._max:
+                    r = _Reservation(now, estimated_tokens)
+                    self._log.append(r)
+                    return r
+                wait = max(0.1, 60.0 - (now - self._log[0].ts))
+            await asyncio.sleep(wait)
+
+    def replace_reservation(self, reservation: _Reservation, actual_tokens: int) -> None:
+        """Swap estimate for actual usage; update rolling average (capped at 10)."""
+        reservation.tokens = actual_tokens
+        self._actuals.append(actual_tokens)
+        if len(self._actuals) > 10:
+            self._actuals.pop(0)
 
 
 async def run_with_retry(

--- a/backend/app/routers/extraction.py
+++ b/backend/app/routers/extraction.py
@@ -49,7 +49,13 @@ def _maybe_wrap_pipeline(
     """Wrap inner extractor in a PipelineExtractor when pipeline config is present."""
     if not preprocess and not chunking:
         return inner
-    return PipelineExtractor(inner=inner, preprocess=preprocess, chunking=chunking)
+    max_tpm = (chunking or {}).get("maxTokensPerMinute")
+    return PipelineExtractor(
+        inner=inner,
+        preprocess=preprocess,
+        chunking=chunking,
+        max_tokens_per_minute=int(max_tpm) if max_tpm is not None else None,
+    )
 
 
 def get_extraction_service(

--- a/backend/tests/adapters/extraction/test_pipeline.py
+++ b/backend/tests/adapters/extraction/test_pipeline.py
@@ -115,3 +115,47 @@ async def test_rate_limit_exhausts_retries_and_raises():
     px = PipelineExtractor(inner=inner, preprocess=None, chunking=None, max_retries=1)
     with pytest.raises(LLMRateLimitError):
         await px.extract(_doc(1), _SCHEMA)
+
+
+import asyncio as _asyncio
+from app.adapters.extraction.pipeline import TpmThrottle
+
+
+async def test_tpm_throttle_allows_within_budget():
+    throttle = TpmThrottle(max_tpm=10_000)
+    r = await throttle.throttle(5_000)
+    assert r.tokens == 5_000
+
+
+async def test_tpm_throttle_blocks_when_budget_full():
+    """Second throttle call must block when the window is saturated."""
+    throttle = TpmThrottle(max_tpm=5_000)
+    await throttle.throttle(5_000)  # saturate window
+    with pytest.raises(_asyncio.TimeoutError):
+        await _asyncio.wait_for(throttle.throttle(1_000), timeout=0.05)
+
+
+async def test_tpm_throttle_oversized_chunk_fires_when_window_empty():
+    """A single chunk larger than max_tpm still fires (window is empty)."""
+    throttle = TpmThrottle(max_tpm=1_000)
+    r = await throttle.throttle(5_000)
+    assert r.tokens == 5_000
+
+
+async def test_tpm_throttle_replace_reservation_mutates_tokens():
+    throttle = TpmThrottle(max_tpm=10_000)
+    r = await throttle.throttle(5_000)
+    throttle.replace_reservation(r, 3_200)
+    assert r.tokens == 3_200
+
+
+async def test_tpm_throttle_rolling_estimate_starts_at_default():
+    throttle = TpmThrottle(max_tpm=30_000, default_estimate=8_000)
+    assert throttle.rolling_estimate == 8_000
+
+
+async def test_tpm_throttle_rolling_estimate_adapts_after_replacement():
+    throttle = TpmThrottle(max_tpm=30_000, default_estimate=8_000)
+    r = await throttle.throttle(8_000)
+    throttle.replace_reservation(r, 5_000)
+    assert throttle.rolling_estimate == 5_000

--- a/backend/tests/adapters/extraction/test_pipeline.py
+++ b/backend/tests/adapters/extraction/test_pipeline.py
@@ -159,3 +159,17 @@ async def test_tpm_throttle_rolling_estimate_adapts_after_replacement():
     r = await throttle.throttle(8_000)
     throttle.replace_reservation(r, 5_000)
     assert throttle.rolling_estimate == 5_000
+
+
+async def test_pipeline_with_tpm_throttle_processes_all_chunks():
+    """TPM throttle enabled with a high budget must not affect output correctness."""
+    inner = _FakeInner()
+    px = PipelineExtractor(
+        inner=inner,
+        preprocess=None,
+        chunking={"strategy": "token_budget_pages", "config": {"maxInputTokens": 150}},
+        max_tokens_per_minute=100_000,
+    )
+    out = await px.extract(_doc(3), _SCHEMA)
+    assert len(inner.calls) == 3
+    assert {p["sku"] for p in out.structured_data["products"]} == {"p0", "p1", "p2"}

--- a/frontend/src/components/extraction/ExtractionForm.tsx
+++ b/frontend/src/components/extraction/ExtractionForm.tsx
@@ -67,6 +67,7 @@ export function ExtractionForm({
   const [maxInputTokens, setMaxInputTokens] = useState('8000')
   const [pageOverlap, setPageOverlap] = useState('0')
   const [dedupeKey, setDedupeKey] = useState('')
+  const [maxTokensPerMinute, setMaxTokensPerMinute] = useState('')
   const [citationLevel, setCitationLevel] =
     useState<'auto' | 'full' | 'page_only' | 'off'>('auto')
 
@@ -148,7 +149,13 @@ export function ExtractionForm({
         const overlap = parseInt(pageOverlap, 10)
         if (!Number.isNaN(overlap) && overlap > 0) cfg.pageOverlap = overlap
         if (dedupeKey.trim()) cfg.dedupeKey = dedupeKey.trim()
-        chunking = { strategy: chunkStrategy, config: cfg, citationLevel }
+        const tpm = parseInt(maxTokensPerMinute, 10)
+        chunking = {
+          strategy: chunkStrategy,
+          config: cfg,
+          citationLevel,
+          ...(!Number.isNaN(tpm) && tpm > 0 ? { maxTokensPerMinute: tpm } : {}),
+        }
       } else if (citationLevel !== 'auto') {
         chunking = { strategy: 'none', citationLevel }
       }
@@ -364,20 +371,32 @@ export function ExtractionForm({
                 </div>
               </div>
               {chunkStrategy === 'token_budget_pages' && (
-                <div className="grid grid-cols-3 gap-3">
-                  <div className="space-y-1.5">
-                    <Label className="text-xs">Max input tokens</Label>
-                    <Input type="number" value={maxInputTokens} onChange={(e) => setMaxInputTokens(e.target.value)} className="h-9" />
+                <>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">Max input tokens</Label>
+                      <Input type="number" value={maxInputTokens} onChange={(e) => setMaxInputTokens(e.target.value)} className="h-9" />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">Page overlap</Label>
+                      <Input type="number" value={pageOverlap} onChange={(e) => setPageOverlap(e.target.value)} className="h-9" />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">Dedupe key</Label>
+                      <Input value={dedupeKey} onChange={(e) => setDedupeKey(e.target.value)} placeholder="e.g. sku" className="h-9" />
+                    </div>
                   </div>
                   <div className="space-y-1.5">
-                    <Label className="text-xs">Page overlap</Label>
-                    <Input type="number" value={pageOverlap} onChange={(e) => setPageOverlap(e.target.value)} className="h-9" />
+                    <Label className="text-xs">Rate limit (TPM)</Label>
+                    <Input
+                      type="number"
+                      value={maxTokensPerMinute}
+                      onChange={(e) => setMaxTokensPerMinute(e.target.value)}
+                      placeholder="e.g. 30000 for OpenAI tier 1"
+                      className="h-9"
+                    />
                   </div>
-                  <div className="space-y-1.5">
-                    <Label className="text-xs">Dedupe key</Label>
-                    <Input value={dedupeKey} onChange={(e) => setDedupeKey(e.target.value)} placeholder="e.g. sku" className="h-9" />
-                  </div>
-                </div>
+                </>
               )}
               <p className="text-[11px] text-muted-foreground">
                 {citationLevel === 'off'

--- a/frontend/src/types/extraction.ts
+++ b/frontend/src/types/extraction.ts
@@ -62,6 +62,7 @@ export interface ChunkingConfig {
   strategy: string
   config?: Record<string, unknown>
   citationLevel?: 'auto' | 'full' | 'page_only' | 'off'
+  maxTokensPerMinute?: number
 }
 
 export interface PreprocessStage {


### PR DESCRIPTION
Closes #108

## Summary

- Adds `TpmThrottle` — a sliding 60-second window rate limiter that pre-reserves token capacity before each chunk fires, then replaces the estimate with actual usage once the chunk completes
- `PipelineExtractor` gains a `max_tokens_per_minute` param; `None` preserves existing behaviour exactly
- The router extracts `maxTokensPerMinute` from the `chunking` dict and passes it through
- Frontend `ChunkingConfig` type gains `maxTokensPerMinute?: number`; the extraction form shows a **Rate limit (TPM)** input inside the "Large document handling" collapsible when chunking strategy is `token_budget_pages`

## Design notes

- Rolling adaptive estimate: the throttle starts with a default of 8,000 tokens/chunk and calibrates to the rolling average of the last 10 actual totals, so it gets more accurate after the first few chunks
- Oversized-chunk safety: a single chunk larger than `max_tpm` fires immediately once the window is empty rather than blocking forever
- Async-safe: a `Lock` ensures the check-then-reserve sequence is atomic so concurrent goroutines don't race past the budget
- The single-chunk fast-path bypasses the throttle entirely (no overhead for small documents)
- Existing `LLMRateLimitError` retry backoff still fires as a reactive safety net if the throttle under-estimates

## Test plan

- [ ] Run `uv run --directory backend python -m pytest tests/adapters/extraction/test_pipeline.py -v` — 14 tests pass
- [ ] Open the extraction form on a document, select LLM method, expand "Large document handling", set chunking to "Token-budgeted pages" — verify "Rate limit (TPM)" input appears
- [ ] Run an extraction with `maxTokensPerMinute` set on a multi-page document against an OpenAI provider — confirm no 429 burst at start

🤖 Generated with [Claude Code](https://claude.com/claude-code)