### PR TITLE
feat(extraction): configurable per-job timeout

### DIFF
--- a/backend/alembic/versions/e1f2a3b4c5d6_add_timeout_minutes_to_extraction_results.py
+++ b/backend/alembic/versions/e1f2a3b4c5d6_add_timeout_minutes_to_extraction_results.py
@@ -1,0 +1,27 @@
+"""add_timeout_minutes_to_extraction_results
+
+Revision ID: e1f2a3b4c5d6
+Revises: aed9d6c56057
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "aed9d6c56057"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "extraction_results",
+        sa.Column("timeout_minutes", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("extraction_results", "timeout_minutes")

--- a/backend/app/models/extraction_result.py
+++ b/backend/app/models/extraction_result.py
@@ -53,6 +53,9 @@ class ExtractionResult(Base):
     started_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    timeout_minutes: Mapped[int | None] = mapped_column(
+        sa.Integer(), nullable=True
+    )
     citations: Mapped[list | None] = mapped_column(JSON, nullable=True)
     provider_response_raw: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     source_parse_run_id: Mapped[UUID | None] = mapped_column(

--- a/backend/app/repositories/extraction_result_repository.py
+++ b/backend/app/repositories/extraction_result_repository.py
@@ -23,6 +23,7 @@ class ExtractionResultRepository:
         created_by: UUID,
         config: dict | None = None,
         source_parse_run_id: UUID | None = None,
+        timeout_minutes: int | None = None,
     ) -> ExtractionResult:
         """Create a new pending extraction result."""
         result = ExtractionResult(
@@ -33,6 +34,7 @@ class ExtractionResultRepository:
             config=config,
             created_by=created_by,
             source_parse_run_id=source_parse_run_id,
+            timeout_minutes=timeout_minutes,
             status=ExtractionResultStatus.pending,
         )
         self.session.add(result)

--- a/backend/app/routers/extraction.py
+++ b/backend/app/routers/extraction.py
@@ -224,6 +224,7 @@ async def run_extraction(
             config=body.config,
             llm_config=body.llm_config,
             user_prompt_template=body.user_prompt_template,
+            timeout_minutes=body.timeout_minutes,
         )
 
         background_tasks.add_task(

--- a/backend/app/schemas/extraction_result.py
+++ b/backend/app/schemas/extraction_result.py
@@ -71,6 +71,7 @@ class RunExtractionRequest(BaseModel):
     user_prompt_template: str | None = Field(None, alias="userPromptTemplate")
     preprocess: list[dict] | None = None
     chunking: dict | None = None
+    timeout_minutes: int | None = Field(default=None, ge=1, le=120)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -91,6 +92,7 @@ class ExtractionResultResponse(BaseModel):
     status_message: str | None = Field(None, alias="statusMessage")
     started_at: datetime | None = Field(None, alias="startedAt")
     source_parse_run_id: UUID | None = Field(None, alias="sourceParseRunId")
+    timeout_minutes: int | None = Field(None, alias="timeoutMinutes")
     created_by: UUID = Field(..., alias="createdBy")
     created_at: datetime = Field(..., alias="createdAt")
     updated_at: datetime = Field(..., alias="updatedAt")
@@ -114,6 +116,7 @@ class ExtractionResultResponse(BaseModel):
             statusMessage=obj.status_message,
             startedAt=obj.started_at,
             sourceParseRunId=obj.source_parse_run_id,
+            timeoutMinutes=obj.timeout_minutes,
             createdBy=obj.created_by,
             createdAt=obj.created_at,
             updatedAt=obj.updated_at,
@@ -128,6 +131,7 @@ class ExtractionResultListResponse(BaseModel):
     extraction_method: str = Field(..., alias="extractionMethod")
     status: ExtractionResultStatus
     status_message: str | None = Field(None, alias="statusMessage")
+    timeout_minutes: int | None = Field(None, alias="timeoutMinutes")
     created_at: datetime = Field(..., alias="createdAt")
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
@@ -141,6 +145,7 @@ class ExtractionResultListResponse(BaseModel):
             extractionMethod=obj.extraction_method,
             status=obj.status,
             statusMessage=obj.status_message,
+            timeoutMinutes=obj.timeout_minutes,
             createdAt=obj.created_at,
         )
 

--- a/backend/app/services/extraction_service.py
+++ b/backend/app/services/extraction_service.py
@@ -22,7 +22,6 @@ from app.services.exceptions import NotFoundError, ConflictError
 
 logger = logging.getLogger(__name__)
 
-STALE_TIMEOUT = timedelta(minutes=10)
 
 
 class ExtractionService:
@@ -106,6 +105,7 @@ class ExtractionService:
         config: dict | None = None,
         llm_config=None,           # PromptConfig | None
         user_prompt_template: str | None = None,
+        timeout_minutes: int | None = None,
     ) -> ExtractionResultResponse:
         """Create a pending extraction result anchored to a CDM ParsedDocument."""
         orm_parsed_doc = await self.parsed_document_repo.get_by_run(parse_run_id)
@@ -141,6 +141,7 @@ class ExtractionService:
             extraction_method=extraction_method,
             created_by=user_id,
             config=merged_config,
+            timeout_minutes=timeout_minutes,
         )
         return ExtractionResultResponse.from_orm_model(result)
 
@@ -153,10 +154,11 @@ class ExtractionService:
         if not reference_time:
             return result
         age = datetime.utcnow() - reference_time.replace(tzinfo=None)
-        if age > STALE_TIMEOUT:
+        effective_timeout = result.timeout_minutes or 10
+        if age > timedelta(minutes=effective_timeout):
             result = await self.result_repo.update_status(
                 result.id, ExtractionResultStatus.failed,
-                "Extraction job timed out (exceeded 10 minutes)",
+                f"Extraction job timed out (exceeded {effective_timeout} minutes)",
             )
         return result
 

--- a/backend/tests/schemas/test_extraction_result_schemas.py
+++ b/backend/tests/schemas/test_extraction_result_schemas.py
@@ -78,6 +78,83 @@ class TestExtractionResultResponse:
         assert resp.provider_response_raw is None
 
 
+class TestRunExtractionRequestTimeout:
+    def test_accepts_valid_timeout(self):
+        req = RunExtractionRequest.model_validate({
+            "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "extractionMethod": "llm",
+            "timeout_minutes": 30,
+        })
+        assert req.timeout_minutes == 30
+
+    def test_rejects_zero(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            RunExtractionRequest.model_validate({
+                "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "extractionMethod": "llm",
+                "timeout_minutes": 0,
+            })
+
+    def test_rejects_121(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            RunExtractionRequest.model_validate({
+                "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "extractionMethod": "llm",
+                "timeout_minutes": 121,
+            })
+
+    def test_omitted_timeout_is_none(self):
+        req = RunExtractionRequest.model_validate({
+            "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "extractionMethod": "llm",
+        })
+        assert req.timeout_minutes is None
+
+
+class TestExtractionResultResponseTimeout:
+    def _make_mock_orm(self, **kwargs):
+        from unittest.mock import MagicMock
+        from uuid import uuid4
+        from datetime import datetime, timezone
+        from app.models.extraction_result import ExtractionResultStatus
+        obj = MagicMock()
+        obj.id = uuid4()
+        obj.document_id = uuid4()
+        obj.source_parse_run_id = None
+        obj.extraction_schema_id = uuid4()
+        obj.schema_definition_snapshot = {}
+        obj.extraction_method = "llm"
+        obj.config = None
+        obj.structured_data = None
+        obj.citations = None
+        obj.provider_response_raw = None
+        obj.extraction_metadata = None
+        obj.status = ExtractionResultStatus.pending
+        obj.status_message = None
+        obj.started_at = None
+        obj.created_by = uuid4()
+        obj.created_at = datetime.now(timezone.utc)
+        obj.updated_at = datetime.now(timezone.utc)
+        obj.timeout_minutes = kwargs.get("timeout_minutes", None)
+        return obj
+
+    def test_timeout_minutes_serialised(self):
+        obj = self._make_mock_orm(timeout_minutes=45)
+        resp = ExtractionResultResponse.from_orm_model(obj)
+        assert resp.timeout_minutes == 45
+
+    def test_null_timeout_serialised(self):
+        obj = self._make_mock_orm(timeout_minutes=None)
+        resp = ExtractionResultResponse.from_orm_model(obj)
+        assert resp.timeout_minutes is None
+
+
 class TestRunExtractionRequestLLMFields:
     def test_accepts_llm_config_camelcase(self):
         from app.schemas.extraction_result import RunExtractionRequest

--- a/backend/tests/services/test_extraction_service.py
+++ b/backend/tests/services/test_extraction_service.py
@@ -1,7 +1,7 @@
 """Tests for ExtractionService CDM-based flow."""
 import dataclasses
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4, UUID
 
@@ -429,6 +429,48 @@ class TestRunExtractionConfigMerge:
             merged_config["user_prompt_template"] = user_prompt_template
         assert "llm_config" not in merged_config
         assert "user_prompt_template" not in merged_config
+
+
+class TestReapStale:
+    """_reap_stale uses per-job timeout_minutes, falling back to 10."""
+
+    def _make_result(self, *, minutes_old: int, timeout_minutes: int | None):
+        result = MagicMock()
+        result.status = ExtractionResultStatus.pending
+        result.timeout_minutes = timeout_minutes
+        result.started_at = None
+        result.created_at = datetime.utcnow() - timedelta(minutes=minutes_old)
+        return result
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("timeout_minutes,minutes_old,expect_reaped", [
+        (None, 11, True),   # NULL → default 10 min; 11 min old → reaped
+        (None, 9, False),   # NULL → default 10 min; 9 min old → not reaped
+        (5, 6, True),       # explicit 5 min; 6 min old → reaped
+        (5, 4, False),      # explicit 5 min; 4 min old → not reaped
+        (60, 45, False),    # explicit 60 min; 45 min old → not reaped
+        (60, 61, True),     # explicit 60 min; 61 min old → reaped
+    ])
+    async def test_reap_stale_uses_per_job_timeout(
+        self, timeout_minutes, minutes_old, expect_reaped
+    ):
+        result = self._make_result(
+            minutes_old=minutes_old, timeout_minutes=timeout_minutes
+        )
+        mock_result_repo = AsyncMock()
+        mock_result_repo.update_status.return_value = result
+
+        service = _make_service(result_repo=mock_result_repo)
+        await service._reap_stale(result)
+
+        if expect_reaped:
+            mock_result_repo.update_status.assert_called_once()
+            args = mock_result_repo.update_status.call_args
+            assert ExtractionResultStatus.failed == args[0][1]
+            expected_n = timeout_minutes or 10
+            assert f"exceeded {expected_n} minutes" in args[0][2]
+        else:
+            mock_result_repo.update_status.assert_not_called()
 
 
 class TestDeleteResult:

--- a/docs/superpowers/plans/2026-06-24-extraction-timeout.md
+++ b/docs/superpowers/plans/2026-06-24-extraction-timeout.md
@@ -1,0 +1,828 @@
+# Configurable Extraction Timeout — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users set a per-job timeout (1–120 minutes, default 10) on extraction runs so large documents no longer fail prematurely.
+
+**Architecture:** A nullable `timeout_minutes` column on `extraction_results` carries the per-job value. The backend stale-reaper reads it (falling back to 10 min). The frontend form sends it as a top-level field on the run request; the hook uses it to set its own polling deadline.
+
+**Tech Stack:** Python 3.12 / FastAPI / SQLAlchemy 2.0 / Alembic (backend); React 18 / TypeScript / Vitest (frontend).
+
+## Global Constraints
+
+- `timeout_minutes` is a top-level field on `RunExtractionRequest` — not nested in `ChunkingConfig`
+- Valid range: 1–120 (inclusive). Pydantic enforces `ge=1, le=120`; `NULL` / omitted means "use default 10"
+- Frontend fallback default must match backend default: **10 minutes** (fixing the previous 5-min frontend mismatch)
+- All backend tests: `uv run python -m pytest -o "addopts=" <path> -v`
+- All frontend tests: `npx vitest run <path>`
+- Run commands from repo root using `--directory` / `-C` flags, never `cd`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `backend/alembic/versions/<rev>_add_timeout_minutes_to_extraction_results.py` | **Create** — migration adding nullable `timeout_minutes` column |
+| `backend/app/models/extraction_result.py` | **Modify** — add `timeout_minutes: Mapped[int \| None]` |
+| `backend/app/schemas/extraction_result.py` | **Modify** — add field to `RunExtractionRequest`; add field to `ExtractionResultResponse` + `from_orm_model` |
+| `backend/app/repositories/extraction_result_repository.py` | **Modify** — add `timeout_minutes` param to `create()` |
+| `backend/app/services/extraction_service.py` | **Modify** — thread `timeout_minutes` through `run_extraction()`; replace `STALE_TIMEOUT` in `_reap_stale()` |
+| `backend/app/routers/extraction.py` | **Modify** — pass `body.timeout_minutes` to `service.run_extraction()` |
+| `backend/tests/schemas/test_extraction_result_schemas.py` | **Modify** — add schema validation tests |
+| `backend/tests/services/test_extraction_service.py` | **Modify** — add `_reap_stale` and `run_extraction` tests |
+| `frontend/src/types/extraction.ts` | **Modify** — add `timeoutMinutes` to `RunExtractionRequest`, `RunWithParseRequest.extractionConfig`, `ExtractionResult` |
+| `frontend/src/components/extraction/ExtractionForm.tsx` | **Modify** — add form state + input field |
+| `frontend/src/hooks/useExtractionResults.ts` | **Modify** — replace hard-coded polling timeout with per-job value |
+| `frontend/src/hooks/useExtractionResults.test.ts` | **Modify** — add polling-timeout tests |
+
+---
+
+## Task 1: DB Migration + ORM Model
+
+**Files:**
+- Create: `backend/alembic/versions/<rev>_add_timeout_minutes_to_extraction_results.py`
+- Modify: `backend/app/models/extraction_result.py`
+
+**Interfaces:**
+- Produces: `ExtractionResult.timeout_minutes: int | None` ORM attribute used by Tasks 2–3
+
+- [ ] **Step 1: Generate the migration file**
+
+```bash
+uv run --directory backend alembic revision --autogenerate -m "add_timeout_minutes_to_extraction_results"
+```
+
+Alembic will create a file under `backend/alembic/versions/`. Open it and replace its `upgrade`/`downgrade` with the following (autogenerate may produce nothing if it doesn't detect the model change yet — that's fine, replace manually):
+
+```python
+import sqlalchemy as sa
+from alembic import op
+
+def upgrade() -> None:
+    op.add_column(
+        "extraction_results",
+        sa.Column("timeout_minutes", sa.Integer(), nullable=True),
+    )
+
+def downgrade() -> None:
+    op.drop_column("extraction_results", "timeout_minutes")
+```
+
+- [ ] **Step 2: Add the column to the ORM model**
+
+In `backend/app/models/extraction_result.py`, add after the `started_at` column (line 55):
+
+```python
+timeout_minutes: Mapped[int | None] = mapped_column(
+    sa.Integer(), nullable=True
+)
+```
+
+- [ ] **Step 3: Run the migration**
+
+```bash
+uv run --directory backend alembic upgrade head
+```
+
+Expected: `Running upgrade <prev> -> <rev>, add_timeout_minutes_to_extraction_results`
+
+- [ ] **Step 4: Smoke-test the column exists**
+
+```bash
+uv run --directory backend python -c "
+from app.models.extraction_result import ExtractionResult
+import sqlalchemy as sa
+cols = {c.name: c for c in ExtractionResult.__table__.columns}
+assert 'timeout_minutes' in cols, 'column missing'
+assert cols['timeout_minutes'].nullable, 'must be nullable'
+print('OK')
+"
+```
+
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/alembic/versions/ backend/app/models/extraction_result.py
+git commit -m "feat(extraction): add timeout_minutes column to extraction_results"
+```
+
+---
+
+## Task 2: Backend Schema + Repository + Service
+
+**Files:**
+- Modify: `backend/app/schemas/extraction_result.py`
+- Modify: `backend/app/repositories/extraction_result_repository.py`
+- Modify: `backend/app/services/extraction_service.py`
+- Modify: `backend/tests/schemas/test_extraction_result_schemas.py`
+- Modify: `backend/tests/services/test_extraction_service.py`
+
+**Interfaces:**
+- Consumes: `ExtractionResult.timeout_minutes` (Task 1)
+- Produces:
+  - `RunExtractionRequest.timeout_minutes: int | None` — Pydantic field with `ge=1, le=120`
+  - `ExtractionResultResponse.timeout_minutes: int | None` — included in `from_orm_model()`
+  - `ExtractionResultRepository.create(..., timeout_minutes: int | None = None)`
+  - `ExtractionService.run_extraction(..., timeout_minutes: int | None = None)`
+
+- [ ] **Step 1: Write the failing schema tests**
+
+Append to `backend/tests/schemas/test_extraction_result_schemas.py`:
+
+```python
+class TestRunExtractionRequestTimeout:
+    def test_accepts_valid_timeout(self):
+        req = RunExtractionRequest.model_validate({
+            "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "extractionMethod": "llm",
+            "timeout_minutes": 30,
+        })
+        assert req.timeout_minutes == 30
+
+    def test_rejects_zero(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            RunExtractionRequest.model_validate({
+                "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "extractionMethod": "llm",
+                "timeout_minutes": 0,
+            })
+
+    def test_rejects_121(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            RunExtractionRequest.model_validate({
+                "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+                "extractionMethod": "llm",
+                "timeout_minutes": 121,
+            })
+
+    def test_omitted_timeout_is_none(self):
+        req = RunExtractionRequest.model_validate({
+            "parseRunId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "extractionSchemaId": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "extractionMethod": "llm",
+        })
+        assert req.timeout_minutes is None
+
+
+class TestExtractionResultResponseTimeout:
+    def _make_mock_orm(self, **kwargs):
+        from unittest.mock import MagicMock
+        from uuid import uuid4
+        from datetime import datetime, timezone
+        from app.models.extraction_result import ExtractionResultStatus
+        obj = MagicMock()
+        obj.id = uuid4()
+        obj.document_id = uuid4()
+        obj.source_parse_run_id = None
+        obj.extraction_schema_id = uuid4()
+        obj.schema_definition_snapshot = {}
+        obj.extraction_method = "llm"
+        obj.config = None
+        obj.structured_data = None
+        obj.citations = None
+        obj.provider_response_raw = None
+        obj.extraction_metadata = None
+        obj.status = ExtractionResultStatus.pending
+        obj.status_message = None
+        obj.started_at = None
+        obj.created_by = uuid4()
+        obj.created_at = datetime.now(timezone.utc)
+        obj.updated_at = datetime.now(timezone.utc)
+        obj.timeout_minutes = kwargs.get("timeout_minutes", None)
+        return obj
+
+    def test_timeout_minutes_serialised(self):
+        obj = self._make_mock_orm(timeout_minutes=45)
+        resp = ExtractionResultResponse.from_orm_model(obj)
+        assert resp.timeout_minutes == 45
+
+    def test_null_timeout_serialised(self):
+        obj = self._make_mock_orm(timeout_minutes=None)
+        resp = ExtractionResultResponse.from_orm_model(obj)
+        assert resp.timeout_minutes is None
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run --directory backend python -m pytest -o "addopts=" tests/schemas/test_extraction_result_schemas.py -v
+```
+
+Expected: `FAILED` on the new tests (`timeout_minutes` field not found).
+
+- [ ] **Step 3: Add `timeout_minutes` to `RunExtractionRequest`**
+
+In `backend/app/schemas/extraction_result.py`, update `RunExtractionRequest`:
+
+```python
+class RunExtractionRequest(BaseModel):
+    """Request to run an extraction against a CDM ParsedDocument."""
+    parse_run_id: UUID = Field(..., alias="parseRunId")
+    extraction_schema_id: UUID = Field(..., alias="extractionSchemaId")
+    extraction_method: str = Field(..., alias="extractionMethod")
+    config: dict | None = None
+    llm_config: PromptConfig | None = Field(None, alias="llmConfig")
+    user_prompt_template: str | None = Field(None, alias="userPromptTemplate")
+    preprocess: list[dict] | None = None
+    chunking: dict | None = None
+    timeout_minutes: int | None = Field(default=None, ge=1, le=120)
+
+    model_config = ConfigDict(populate_by_name=True)
+```
+
+- [ ] **Step 4: Add `timeout_minutes` to `ExtractionResultResponse`**
+
+In `ExtractionResultResponse`, add the field and wire `from_orm_model`:
+
+```python
+class ExtractionResultResponse(BaseModel):
+    """Full extraction result response."""
+    id: UUID = Field(..., alias="id")
+    document_id: UUID = Field(..., alias="documentId")
+    extraction_schema_id: UUID = Field(..., alias="extractionSchemaId")
+    schema_definition_snapshot: dict = Field(..., alias="schemaDefinitionSnapshot")
+    extraction_method: str = Field(..., alias="extractionMethod")
+    config: dict | None = None
+    structured_data: dict | None = Field(None, alias="structuredData")
+    citations: list | None = Field(None, alias="citations")
+    provider_response_raw: dict | None = Field(None, alias="providerResponseRaw")
+    extraction_metadata: dict | None = Field(None, alias="extractionMetadata")
+    status: ExtractionResultStatus
+    status_message: str | None = Field(None, alias="statusMessage")
+    started_at: datetime | None = Field(None, alias="startedAt")
+    source_parse_run_id: UUID | None = Field(None, alias="sourceParseRunId")
+    timeout_minutes: int | None = Field(None, alias="timeoutMinutes")
+    created_by: UUID = Field(..., alias="createdBy")
+    created_at: datetime = Field(..., alias="createdAt")
+    updated_at: datetime = Field(..., alias="updatedAt")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    @classmethod
+    def from_orm_model(cls, obj) -> "ExtractionResultResponse":
+        return cls(
+            id=obj.id,
+            documentId=obj.document_id,
+            extractionSchemaId=obj.extraction_schema_id,
+            schemaDefinitionSnapshot=obj.schema_definition_snapshot,
+            extractionMethod=obj.extraction_method,
+            config=obj.config,
+            structuredData=obj.structured_data,
+            citations=obj.citations,
+            providerResponseRaw=obj.provider_response_raw,
+            extractionMetadata=obj.extraction_metadata,
+            status=obj.status,
+            statusMessage=obj.status_message,
+            startedAt=obj.started_at,
+            sourceParseRunId=obj.source_parse_run_id,
+            timeoutMinutes=obj.timeout_minutes,
+            createdBy=obj.created_by,
+            createdAt=obj.created_at,
+            updatedAt=obj.updated_at,
+        )
+```
+
+- [ ] **Step 5: Add `timeout_minutes` to `ExtractionResultRepository.create()`**
+
+In `backend/app/repositories/extraction_result_repository.py`, update `create()`:
+
+```python
+async def create(
+    self,
+    document_id: UUID,
+    extraction_schema_id: UUID,
+    schema_definition_snapshot: dict,
+    extraction_method: str,
+    created_by: UUID,
+    config: dict | None = None,
+    source_parse_run_id: UUID | None = None,
+    timeout_minutes: int | None = None,
+) -> ExtractionResult:
+    """Create a new pending extraction result."""
+    result = ExtractionResult(
+        document_id=document_id,
+        extraction_schema_id=extraction_schema_id,
+        schema_definition_snapshot=schema_definition_snapshot,
+        extraction_method=extraction_method,
+        config=config,
+        created_by=created_by,
+        source_parse_run_id=source_parse_run_id,
+        timeout_minutes=timeout_minutes,
+        status=ExtractionResultStatus.pending,
+    )
+    self.session.add(result)
+    await self.session.commit()
+    await self.session.refresh(result)
+    return result
+```
+
+- [ ] **Step 6: Write the failing service tests for `_reap_stale`**
+
+Append to `backend/tests/services/test_extraction_service.py`:
+
+```python
+class TestReapStale:
+    """_reap_stale uses per-job timeout_minutes, falling back to 10."""
+
+    def _make_result(self, *, minutes_old: int, timeout_minutes: int | None):
+        from unittest.mock import MagicMock
+        result = MagicMock()
+        result.status = ExtractionResultStatus.pending
+        result.timeout_minutes = timeout_minutes
+        result.started_at = None
+        result.created_at = datetime.utcnow() - timedelta(minutes=minutes_old)
+        return result
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("timeout_minutes,minutes_old,expect_reaped", [
+        (None, 11, True),   # NULL → default 10 min; 11 min old → reaped
+        (None, 9, False),   # NULL → default 10 min; 9 min old → not reaped
+        (5, 6, True),       # explicit 5 min; 6 min old → reaped
+        (5, 4, False),      # explicit 5 min; 4 min old → not reaped
+        (60, 45, False),    # explicit 60 min; 45 min old → not reaped
+        (60, 61, True),     # explicit 60 min; 61 min old → reaped
+    ])
+    async def test_reap_stale_uses_per_job_timeout(
+        self, timeout_minutes, minutes_old, expect_reaped
+    ):
+        result = self._make_result(
+            minutes_old=minutes_old, timeout_minutes=timeout_minutes
+        )
+        mock_result_repo = AsyncMock()
+        mock_result_repo.update_status.return_value = result
+
+        service = _make_service(result_repo=mock_result_repo)
+        await service._reap_stale(result)
+
+        if expect_reaped:
+            mock_result_repo.update_status.assert_called_once()
+            args = mock_result_repo.update_status.call_args
+            assert ExtractionResultStatus.failed == args[0][1]
+            expected_n = timeout_minutes or 10
+            assert f"exceeded {expected_n} minutes" in args[0][2]
+        else:
+            mock_result_repo.update_status.assert_not_called()
+```
+
+Also add an import at the top of the test file if not present: `from datetime import timedelta`
+
+- [ ] **Step 7: Run service tests to confirm failure**
+
+```bash
+uv run --directory backend python -m pytest -o "addopts=" tests/services/test_extraction_service.py::TestReapStale -v
+```
+
+Expected: `FAILED` — `STALE_TIMEOUT` is still hard-coded.
+
+- [ ] **Step 8: Update `ExtractionService`**
+
+In `backend/app/services/extraction_service.py`:
+
+1. **Remove** the module-level constant `STALE_TIMEOUT = timedelta(minutes=10)`.
+
+2. **Update `run_extraction()`** to accept and pass `timeout_minutes`:
+
+```python
+async def run_extraction(
+    self,
+    parse_run_id: UUID,
+    extraction_schema_id: UUID,
+    extraction_method: str,
+    user_id: UUID,
+    config: dict | None = None,
+    llm_config=None,
+    user_prompt_template: str | None = None,
+    timeout_minutes: int | None = None,
+) -> ExtractionResultResponse:
+    """Create a pending extraction result anchored to a CDM ParsedDocument."""
+    orm_parsed_doc = await self.parsed_document_repo.get_by_run(parse_run_id)
+    if not orm_parsed_doc:
+        raise NotFoundError(f"ParsedDocument for parse_run_id {parse_run_id} not found")
+
+    schema = await self.schema_repo.get_by_id(extraction_schema_id)
+    if not schema:
+        raise NotFoundError(f"Extraction schema {extraction_schema_id} not found")
+
+    document = await self.document_repo.get_by_source_document_for_project(
+        source_document_id=orm_parsed_doc.source_document_id,
+        project_id=schema.project_id,
+    )
+    if not document:
+        raise NotFoundError(
+            f"No document found in project {schema.project_id} "
+            f"for source_document {orm_parsed_doc.source_document_id}"
+        )
+
+    merged_config = dict(config or {})
+    merged_config["extraction_target"] = schema.extraction_target
+    if llm_config is not None:
+        merged_config["llm_config"] = llm_config.model_dump(by_alias=False, mode="json")
+    if user_prompt_template:
+        merged_config["user_prompt_template"] = user_prompt_template
+
+    result = await self.result_repo.create(
+        document_id=document.id,
+        source_parse_run_id=parse_run_id,
+        extraction_schema_id=extraction_schema_id,
+        schema_definition_snapshot=schema.schema_definition,
+        extraction_method=extraction_method,
+        created_by=user_id,
+        config=merged_config,
+        timeout_minutes=timeout_minutes,
+    )
+    return ExtractionResultResponse.from_orm_model(result)
+```
+
+3. **Replace `_reap_stale()`**:
+
+```python
+async def _reap_stale(self, result):
+    if result.status != ExtractionResultStatus.pending:
+        return result
+    reference_time = result.started_at or result.created_at
+    if not reference_time:
+        return result
+    age = datetime.utcnow() - reference_time.replace(tzinfo=None)
+    effective_timeout = result.timeout_minutes or 10
+    if age > timedelta(minutes=effective_timeout):
+        result = await self.result_repo.update_status(
+            result.id, ExtractionResultStatus.failed,
+            f"Extraction job timed out (exceeded {effective_timeout} minutes)",
+        )
+    return result
+```
+
+- [ ] **Step 9: Run all schema + service tests**
+
+```bash
+uv run --directory backend python -m pytest -o "addopts=" tests/schemas/test_extraction_result_schemas.py tests/services/test_extraction_service.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/app/schemas/extraction_result.py backend/app/repositories/extraction_result_repository.py backend/app/services/extraction_service.py backend/tests/schemas/test_extraction_result_schemas.py backend/tests/services/test_extraction_service.py
+git commit -m "feat(extraction): thread timeout_minutes through schema, repo, and service"
+```
+
+---
+
+## Task 3: Router Wiring
+
+**Files:**
+- Modify: `backend/app/routers/extraction.py`
+
+**Interfaces:**
+- Consumes: `RunExtractionRequest.timeout_minutes` (Task 2), `ExtractionService.run_extraction(..., timeout_minutes)` (Task 2)
+
+- [ ] **Step 1: Pass `timeout_minutes` in the `run_extraction` router call**
+
+In `backend/app/routers/extraction.py`, find the `service.run_extraction(...)` call (around line 219) and add the new argument:
+
+```python
+result = await service.run_extraction(
+    parse_run_id=body.parse_run_id,
+    extraction_schema_id=body.extraction_schema_id,
+    extraction_method=body.extraction_method,
+    user_id=current_user.id,
+    config=body.config,
+    llm_config=body.llm_config,
+    user_prompt_template=body.user_prompt_template,
+    timeout_minutes=body.timeout_minutes,
+)
+```
+
+- [ ] **Step 2: Verify the app starts without errors**
+
+```bash
+uv run --directory backend uvicorn app.main:app --reload
+```
+
+Expected: server starts. Stop with Ctrl-C.
+
+- [ ] **Step 3: Run the full backend test suite to catch regressions**
+
+```bash
+uv run --directory backend python -m pytest -o "addopts=" -v
+```
+
+Expected: all existing tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/routers/extraction.py
+git commit -m "feat(extraction): pass timeout_minutes from router to service"
+```
+
+---
+
+## Task 4: Frontend — Types, Form, Hook
+
+**Files:**
+- Modify: `frontend/src/types/extraction.ts`
+- Modify: `frontend/src/components/extraction/ExtractionForm.tsx`
+- Modify: `frontend/src/hooks/useExtractionResults.ts`
+- Modify: `frontend/src/hooks/useExtractionResults.test.ts`
+
+**Interfaces:**
+- Consumes: `timeoutMinutes` returned in `ExtractionResultResponse` from the backend (Task 2)
+- Produces: `timeoutMinutes?: number` sent in `RunExtractionRequest` wire format
+
+- [ ] **Step 1: Write the failing hook tests**
+
+Append to `frontend/src/hooks/useExtractionResults.test.ts`:
+
+```typescript
+describe('extraction polling timeout', () => {
+  it('uses timeoutMinutes from result when set — stops polling after that many minutes', async () => {
+    vi.useFakeTimers()
+
+    const pendingResult = {
+      ...fakeExtractionResult,
+      timeoutMinutes: 20,
+    }
+    const completedResult = { ...pendingResult, status: 'completed' as const }
+
+    // First call returns pending, subsequent calls return pending until timeout
+    mockExtraction.listExtractionResults
+      .mockResolvedValueOnce([pendingResult])
+      .mockResolvedValue([pendingResult])
+
+    const { result } = renderHook(() => useExtractionResults('doc-1'))
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    // Advance time past 20-minute deadline
+    await act(async () => {
+      vi.advanceTimersByTime(20 * 60 * 1000 + 1)
+      await vi.runAllTimersAsync()
+    })
+
+    expect(result.current.results[0]?.status).toBe('failed')
+    expect(result.current.results[0]?.statusMessage).toBe('Processing timeout')
+
+    vi.useRealTimers()
+  })
+
+  it('falls back to 10-minute deadline when timeoutMinutes is null', async () => {
+    vi.useFakeTimers()
+
+    const pendingResult = {
+      ...fakeExtractionResult,
+      timeoutMinutes: null,
+    }
+
+    mockExtraction.listExtractionResults
+      .mockResolvedValueOnce([pendingResult])
+      .mockResolvedValue([pendingResult])
+
+    const { result } = renderHook(() => useExtractionResults('doc-1'))
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    // Still pending before 10-minute mark
+    await act(async () => {
+      vi.advanceTimersByTime(9 * 60 * 1000)
+      await vi.runAllTimersAsync()
+    })
+    expect(result.current.results[0]?.status).toBe('pending')
+
+    // Timed out after 10 minutes
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 60 * 1000)
+      await vi.runAllTimersAsync()
+    })
+    expect(result.current.results[0]?.status).toBe('failed')
+
+    vi.useRealTimers()
+  })
+})
+```
+
+Also update the `fakeExtractionResult` fixture in the test file to include `timeoutMinutes: null`:
+
+```typescript
+const fakeExtractionResult = {
+  id: 'result-1',
+  documentId: 'doc-1',
+  extractionSchemaId: 'schema-1',
+  schemaDefinitionSnapshot: {},
+  extractionMethod: 'llm',
+  config: null,
+  structuredData: null,
+  extractionMetadata: null,
+  citations: null,
+  providerResponseRaw: null,
+  sourceParseRunId: 'run-1',
+  status: 'pending' as const,
+  statusMessage: null,
+  startedAt: null,
+  createdBy: 'user-1',
+  createdAt: '2026-06-23T00:00:00Z',
+  updatedAt: '2026-06-23T00:00:00Z',
+  timeoutMinutes: null,
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npx vitest run src/hooks/useExtractionResults.test.ts
+```
+
+Expected: new tests `FAIL` (field not on type yet).
+
+- [ ] **Step 3: Update TypeScript types**
+
+In `frontend/src/types/extraction.ts`:
+
+1. Add `timeoutMinutes: number | null` to `ExtractionResult`:
+
+```typescript
+export interface ExtractionResult {
+  id: string
+  documentId: string
+  extractionSchemaId: string
+  schemaDefinitionSnapshot: Record<string, unknown>
+  extractionMethod: string
+  config: Record<string, unknown> | null
+  structuredData: Record<string, unknown> | null
+  extractionMetadata: Record<string, unknown> | null
+  citations: Record<string, unknown>[] | null
+  providerResponseRaw: Record<string, unknown> | null
+  sourceParseRunId: string | null
+  status: ExtractionResultStatus
+  statusMessage: string | null
+  startedAt: string | null
+  timeoutMinutes: number | null
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}
+```
+
+2. Add `timeoutMinutes?: number` to `RunExtractionRequest`:
+
+```typescript
+export interface RunExtractionRequest {
+  parseRunId: string
+  extractionSchemaId: string
+  extractionMethod: string
+  config?: Record<string, unknown>
+  llmConfig?: PromptConfig
+  userPromptTemplate?: string
+  chunking?: ChunkingConfig
+  preprocess?: PreprocessStage[]
+  timeoutMinutes?: number
+}
+```
+
+3. Add `timeoutMinutes?: number` to `RunWithParseRequest.extractionConfig`:
+
+```typescript
+export interface RunWithParseRequest {
+  parseConfig: {
+    parser: string
+    config: Record<string, unknown>
+    representationKind: string
+  }
+  extractionConfig: {
+    extractionSchemaId: string
+    extractionMethod: string
+    config?: Record<string, unknown>
+    llmConfig?: PromptConfig
+    userPromptTemplate?: string
+    chunking?: ChunkingConfig
+    preprocess?: PreprocessStage[]
+    timeoutMinutes?: number
+  }
+}
+```
+
+- [ ] **Step 4: Update the polling hook**
+
+In `frontend/src/hooks/useExtractionResults.ts`:
+
+1. Remove `EXTRACTION_POLLING_TIMEOUT` and `PARSE_TIMEOUT` constants (lines 14–15). Keep `POLLING_INTERVAL`.
+
+2. Add a timeout ref after `pollingStartRef`:
+```typescript
+const timeoutMsRef = useRef<number>(10 * 60 * 1_000)
+```
+
+3. In `fetchResults`, replace the `EXTRACTION_POLLING_TIMEOUT` check with `timeoutMsRef.current`:
+
+```typescript
+if (
+  pollingStartRef.current &&
+  Date.now() - pollingStartRef.current > timeoutMsRef.current
+) {
+```
+
+4. In `runExtractionWithParse`, replace the `PARSE_TIMEOUT` references with a local constant and set `timeoutMsRef` before calling `fetchResults()`:
+
+```typescript
+const PARSE_TIMEOUT_MS = 10 * 60 * 1_000
+
+// ... (existing parse phase logic — replace all PARSE_TIMEOUT refs with PARSE_TIMEOUT_MS)
+
+// Just before the final fetchResults() call:
+timeoutMsRef.current = (extractionConfig.timeoutMinutes ?? 10) * 60 * 1_000
+
+setExtractionPhase('extracting')
+try {
+  await extractionApi.runExtraction({
+    parseRunId: parseRunId!,
+    extractionSchemaId: extractionConfig.extractionSchemaId,
+    extractionMethod: extractionConfig.extractionMethod,
+    config: extractionConfig.config,
+    llmConfig: extractionConfig.llmConfig,
+    userPromptTemplate: extractionConfig.userPromptTemplate,
+    chunking: extractionConfig.chunking,
+    preprocess: extractionConfig.preprocess,
+    timeoutMinutes: extractionConfig.timeoutMinutes,
+  })
+  await fetchResults()
+  setExtractionPhase('done')
+```
+
+- [ ] **Step 5: Add the form field**
+
+In `frontend/src/components/extraction/ExtractionForm.tsx`:
+
+1. Add state after `maxTokensPerMinute` (line 70):
+```typescript
+const [timeoutMinutes, setTimeoutMinutes] = useState('')
+```
+
+2. In `handleRun`, inside the `extractionMethod === 'llm'` branch, add `timeoutMinutes` to `extractionConfig`:
+
+```typescript
+const tm = parseInt(timeoutMinutes, 10)
+extractionConfig = {
+  extractionSchemaId: schemaId,
+  extractionMethod,
+  config: { structured_output_mode: structuredOutputMode, inject_block_ids: injectBlockIds },
+  llmConfig: promptConfig,
+  userPromptTemplate: userPromptTemplate.trim() || undefined,
+  ...(chunking ? { chunking } : {}),
+  ...(!Number.isNaN(tm) && tm >= 1 ? { timeoutMinutes: Math.min(tm, 120) } : {}),
+}
+```
+
+3. In the JSX, add the timeout input inside the `CollapsibleContent` "Large document handling" section, after the rate limit TPM input (after line 398):
+
+```tsx
+<div className="space-y-1.5">
+  <Label className="text-xs">Timeout (minutes)</Label>
+  <Input
+    type="number"
+    value={timeoutMinutes}
+    onChange={(e) => setTimeoutMinutes(e.target.value)}
+    placeholder="10"
+    min={1}
+    max={120}
+    className="h-9"
+  />
+</div>
+```
+
+- [ ] **Step 6: Run the hook tests**
+
+```bash
+npx vitest run src/hooks/useExtractionResults.test.ts
+```
+
+Expected: all PASS (including the two new tests).
+
+- [ ] **Step 7: Run TypeScript build to catch type errors**
+
+```bash
+npm run --prefix frontend build
+```
+
+Expected: build succeeds with no type errors.
+
+- [ ] **Step 8: Run the full frontend test suite**
+
+```bash
+npx vitest run --reporter=verbose
+```
+
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/types/extraction.ts frontend/src/components/extraction/ExtractionForm.tsx frontend/src/hooks/useExtractionResults.ts frontend/src/hooks/useExtractionResults.test.ts
+git commit -m "feat(extraction): add configurable timeout to extraction form and polling hook"
+```

--- a/docs/superpowers/specs/2026-06-24-extraction-timeout-design.md
+++ b/docs/superpowers/specs/2026-06-24-extraction-timeout-design.md
@@ -1,0 +1,149 @@
+# Configurable Extraction Timeout
+
+**Date:** 2026-06-24
+**Status:** Approved
+
+## Problem
+
+Extraction jobs on large files fail with a timeout error before processing completes. Both limits are hard-coded:
+
+| Layer | Current value | Behaviour |
+|---|---|---|
+| Backend stale-job reaper | 10 minutes | Marks pending jobs `failed` |
+| Frontend polling | 5 minutes | Stops polling, shows "Processing timeout" |
+
+The frontend times out first (5 min), even though the backend would allow 10 min. Users have no way to extend either limit.
+
+## Solution
+
+Add an optional `timeout_minutes` field to `RunExtractionRequest`. The value is stored on the `ExtractionResult` row and used by both the backend reaper and the frontend polling hook to determine when a job has truly stalled.
+
+**Defaults:** backend keeps 10 minutes. Frontend fallback aligns to 10 minutes (fixing the current 5-min mismatch). **Max:** 120 minutes, enforced by backend validation.
+
+---
+
+## Data Model
+
+### New column: `extraction_results.timeout_minutes`
+
+- Type: `Integer`, nullable
+- `NULL` means "use default" (10 minutes)
+- Added via Alembic migration
+
+### Schema placement
+
+`timeout_minutes` is a **top-level field on `RunExtractionRequest`**, not nested inside `ChunkingConfig`. It is a job execution concern, not a chunking concern. In the UI it appears in the large-file processing section alongside "Max tokens / minute", but the wire format sends it at the root:
+
+```json
+{
+  "parse_run_id": "...",
+  "extraction_schema_id": "...",
+  "extraction_method": "llm",
+  "chunking": { "strategy": "token_budget_pages", "maxTokensPerMinute": 50000 },
+  "timeout_minutes": 45
+}
+```
+
+---
+
+## Backend Changes
+
+### `backend/app/schemas/extraction_result.py`
+
+Add to `RunExtractionRequest`:
+
+```python
+timeout_minutes: int | None = Field(default=None, ge=1, le=120)
+```
+
+Pydantic returns `422 Unprocessable Entity` for values outside 1–120.
+
+### `backend/app/routers/extraction.py`
+
+Extract `timeout_minutes` from the request and pass it to the result-creation call.
+
+### `backend/app/repositories/extraction_result_repository.py`
+
+`create()` accepts `timeout_minutes: int | None` and writes it to the new column.
+
+### `backend/app/services/extraction_service.py`
+
+**`_reap_stale()`** — replace hardcoded `STALE_TIMEOUT` with a per-job value:
+
+```python
+timeout = timedelta(minutes=result.timeout_minutes or 10)
+if age > timeout:
+    ...message = f"Extraction job timed out (exceeded {result.timeout_minutes or 10} minutes)"
+```
+
+The module-level `STALE_TIMEOUT` constant is removed.
+
+### `backend/app/schemas/extraction_result.py` — response
+
+Add to `ExtractionResultResponse`:
+
+```python
+timeout_minutes: int | None
+```
+
+Serialised via `from_orm_model()` so the frontend receives the value.
+
+---
+
+## Frontend Changes
+
+### `frontend/src/types/extraction.ts`
+
+- Add `timeoutMinutes?: number` to `RunExtractionRequest` (not `ChunkingConfig`)
+- Add `timeoutMinutes: number | null` to `ExtractionResultResponse`
+
+### `frontend/src/components/extraction/ExtractionForm.tsx`
+
+Add a number input "Timeout (minutes)" in the large-file processing section, below "Max tokens / minute":
+
+- Placeholder: `10`
+- Min: `1`, Max: `120`
+- Sent in the request body only when set
+
+### `frontend/src/hooks/useExtractionResults.ts`
+
+Replace the hardcoded `EXTRACTION_POLLING_TIMEOUT` (5 min) and `PARSE_TIMEOUT` (10 min) constants. After the first successful poll, derive the deadline from the job itself:
+
+```ts
+const deadlineMs = (result.timeoutMinutes ?? 10) * 60 * 1000;
+```
+
+This aligns the frontend fallback default (10 min) with the backend default, fixing the current mismatch where the frontend was cutting off 5 minutes earlier than the backend reaper.
+
+---
+
+## Error Handling & Edge Cases
+
+| Scenario | Behaviour |
+|---|---|
+| `timeout_minutes` outside 1–120 | Backend returns `422` |
+| `NULL` timeout on existing/new rows | Reaper and hook both fall back to 10 minutes |
+| Frontend receives `null` timeout | Hook uses `10 * 60 * 1000` ms fallback |
+| Job completes before timeout | Polling stops on `completed`/`failed` — timeout is a ceiling only |
+| User submits without setting timeout | Field omitted from request; column stays `NULL` |
+
+---
+
+## Testing
+
+### Backend unit — `_reap_stale`
+
+Parametrise over `timeout_minutes` values (`None`, `5`, `60`). Assert the correct `timedelta` is applied and the error message reflects the actual value.
+
+### Backend unit — Pydantic schema
+
+Assert `422` for `timeout_minutes=0` and `timeout_minutes=121`. Assert valid for `timeout_minutes=30`.
+
+### Backend integration — full run
+
+Create a result with `timeout_minutes=1`, advance mock time past 1 minute, poll via the GET endpoint, assert status is `failed` with `"exceeded 1 minutes"` in the message.
+
+### Frontend — hook
+
+- Mock a result response with `timeoutMinutes: 20`; assert polling deadline is `20 * 60 * 1000` ms.
+- Mock `timeoutMinutes: null`; assert fallback is `10 * 60 * 1000` ms.

--- a/frontend/src/components/extraction/ExtractionForm.tsx
+++ b/frontend/src/components/extraction/ExtractionForm.tsx
@@ -68,6 +68,7 @@ export function ExtractionForm({
   const [pageOverlap, setPageOverlap] = useState('0')
   const [dedupeKey, setDedupeKey] = useState('')
   const [maxTokensPerMinute, setMaxTokensPerMinute] = useState('')
+  const [timeoutMinutes, setTimeoutMinutes] = useState('')
   const [citationLevel, setCitationLevel] =
     useState<'auto' | 'full' | 'page_only' | 'off'>('auto')
 
@@ -159,6 +160,7 @@ export function ExtractionForm({
       } else if (citationLevel !== 'auto') {
         chunking = { strategy: 'none', citationLevel }
       }
+      const tm = parseInt(timeoutMinutes, 10)
       extractionConfig = {
         extractionSchemaId: schemaId,
         extractionMethod,
@@ -166,6 +168,7 @@ export function ExtractionForm({
         llmConfig: promptConfig,
         userPromptTemplate: userPromptTemplate.trim() || undefined,
         ...(chunking ? { chunking } : {}),
+        ...(!Number.isNaN(tm) && tm >= 1 ? { timeoutMinutes: Math.min(tm, 120) } : {}),
       }
     } else {
       extractionConfig = { extractionSchemaId: schemaId, extractionMethod, config: {} }
@@ -398,6 +401,18 @@ export function ExtractionForm({
                   </div>
                 </>
               )}
+              <div className="space-y-1.5">
+                <Label className="text-xs">Timeout (minutes)</Label>
+                <Input
+                  type="number"
+                  value={timeoutMinutes}
+                  onChange={(e) => setTimeoutMinutes(e.target.value)}
+                  placeholder="10"
+                  min={1}
+                  max={120}
+                  className="h-9"
+                />
+              </div>
               <p className="text-[11px] text-muted-foreground">
                 {citationLevel === 'off'
                   ? 'No provenance will be captured.'

--- a/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
+++ b/frontend/src/components/extraction/ExtractionResultViewer.test.tsx
@@ -20,6 +20,7 @@ function buildResult(overrides: Partial<ExtractionResult> = {}): ExtractionResul
     status: 'completed',
     statusMessage: null,
     startedAt: '2026-01-01T00:00:00Z',
+    timeoutMinutes: null,
     createdBy: 'user-1',
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',

--- a/frontend/src/hooks/useExtractionResults.test.ts
+++ b/frontend/src/hooks/useExtractionResults.test.ts
@@ -53,6 +53,7 @@ const fakeExtractionResult = {
   createdBy: 'user-1',
   createdAt: '2026-06-23T00:00:00Z',
   updatedAt: '2026-06-23T00:00:00Z',
+  timeoutMinutes: null,
 }
 
 const baseRequest = {
@@ -217,6 +218,7 @@ describe('clearSelection', () => {
       extractionMethod: 'llm',
       status: 'completed' as const,
       statusMessage: null,
+      timeoutMinutes: null,
       createdAt: '2026-06-24T00:00:00Z',
     }
     mockExtraction.listExtractionResults.mockResolvedValue([listItem])
@@ -242,6 +244,7 @@ describe('deleteResult', () => {
       extractionMethod: 'llm',
       status: 'completed' as const,
       statusMessage: null,
+      timeoutMinutes: null,
       createdAt: '2026-06-24T00:00:00Z',
     }
     mockExtraction.listExtractionResults.mockResolvedValue([listItem])
@@ -268,6 +271,7 @@ describe('deleteResult', () => {
       extractionMethod: 'llm',
       status: 'completed' as const,
       statusMessage: null,
+      timeoutMinutes: null,
       createdAt: '2026-06-24T00:00:00Z',
     }
     const fullResult = { ...fakeExtractionResult, id: 'result-1', status: 'completed' as const }
@@ -283,5 +287,60 @@ describe('deleteResult', () => {
 
     await act(async () => { await result.current.deleteResult('result-1') })
     expect(result.current.selectedResult).toBeNull()
+  })
+})
+
+describe('extraction polling timeout', () => {
+  // timeoutMinutes: 1 → deadline = 60000ms; interval = 3000ms
+  // interval fires at 3s, 6s, ..., 60s (20 times — all before deadline)
+  // interval fires at 63s (21st) — this one is past the deadline → timeout
+  const INTERVAL = 3_000
+  const ONE_MINUTE_MS = 60_000
+
+  it('uses timeoutMinutes from result when set — stops polling after that many minutes', async () => {
+    vi.useFakeTimers()
+
+    const pendingResult = { ...fakeExtractionResult, timeoutMinutes: 1 }
+    mockExtraction.listExtractionResults.mockResolvedValue([pendingResult])
+
+    const { result } = renderHook(() => useExtractionResults('doc-1'))
+    // Let initial fetch run and interval start
+    await act(async () => {})
+
+    // Advance to just before the timeout — still pending
+    act(() => { vi.advanceTimersByTime(ONE_MINUTE_MS - 1) })
+    await act(async () => {})
+    expect(result.current.results[0]?.status).toBe('pending')
+
+    // Advance past the timeout (next interval fires after 60s deadline)
+    act(() => { vi.advanceTimersByTime(INTERVAL + 1) })
+    await act(async () => {})
+
+    expect(result.current.results[0]?.status).toBe('failed')
+    expect(result.current.results[0]?.statusMessage).toBe('Processing timeout')
+
+    vi.useRealTimers()
+  })
+
+  it('falls back to 10-minute deadline when timeoutMinutes is null', async () => {
+    vi.useFakeTimers()
+
+    const pendingResult = { ...fakeExtractionResult, timeoutMinutes: null }
+    mockExtraction.listExtractionResults.mockResolvedValue([pendingResult])
+
+    const { result } = renderHook(() => useExtractionResults('doc-1'))
+    await act(async () => {})
+
+    // Still pending before 10-minute mark
+    act(() => { vi.advanceTimersByTime(10 * ONE_MINUTE_MS - 1) })
+    await act(async () => {})
+    expect(result.current.results[0]?.status).toBe('pending')
+
+    // Advance past the 10-minute timeout (next interval after 600s)
+    act(() => { vi.advanceTimersByTime(INTERVAL + 1) })
+    await act(async () => {})
+    expect(result.current.results[0]?.status).toBe('failed')
+
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/hooks/useExtractionResults.ts
+++ b/frontend/src/hooks/useExtractionResults.ts
@@ -11,8 +11,7 @@ import * as extractionApi from '@/api/extraction'
 import { createParseRun, listParseRuns, getParseRun } from '@/api/parseRuns'
 
 const POLLING_INTERVAL = 3_000
-const EXTRACTION_POLLING_TIMEOUT = 5 * 60 * 1_000
-const PARSE_TIMEOUT = 10 * 60 * 1_000
+const PARSE_TIMEOUT_MS = 10 * 60 * 1_000
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -75,6 +74,7 @@ export function useExtractionResults(
   const [phaseError, setPhaseError] = useState<string | null>(null)
   const pollingRef = useRef<NodeJS.Timeout | null>(null)
   const pollingStartRef = useRef<number | null>(null)
+  const timeoutMsRef = useRef<number>(10 * 60 * 1_000)
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -98,11 +98,13 @@ export function useExtractionResults(
 
       const hasPending = data.some((r) => r.status === 'pending')
       if (hasPending && !pollingRef.current) {
+        const firstPending = data.find((r) => r.status === 'pending')
+        timeoutMsRef.current = (firstPending?.timeoutMinutes ?? 10) * 60 * 1_000
         pollingStartRef.current = Date.now()
         pollingRef.current = setInterval(async () => {
           if (
             pollingStartRef.current &&
-            Date.now() - pollingStartRef.current > EXTRACTION_POLLING_TIMEOUT
+            Date.now() - pollingStartRef.current > timeoutMsRef.current
           ) {
             setResults((prev) =>
               prev.map((r) =>
@@ -116,6 +118,7 @@ export function useExtractionResults(
           }
           try {
             const updated = await extractionApi.listExtractionResults(documentId)
+            if (!pollingStartRef.current) return  // polling was stopped while awaiting
             setResults(updated)
             if (!updated.some((r) => r.status === 'pending')) stopPolling()
           } catch {
@@ -199,7 +202,7 @@ export function useExtractionResults(
 
         let resolvedId: string | null = null
         while (resolvedId === null) {
-          if (Date.now() - started > PARSE_TIMEOUT) {
+          if (Date.now() - started > PARSE_TIMEOUT_MS) {
             setExtractionPhase('failed')
             setPhaseError('Parse timed out')
             return
@@ -219,7 +222,7 @@ export function useExtractionResults(
         const foundId = resolvedId as string
 
         for (;;) {
-          if (Date.now() - started > PARSE_TIMEOUT) {
+          if (Date.now() - started > PARSE_TIMEOUT_MS) {
             setExtractionPhase('failed')
             setPhaseError('Parse timed out')
             return
@@ -249,6 +252,7 @@ export function useExtractionResults(
           userPromptTemplate: extractionConfig.userPromptTemplate,
           chunking: extractionConfig.chunking,
           preprocess: extractionConfig.preprocess,
+          timeoutMinutes: extractionConfig.timeoutMinutes,
         })
         await fetchResults()
         setExtractionPhase('done')

--- a/frontend/src/types/extraction.ts
+++ b/frontend/src/types/extraction.ts
@@ -43,6 +43,7 @@ export interface ExtractionResult {
   status: ExtractionResultStatus
   statusMessage: string | null
   startedAt: string | null
+  timeoutMinutes: number | null
   createdBy: string
   createdAt: string
   updatedAt: string
@@ -55,6 +56,7 @@ export interface ExtractionResultListItem {
   extractionMethod: string
   status: ExtractionResultStatus
   statusMessage: string | null
+  timeoutMinutes: number | null
   createdAt: string
 }
 
@@ -79,6 +81,7 @@ export interface RunExtractionRequest {
   userPromptTemplate?: string
   chunking?: ChunkingConfig
   preprocess?: PreprocessStage[]
+  timeoutMinutes?: number
 }
 
 export interface ExtractorInfo {
@@ -106,5 +109,6 @@ export interface RunWithParseRequest {
     userPromptTemplate?: string
     chunking?: ChunkingConfig
     preprocess?: PreprocessStage[]
+    timeoutMinutes?: number
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `timeout_minutes` field to `RunExtractionRequest` so users can set a custom timeout (1–120 min, default 10) per extraction job
- Backend: Alembic migration adds `timeout_minutes` column to `extraction_results`; stale-job reaper uses the stored value (falls back to 10 min) instead of a hard-coded constant
- Frontend: New \"Timeout (minutes)\" input in the Large document handling section; polling hook reads `timeoutMinutes` from the first pending result and uses it as the deadline

## Test plan

- [ ] Backend schema tests: `pytest tests/schemas/test_extraction_result_schemas.py -v` — 4 new tests for valid/invalid `timeout_minutes` values
- [ ] Backend service tests: `pytest tests/services/test_extraction_service.py -v` — 6 parametrized `_reap_stale` tests covering custom and null timeouts
- [ ] Frontend hook tests: `npx vitest run src/hooks/useExtractionResults.test.ts` — 2 new polling-timeout tests (1-min custom, 10-min null fallback)
- [ ] TypeScript: `npx tsc --noEmit` — no errors
- [ ] Manual: Open extraction form → expand Large document handling → verify Timeout (minutes) input appears after Rate limit (TPM); submit job with a short timeout and confirm frontend marks it failed after that interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)