### PR TITLE
Local pipeline parse — Iteration 2: FitzTool + CamelotTool + LocalParseRunner + config UI

### DIFF
--- a/backend/app/cdm/adapters/local_pipeline/__init__.py
+++ b/backend/app/cdm/adapters/local_pipeline/__init__.py
@@ -1,0 +1,27 @@
+from app.cdm.adapters.local_pipeline.adapter import LocalPipelineAdapter
+from app.cdm.adapters.local_pipeline.config import (
+    CamelotConfig,
+    FitzConfig,
+    LocalPipelineConfig,
+    build_pipeline_config,
+)
+from app.cdm.adapters.local_pipeline.merger import MergeResult, merge, overlap_fraction
+from app.cdm.adapters.local_pipeline.tools.base import LocalTool, PageMeta, ToolResult
+from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
+from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+
+__all__ = [
+    "LocalPipelineAdapter",
+    "CamelotConfig",
+    "FitzConfig",
+    "LocalPipelineConfig",
+    "build_pipeline_config",
+    "MergeResult",
+    "merge",
+    "overlap_fraction",
+    "LocalTool",
+    "PageMeta",
+    "ToolResult",
+    "CamelotTool",
+    "FitzTool",
+]

--- a/backend/app/cdm/adapters/local_pipeline/adapter.py
+++ b/backend/app/cdm/adapters/local_pipeline/adapter.py
@@ -1,0 +1,59 @@
+"""LocalPipelineAdapter — pure assembler: merged blocks + page geometry → CDM.
+
+All heavy lifting (eviction, id minting, bbox normalization) happens upstream
+in the tools and the merger. This adapter only assembles the ParsedDocument.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, List
+from uuid import uuid4
+
+from app.cdm.adapters.base import SourceMeta
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta
+from app.cdm.models import Block, Page, ParsedDocument, ParserKind
+
+
+class LocalPipelineAdapter:
+    parser: ClassVar[ParserKind] = ParserKind.LOCAL_PIPELINE
+
+    def adapt(self, raw: Any, source_meta: SourceMeta) -> ParsedDocument:
+        page_meta: Dict[int, PageMeta] = raw["page_meta"]
+        blocks: List[Block] = list(raw["blocks"])
+
+        blocks_by_page: Dict[int, List[Block]] = {}
+        for b in blocks:
+            blocks_by_page.setdefault(b.page_index, []).append(b)
+
+        page_indices = sorted(set(page_meta.keys()) | set(blocks_by_page.keys()))
+        pages: List[Page] = []
+        for idx in page_indices:
+            pm = page_meta.get(idx)
+            page_blocks = sorted(
+                blocks_by_page.get(idx, []),
+                key=lambda b: (b.reading_order if b.reading_order is not None else 1e9),
+            )
+            pages.append(Page(
+                index=idx,
+                width=pm.width if pm else None,
+                height=pm.height if pm else None,
+                unit=pm.unit if pm else None,
+                rotation=pm.rotation if pm else 0,
+                block_ids=[b.id for b in page_blocks],
+            ))
+
+        ordered_blocks = sorted(
+            blocks,
+            key=lambda b: (b.page_index, b.reading_order if b.reading_order is not None else 1e9),
+        )
+        full_text = "\n\n".join(b.text for b in ordered_blocks if b.text)
+
+        return ParsedDocument(
+            id=str(uuid4()),
+            source_document_id=source_meta.source_document_id,
+            parse_run_id=source_meta.parse_run_id,
+            source_filename=source_meta.filename,
+            page_count=len(pages),
+            pages=pages,
+            blocks=ordered_blocks,
+            full_text=full_text or None,
+        )

--- a/backend/app/cdm/adapters/local_pipeline/adapter.py
+++ b/backend/app/cdm/adapters/local_pipeline/adapter.py
@@ -46,6 +46,7 @@ class LocalPipelineAdapter:
             key=lambda b: (b.page_index, b.reading_order if b.reading_order is not None else 1e9),
         )
         full_text = "\n\n".join(b.text for b in ordered_blocks if b.text)
+        full_markdown = "\n\n".join(b.markdown for b in ordered_blocks if b.markdown)
 
         return ParsedDocument(
             id=str(uuid4()),
@@ -56,4 +57,5 @@ class LocalPipelineAdapter:
             pages=pages,
             blocks=ordered_blocks,
             full_text=full_text or None,
+            full_markdown=full_markdown or None,
         )

--- a/backend/app/cdm/adapters/local_pipeline/config.py
+++ b/backend/app/cdm/adapters/local_pipeline/config.py
@@ -1,0 +1,72 @@
+"""Configs for the local pipeline tools and the pipeline itself.
+
+The per-tool configs are Pydantic models (serializable → ParseRun.config).
+LocalPipelineConfig is a runtime object holding instantiated tools; it is NOT
+persisted — the runner persists the raw config dict it received.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel
+
+from app.cdm.adapters.local_pipeline.tools.base import LocalTool, PageMeta
+
+
+class FitzConfig(BaseModel):
+    min_chars_threshold: int = 10   # pages below → emit warning
+    include_images: bool = True      # emit FIGURE blocks for image blocks
+    span_detail: bool = False        # store full span list in parser_extras
+
+
+class CamelotConfig(BaseModel):
+    flavor: Literal["lattice", "stream"] = "lattice"
+    edge_tol: int = 50
+    row_tol: int = 2
+    copy_text: List[str] = []
+
+
+# tool_id -> the Pydantic config class that validates its per-tool config dict.
+TOOL_REGISTRY: Dict[str, type[BaseModel]] = {
+    "fitz": FitzConfig,
+    "camelot": CamelotConfig,
+}
+
+
+@dataclass
+class LocalPipelineConfig:
+    """Runtime pipeline config — ordered tools (later = higher priority)."""
+    tools: List[LocalTool]
+    eviction_overlap_threshold: float = 0.5
+
+
+def build_pipeline_config(
+    config: Dict[str, Any],
+    page_meta: Optional[Dict[int, PageMeta]] = None,
+) -> LocalPipelineConfig:
+    """Build a runtime LocalPipelineConfig from a serialized config dict.
+
+    `page_meta` is passed to CamelotTool for bbox y-flip (the runner supplies
+    FitzTool's page_meta after FitzTool completes; for fitz-only configs it is
+    unused).
+    """
+    # Imported here to avoid a circular import (tools import nothing from config).
+    from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
+    from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+
+    tools: List[LocalTool] = []
+    for entry in config.get("tools", []):
+        tool_id = entry.get("tool_id")
+        raw_cfg = entry.get("config", {}) or {}
+        cfg_cls = TOOL_REGISTRY.get(tool_id)
+        if cfg_cls is None:
+            raise ValueError(f"unknown tool: {tool_id!r}")
+        tool_cfg = cfg_cls.model_validate(raw_cfg)
+        if tool_id == "fitz":
+            tools.append(FitzTool(config=tool_cfg))  # type: ignore[arg-type]
+        elif tool_id == "camelot":
+            tools.append(CamelotTool(config=tool_cfg, page_meta=page_meta or {}))  # type: ignore[arg-type]
+
+    threshold = config.get("eviction_overlap_threshold", 0.5)
+    return LocalPipelineConfig(tools=tools, eviction_overlap_threshold=threshold)

--- a/backend/app/cdm/adapters/local_pipeline/merger.py
+++ b/backend/app/cdm/adapters/local_pipeline/merger.py
@@ -1,0 +1,119 @@
+"""Merge tool outputs into a final ordered block list + an audit raw_output.
+
+Eviction rule (spec §6.2): later-declared tools win. A fitz PARAGRAPH block
+that overlaps a camelot TABLE block beyond the threshold is evicted (logged,
+not deleted).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+from app.cdm.adapters.local_pipeline.tools.base import ToolResult
+from app.cdm.models import BBox, Block
+
+
+def _area(b: BBox) -> float:
+    return max(0.0, b.x1 - b.x0) * max(0.0, b.y1 - b.y0)
+
+
+def overlap_fraction(table_bbox: BBox, fitz_bbox: BBox) -> float:
+    """Intersection area / area(fitz_bbox), in normalized coords."""
+    fitz_area = _area(fitz_bbox)
+    if fitz_area == 0.0:
+        return 0.0
+    ix0 = max(table_bbox.x0, fitz_bbox.x0)
+    iy0 = max(table_bbox.y0, fitz_bbox.y0)
+    ix1 = min(table_bbox.x1, fitz_bbox.x1)
+    iy1 = min(table_bbox.y1, fitz_bbox.y1)
+    inter = max(0.0, ix1 - ix0) * max(0.0, iy1 - iy0)
+    return inter / fitz_area
+
+
+@dataclass
+class MergeResult:
+    blocks: List[Block]              # final, non-evicted, ordered, ids minted
+    raw_output: Dict[str, Any]
+
+
+def _sort_key(block: Block) -> Tuple[float, float]:
+    if block.bbox is None:
+        return (1e9, 1e9)
+    return (block.bbox.y0, block.bbox.x0)
+
+
+def merge(
+    fitz_result: ToolResult,
+    camelot_result: ToolResult,
+    *,
+    source_document_id: str,
+    eviction_overlap_threshold: float = 0.5,
+) -> MergeResult:
+    table_blocks = list(camelot_result.blocks)
+
+    # 1. Eviction pass — fitz blocks overlapping any table beyond threshold.
+    evicted_ids = set()
+    eviction_winner: Dict[str, str] = {}   # fitz prov id -> table prov id
+    eviction_overlap: Dict[str, float] = {}
+    for fb in fitz_result.blocks:
+        if fb.bbox is None:
+            continue
+        for tb in table_blocks:
+            if tb.page_index != fb.page_index or tb.bbox is None:
+                continue
+            frac = overlap_fraction(tb.bbox, fb.bbox)
+            if frac > eviction_overlap_threshold:
+                evicted_ids.add(fb.id)
+                eviction_winner[fb.id] = tb.id
+                eviction_overlap[fb.id] = frac
+                break
+
+    surviving_fitz = [b for b in fitz_result.blocks if b.id not in evicted_ids]
+    combined = surviving_fitz + table_blocks
+
+    # 2. Mint final ids + reading order, grouped per page.
+    by_page: Dict[int, List[Block]] = {}
+    for b in combined:
+        by_page.setdefault(b.page_index, []).append(b)
+
+    prov_to_final: Dict[str, str] = {}
+    final_blocks: List[Block] = []
+    for page_index in sorted(by_page.keys()):
+        ordered = sorted(by_page[page_index], key=_sort_key)
+        for reading_order, block in enumerate(ordered):
+            final_id = f"{source_document_id}:{page_index}:{reading_order}"
+            prov_to_final[block.id] = final_id
+            final_blocks.append(
+                block.model_copy(update={"id": final_id, "reading_order": reading_order})
+            )
+
+    # 3. Build raw_output (audit trail).
+    def _block_map(result: ToolResult) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for prov_id, native in result.native_by_block.items():
+            final_id = prov_to_final.get(prov_id)
+            if final_id is not None:  # skip evicted (no final id)
+                out[final_id] = native
+        return out
+
+    evicted_records = [
+        {
+            "block_id": prov_id,
+            "tool": "fitz",
+            "reason": "spatial_overlap",
+            "won_by": prov_to_final[eviction_winner[prov_id]],
+            "overlap_fraction": eviction_overlap[prov_id],
+            "raw_block": fitz_result.native_by_block.get(prov_id),
+        }
+        for prov_id in evicted_ids
+    ]
+
+    raw_output = {
+        "tools": {
+            "fitz": {"raw": fitz_result.raw, "block_map": _block_map(fitz_result)},
+            "camelot": {"raw": camelot_result.raw, "block_map": _block_map(camelot_result)},
+        },
+        "evicted": evicted_records,
+    }
+
+    return MergeResult(blocks=final_blocks, raw_output=raw_output)

--- a/backend/app/cdm/adapters/local_pipeline/tools/base.py
+++ b/backend/app/cdm/adapters/local_pipeline/tools/base.py
@@ -1,0 +1,47 @@
+"""Contracts shared by all local parsing tools.
+
+A LocalTool reads a PDF and returns CDM Blocks (with normalized bboxes) plus
+the native records that produced them, for the audit trail.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+from app.cdm.models import Block
+
+
+def clamp01(v: float) -> float:
+    """Clamp a coordinate fraction into the [0, 1] range."""
+    return max(0.0, min(1.0, v))
+
+
+class PageMeta(BaseModel):
+    """Authoritative page geometry, sourced from FitzTool."""
+    index: int
+    width: float       # PDF points
+    height: float      # PDF points
+    unit: str = "points"
+    rotation: int = 0  # degrees
+
+
+class ToolResult(BaseModel):
+    """Output of one LocalTool.run() invocation."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    tool_id: str
+    blocks: List[Block]
+    page_meta: Dict[int, PageMeta]          # keyed by 0-based page index
+    raw: Any = None                          # serializable native dump
+    native_by_block: Dict[str, Any] = {}     # provisional block id -> native record
+    warnings: List[str] = []
+    duration_ms: int = 0
+
+
+@runtime_checkable
+class LocalTool(Protocol):
+    tool_id: str
+
+    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult: ...

--- a/backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py
+++ b/backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py
@@ -1,0 +1,141 @@
+"""CamelotTool — table extraction via camelot-py. Emits CDM TABLE Blocks.
+
+Camelot uses 1-indexed page numbers and a bottom-left coordinate origin.
+This tool converts to 0-based page indices and top-left normalized bboxes
+using page geometry supplied by FitzTool (via `page_meta`).
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import camelot
+
+from app.cdm.adapters.local_pipeline.config import CamelotConfig
+from app.cdm.adapters.local_pipeline.tools.base import (
+    PageMeta,
+    ToolResult,
+    clamp01,
+)
+from app.cdm.models import BBox, Block, BlockRole, Cell, Table
+
+
+class CamelotTool:
+    tool_id = "camelot"
+
+    def __init__(
+        self,
+        config: Optional[CamelotConfig] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+    ) -> None:
+        self.config = config or CamelotConfig()
+        self.page_meta = page_meta or {}
+
+    @staticmethod
+    def _pages_arg(pages: Optional[List[int]]) -> str:
+        """Translate 0-based CDM page indices to camelot's 1-indexed string."""
+        if not pages:
+            return "1-end"
+        return ",".join(str(p + 1) for p in sorted(pages))
+
+    def _norm_bbox(self, native_bbox, page_meta: PageMeta) -> BBox:
+        x1, y1, x2, y2 = native_bbox  # bottom-left origin
+        w, h = page_meta.width, page_meta.height
+        # Flip y: top-left y = page_height - bottom_left_y.
+        return BBox(
+            x0=clamp01(min(x1, x2) / w),
+            y0=clamp01((h - max(y1, y2)) / h),
+            x1=clamp01(max(x1, x2) / w),
+            y1=clamp01((h - min(y1, y2)) / h),
+            source_space="pdf_points",
+            source_coords=(float(x1), float(y1), float(x2), float(y2)),
+        )
+
+    def _cells(self, table: Any, page_meta: PageMeta) -> List[Cell]:
+        cells: List[Cell] = []
+        for r, row in enumerate(table.cells):
+            for c, cell in enumerate(row):
+                cells.append(Cell(
+                    row=r,
+                    col=c,
+                    text=(cell.text or "").strip(),
+                    bbox=self._norm_bbox(
+                        (cell.x1, cell.y1, cell.x2, cell.y2), page_meta
+                    ),
+                ))
+        return cells
+
+    def _table_to_block(
+        self, table: Any, page_index: int, page_meta: Optional[PageMeta], table_seq: int
+    ) -> Block:
+        report = table.parsing_report or {}
+        rows, cols = table.df.shape
+        cdm_table = Table(
+            rows=int(rows),
+            cols=int(cols),
+            cells=self._cells(table, page_meta) if page_meta else [],
+            html=table.df.to_html(),
+        )
+        bbox = self._norm_bbox(table._bbox, page_meta) if page_meta else None
+        return Block(
+            id=f"camelot:{page_index}:{table_seq}",
+            role=BlockRole.TABLE,
+            native_type="table",
+            page_index=page_index,
+            bbox=bbox,
+            table=cdm_table,
+            parser_extras={
+                "camelot_accuracy": report.get("accuracy"),
+                "camelot_order": report.get("order"),
+                "camelot_flavor": self.config.flavor,
+            },
+        )
+
+    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+        t0 = time.perf_counter()
+        warnings: List[str] = []
+        blocks: List[Block] = []
+        native_by_block: Dict[str, Any] = {}
+        raw_tables: List[Dict[str, Any]] = []
+
+        read_kwargs: Dict[str, Any] = {
+            "flavor": self.config.flavor,
+            "pages": self._pages_arg(pages),
+            "edge_tol": self.config.edge_tol,
+            "row_tol": self.config.row_tol,
+        }
+        if self.config.copy_text:
+            read_kwargs["copy_text"] = self.config.copy_text
+
+        tables = camelot.read_pdf(str(pdf_path), **read_kwargs)
+
+        seq_by_page: Dict[int, int] = {}
+        for table in tables:
+            page_index = int(table.page) - 1
+            seq = seq_by_page.get(page_index, 0)
+            seq_by_page[page_index] = seq + 1
+            pm = self.page_meta.get(page_index)
+            if pm is None:
+                warnings.append(
+                    f"page {page_index}: no page_meta; table bbox omitted"
+                )
+            block = self._table_to_block(table, page_index, pm, seq)
+            blocks.append(block)
+            native_record = {
+                "page": int(table.page),
+                "parsing_report": table.parsing_report,
+                "html": table.df.to_html(),
+            }
+            native_by_block[block.id] = native_record
+            raw_tables.append(native_record)
+
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks=blocks,
+            page_meta=self.page_meta,
+            raw={"tables": raw_tables},
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )

--- a/backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py
+++ b/backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py
@@ -66,22 +66,38 @@ class CamelotTool:
                 ))
         return cells
 
+    @staticmethod
+    def _df_to_text(df: Any) -> str:
+        """Plain-text rendering of the table — one row per line, cells joined."""
+        return "\n".join(
+            " | ".join("" if c is None else str(c) for c in row)
+            for row in df.values.tolist()
+        )
+
     def _table_to_block(
         self, table: Any, page_index: int, page_meta: Optional[PageMeta], table_seq: int
     ) -> Block:
         report = table.parsing_report or {}
-        rows, cols = table.df.shape
+        df = table.df
+        rows, cols = df.shape
+        html = df.to_html(index=False)
+        markdown = df.to_markdown(index=False)
+        text = self._df_to_text(df)
         cdm_table = Table(
             rows=int(rows),
             cols=int(cols),
             cells=self._cells(table, page_meta) if page_meta else [],
-            html=table.df.to_html(),
+            html=html,
+            markdown=markdown,
         )
         bbox = self._norm_bbox(table._bbox, page_meta) if page_meta else None
         return Block(
             id=f"camelot:{page_index}:{table_seq}",
             role=BlockRole.TABLE,
             native_type="table",
+            text=text,
+            markdown=markdown,
+            html=html,
             page_index=page_index,
             bbox=bbox,
             table=cdm_table,

--- a/backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py
+++ b/backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py
@@ -102,9 +102,12 @@ class CamelotTool:
         read_kwargs: Dict[str, Any] = {
             "flavor": self.config.flavor,
             "pages": self._pages_arg(pages),
-            "edge_tol": self.config.edge_tol,
-            "row_tol": self.config.row_tol,
         }
+        # edge_tol/row_tol are stream-only knobs; camelot raises if they are
+        # passed with flavor="lattice".
+        if self.config.flavor == "stream":
+            read_kwargs["edge_tol"] = self.config.edge_tol
+            read_kwargs["row_tol"] = self.config.row_tol
         if self.config.copy_text:
             read_kwargs["copy_text"] = self.config.copy_text
 

--- a/backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py
+++ b/backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py
@@ -16,6 +16,22 @@ from app.cdm.adapters.local_pipeline.tools.base import (
 from app.cdm.models import BBox, Block, BlockRole
 
 
+def _json_safe(obj: Any) -> Any:
+    """Recursively replace non-JSON-serializable bytes with a size marker.
+
+    fitz image blocks carry raw image bytes under the "image" key; these must
+    not reach the JSON ``raw_payload`` column. We don't need the raw bytes in
+    the audit trail — the bbox and image metadata are enough.
+    """
+    if isinstance(obj, bytes):
+        return f"<{len(obj)} bytes>"
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    return obj
+
+
 def _block_text(native_block: Dict[str, Any]) -> str:
     """Join span texts within a fitz text block into a single string."""
     parts: List[str] = []
@@ -65,7 +81,7 @@ class FitzTool:
                 page_meta[i] = PageMeta(
                     index=i, width=width, height=height, rotation=page.rotation
                 )
-                native_raw[i] = pd
+                native_raw[i] = _json_safe(pd)
 
                 char_count = 0
                 for bi, blk in enumerate(pd.get("blocks", [])):
@@ -97,7 +113,7 @@ class FitzTool:
                             parser_extras=extras,
                         )
                         blocks.append(block)
-                        native_by_block[prov_id] = blk
+                        native_by_block[prov_id] = _json_safe(blk)
                     elif btype == 1 and self.config.include_images:
                         block = Block(
                             id=prov_id,
@@ -108,7 +124,7 @@ class FitzTool:
                             parser_extras={"fitz_block_type": 1},
                         )
                         blocks.append(block)
-                        native_by_block[prov_id] = blk
+                        native_by_block[prov_id] = _json_safe(blk)
 
                 if char_count < self.config.min_chars_threshold:
                     warnings.append(

--- a/backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py
+++ b/backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py
@@ -1,0 +1,129 @@
+"""FitzTool — text + image extraction via PyMuPDF. Emits CDM Blocks."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import fitz  # PyMuPDF
+
+from app.cdm.adapters.local_pipeline.config import FitzConfig
+from app.cdm.adapters.local_pipeline.tools.base import (
+    PageMeta,
+    ToolResult,
+    clamp01,
+)
+from app.cdm.models import BBox, Block, BlockRole
+
+
+def _block_text(native_block: Dict[str, Any]) -> str:
+    """Join span texts within a fitz text block into a single string."""
+    parts: List[str] = []
+    for line in native_block.get("lines", []):
+        line_text = "".join(span.get("text", "") for span in line.get("spans", []))
+        parts.append(line_text)
+    return "\n".join(parts).strip()
+
+
+def _spans(native_block: Dict[str, Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for line in native_block.get("lines", []):
+        for span in line.get("spans", []):
+            out.append({
+                "text": span.get("text", ""),
+                "font": span.get("font"),
+                "size": span.get("size"),
+                "flags": span.get("flags"),
+                "bbox": span.get("bbox"),
+            })
+    return out
+
+
+class FitzTool:
+    tool_id = "fitz"
+
+    def __init__(self, config: Optional[FitzConfig] = None) -> None:
+        self.config = config or FitzConfig()
+
+    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+        t0 = time.perf_counter()
+        blocks: List[Block] = []
+        page_meta: Dict[int, PageMeta] = {}
+        native_raw: Dict[int, Any] = {}
+        native_by_block: Dict[str, Any] = {}
+        warnings: List[str] = []
+
+        doc = fitz.open(str(pdf_path))
+        try:
+            for i in range(len(doc)):
+                if pages is not None and i not in pages:
+                    continue
+                page = doc[i]
+                pd = page.get_text("dict")
+                width = float(pd["width"])
+                height = float(pd["height"])
+                page_meta[i] = PageMeta(
+                    index=i, width=width, height=height, rotation=page.rotation
+                )
+                native_raw[i] = pd
+
+                char_count = 0
+                for bi, blk in enumerate(pd.get("blocks", [])):
+                    btype = blk.get("type", 0)
+                    x0, y0, x1, y1 = blk["bbox"]
+                    bbox = BBox(
+                        x0=clamp01(x0 / width),
+                        y0=clamp01(y0 / height),
+                        x1=clamp01(x1 / width),
+                        y1=clamp01(y1 / height),
+                        source_space="pdf_points",
+                        source_coords=(float(x0), float(y0), float(x1), float(y1)),
+                    )
+                    prov_id = f"fitz:{i}:{bi}"
+
+                    if btype == 0:
+                        text = _block_text(blk)
+                        char_count += len(text)
+                        extras: Dict[str, Any] = {"fitz_block_type": 0}
+                        if self.config.span_detail:
+                            extras["spans"] = _spans(blk)
+                        block = Block(
+                            id=prov_id,
+                            role=BlockRole.PARAGRAPH,
+                            native_type="text",
+                            text=text,
+                            page_index=i,
+                            bbox=bbox,
+                            parser_extras=extras,
+                        )
+                        blocks.append(block)
+                        native_by_block[prov_id] = blk
+                    elif btype == 1 and self.config.include_images:
+                        block = Block(
+                            id=prov_id,
+                            role=BlockRole.FIGURE,
+                            native_type="image",
+                            page_index=i,
+                            bbox=bbox,
+                            parser_extras={"fitz_block_type": 1},
+                        )
+                        blocks.append(block)
+                        native_by_block[prov_id] = blk
+
+                if char_count < self.config.min_chars_threshold:
+                    warnings.append(
+                        f"page {i}: {char_count} chars below threshold "
+                        f"{self.config.min_chars_threshold} (possible CID corruption or scan)"
+                    )
+        finally:
+            doc.close()
+
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks=blocks,
+            page_meta=page_meta,
+            raw={"pages": native_raw},
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )

--- a/backend/app/services/parsing/errors.py
+++ b/backend/app/services/parsing/errors.py
@@ -26,6 +26,10 @@ class DoclingRunError(ParseRunError):
     """Raised by docling_runner when conversion fails on any batch."""
 
 
+class LocalPipelineRunError(ParseRunError):
+    """Raised by local_pipeline_runner when a tool invocation fails."""
+
+
 class ParseFailedError(RuntimeError):
     """Domain error raised by ParsingService to callers (routers) after
     a failed ParseRun has been persisted."""

--- a/backend/app/services/parsing/local_pipeline_runner.py
+++ b/backend/app/services/parsing/local_pipeline_runner.py
@@ -1,0 +1,122 @@
+"""Drives the local tool pipeline end-to-end: tools → merge → CDM + ParseRun."""
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from app.cdm.adapters.base import SourceMeta
+from app.cdm.adapters.local_pipeline.adapter import LocalPipelineAdapter
+from app.cdm.adapters.local_pipeline.config import build_pipeline_config
+from app.cdm.adapters.local_pipeline.merger import merge
+from app.cdm.adapters.local_pipeline.tools.base import ToolResult
+from app.cdm.models import ParsedDocument, ParserKind
+from app.cdm.source import ParseRun, ParseRunStatus, SourceDocument
+from app.services.parsing.errors import LocalPipelineRunError
+
+
+async def run_local_pipeline(
+    *,
+    source: SourceDocument,
+    file_path: str,
+    representation_kind: str,
+    config: Dict[str, Any],
+    client: Any = None,           # unused — local pipeline needs no client
+    parse_run_id: Optional[str] = None,
+) -> Tuple[ParseRun, ParsedDocument]:
+    """Run the configured local tools, merge, and adapt to CDM.
+
+    Tools run sequentially; FitzTool runs first and supplies page geometry to
+    CamelotTool (spec §6.2). On any tool failure, a FAILED ParseRun is raised
+    inside LocalPipelineRunError.
+    """
+    run_id = parse_run_id or str(uuid.uuid4())
+    started_at = datetime.now(timezone.utc)
+    t0 = time.perf_counter()
+
+    def _fail(exc: Exception) -> LocalPipelineRunError:
+        finished_at = datetime.now(timezone.utc)
+        duration_ms = int((time.perf_counter() - t0) * 1000)
+        failed = ParseRun(
+            id=run_id,
+            source_document_id=source.id,
+            parser=ParserKind.LOCAL_PIPELINE,
+            representation_kind=representation_kind,
+            config=config,
+            status=ParseRunStatus.FAILED,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=duration_ms,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        return LocalPipelineRunError(f"Local pipeline failed: {exc}", run=failed)
+
+    try:
+        pdf_path = Path(file_path)
+
+        # Build the pipeline to learn tool order + threshold. FitzTool runs
+        # first; CamelotTool is rebuilt below once we have page_meta.
+        pipeline = build_pipeline_config(config)
+
+        fitz_tool = next((t for t in pipeline.tools if t.tool_id == "fitz"), None)
+        if fitz_tool is None:
+            raise ValueError("local pipeline requires a 'fitz' tool")
+
+        fitz_result: ToolResult = fitz_tool.run(pdf_path)
+        warnings = list(fitz_result.warnings)
+
+        # CamelotTool needs fitz page_meta for y-flip; rebuild with page_meta.
+        camelot_entry = next(
+            (e for e in config.get("tools", []) if e.get("tool_id") == "camelot"),
+            None,
+        )
+        if camelot_entry is not None:
+            camelot_pipeline = build_pipeline_config(
+                {"tools": [camelot_entry]}, page_meta=fitz_result.page_meta
+            )
+            camelot_tool = camelot_pipeline.tools[0]
+            camelot_result = camelot_tool.run(pdf_path)
+            warnings.extend(camelot_result.warnings)
+        else:
+            camelot_result = ToolResult(tool_id="camelot", blocks=[], page_meta={},
+                                        raw={"tables": []})
+
+        merge_result = merge(
+            fitz_result,
+            camelot_result,
+            source_document_id=source.id,
+            eviction_overlap_threshold=pipeline.eviction_overlap_threshold,
+        )
+    except Exception as exc:  # noqa: BLE001 — wrap into a FAILED ParseRun
+        raise _fail(exc) from exc
+
+    finished_at = datetime.now(timezone.utc)
+    duration_ms = int((time.perf_counter() - t0) * 1000)
+
+    run = ParseRun(
+        id=run_id,
+        source_document_id=source.id,
+        parser=ParserKind.LOCAL_PIPELINE,
+        representation_kind=representation_kind,
+        config=config,
+        status=ParseRunStatus.SUCCEEDED,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        warnings=warnings,
+        raw_payload=merge_result.raw_output,
+    )
+
+    adapter = LocalPipelineAdapter()
+    doc = adapter.adapt(
+        {"page_meta": fitz_result.page_meta, "blocks": merge_result.blocks},
+        SourceMeta(
+            source_document_id=source.id,
+            parse_run_id=run.id,
+            filename=source.filename,
+            sha256=source.sha256,
+        ),
+    )
+    return run, doc

--- a/backend/app/services/parsing/parsing_service.py
+++ b/backend/app/services/parsing/parsing_service.py
@@ -24,6 +24,7 @@ from app.services.parsing.docling_runner import run_docling
 from app.services.parsing.errors import ParseFailedError, ParseRunError
 from app.services.parsing.landingai_runner import run_landingai
 from app.services.parsing.llamaparse_runner import run_llamaparse
+from app.services.parsing.local_pipeline_runner import run_local_pipeline
 from app.services.parsing.simple_runner import run_simple
 
 
@@ -34,6 +35,7 @@ _RUNNERS: Dict[ParserKind, Callable] = {
     ParserKind.LANDING_AI: run_landingai,
     ParserKind.SIMPLE:     run_simple,
     ParserKind.DOCLING:    run_docling,
+    ParserKind.LOCAL_PIPELINE: run_local_pipeline,
 }
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "docling>=2.105.0",
     "pypdf>=6.6.2",
     "pymupdf>=1.24.0", # fitz — PDF text/image/drawing extraction for DocumentProbe
+    "camelot-py>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "pypdf>=6.6.2",
     "pymupdf>=1.24.0", # fitz — PDF text/image/drawing extraction for DocumentProbe
     "camelot-py>=2.0.0",
+    "tabulate>=0.10.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/cdm/adapters/local_pipeline/test_adapter.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_adapter.py
@@ -1,0 +1,58 @@
+from app.cdm.adapters.base import SourceMeta
+from app.cdm.adapters.local_pipeline.adapter import LocalPipelineAdapter
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta
+from app.cdm.models import BBox, Block, BlockRole, ParsedDocument, ParserKind
+
+
+def _bbox(y0):
+    return BBox(x0=0.1, y0=y0, x1=0.9, y1=y0 + 0.05)
+
+
+def _blocks():
+    return [
+        Block(id="doc1:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+              text="alpha", page_index=0, bbox=_bbox(0.1), reading_order=0),
+        Block(id="doc1:0:1", role=BlockRole.TABLE, native_type="table",
+              text="", page_index=0, bbox=_bbox(0.5), reading_order=1),
+        Block(id="doc1:1:0", role=BlockRole.PARAGRAPH, native_type="text",
+              text="beta", page_index=1, bbox=_bbox(0.2), reading_order=0),
+    ]
+
+
+def test_adapter_parser_kind():
+    assert LocalPipelineAdapter.parser == ParserKind.LOCAL_PIPELINE
+
+
+def test_adapter_builds_parsed_document():
+    raw = {
+        "page_meta": {
+            0: PageMeta(index=0, width=612.0, height=792.0),
+            1: PageMeta(index=1, width=612.0, height=792.0),
+        },
+        "blocks": _blocks(),
+    }
+    doc = LocalPipelineAdapter().adapt(raw, SourceMeta(
+        source_document_id="doc1", parse_run_id="run1", filename="x.pdf"
+    ))
+    assert isinstance(doc, ParsedDocument)
+    assert doc.source_document_id == "doc1"
+    assert doc.parse_run_id == "run1"
+    assert doc.page_count == 2
+    assert len(doc.blocks) == 3
+    assert doc.full_text == "alpha\n\nbeta"
+
+
+def test_adapter_page_block_ids_in_reading_order():
+    raw = {
+        "page_meta": {0: PageMeta(index=0, width=612.0, height=792.0),
+                      1: PageMeta(index=1, width=612.0, height=792.0)},
+        "blocks": _blocks(),
+    }
+    doc = LocalPipelineAdapter().adapt(raw, SourceMeta(
+        source_document_id="doc1", parse_run_id="run1"
+    ))
+    page0 = next(p for p in doc.pages if p.index == 0)
+    assert page0.block_ids == ["doc1:0:0", "doc1:0:1"]
+    assert page0.width == 612.0
+    assert page0.height == 792.0
+    assert page0.unit == "points"

--- a/backend/tests/cdm/adapters/local_pipeline/test_adapter.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_adapter.py
@@ -13,7 +13,8 @@ def _blocks():
         Block(id="doc1:0:0", role=BlockRole.PARAGRAPH, native_type="text",
               text="alpha", page_index=0, bbox=_bbox(0.1), reading_order=0),
         Block(id="doc1:0:1", role=BlockRole.TABLE, native_type="table",
-              text="", page_index=0, bbox=_bbox(0.5), reading_order=1),
+              text="A | B", markdown="| A | B |", page_index=0, bbox=_bbox(0.5),
+              reading_order=1),
         Block(id="doc1:1:0", role=BlockRole.PARAGRAPH, native_type="text",
               text="beta", page_index=1, bbox=_bbox(0.2), reading_order=0),
     ]
@@ -39,7 +40,9 @@ def test_adapter_builds_parsed_document():
     assert doc.parse_run_id == "run1"
     assert doc.page_count == 2
     assert len(doc.blocks) == 3
-    assert doc.full_text == "alpha\n\nbeta"
+    assert doc.full_text == "alpha\n\nA | B\n\nbeta"
+    # full_markdown is assembled from block.markdown (only the table here).
+    assert doc.full_markdown == "| A | B |"
 
 
 def test_adapter_page_block_ids_in_reading_order():

--- a/backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.cdm.adapters.local_pipeline.config import CamelotConfig
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta
+from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
+from app.cdm.models import BlockRole
+
+
+class _FakeDF:
+    def to_html(self):
+        return "<table><tr><td>A</td></tr></table>"
+
+    @property
+    def shape(self):
+        return (1, 2)
+
+
+def _fake_cell(x1, y1, x2, y2, text):
+    return SimpleNamespace(x1=x1, y1=y1, x2=x2, y2=y2, text=text)
+
+
+def _fake_table():
+    # camelot bottom-left origin; page is 792pt tall.
+    return SimpleNamespace(
+        page=2,
+        df=_FakeDF(),
+        parsing_report={"accuracy": 98.5, "order": 1, "page": 2, "whitespace": 12.0},
+        _bbox=(72.0, 600.0, 540.0, 720.0),  # x1,y1,x2,y2 bottom-left
+        cells=[[_fake_cell(72.0, 700.0, 300.0, 720.0, "A"),
+                _fake_cell(300.0, 700.0, 540.0, 720.0, "B")]],
+    )
+
+
+def test_camelot_tool_id():
+    assert CamelotTool().tool_id == "camelot"
+
+
+def test_table_to_block_role_and_page_index():
+    pm = PageMeta(index=1, width=612.0, height=792.0)
+    tool = CamelotTool(page_meta={1: pm})
+    block = tool._table_to_block(_fake_table(), page_index=1, page_meta=pm, table_seq=0)
+    assert block.role == BlockRole.TABLE
+    assert block.page_index == 1
+    assert block.id == "camelot:1:0"
+
+
+def test_table_to_block_bbox_y_flipped_and_normalized():
+    pm = PageMeta(index=1, width=612.0, height=792.0)
+    block = CamelotTool()._table_to_block(_fake_table(), page_index=1, page_meta=pm, table_seq=0)
+    bb = block.bbox
+    # bottom-left (72,600,540,720) → top-left y: y0=(792-720)/792, y1=(792-600)/792
+    assert bb.x0 == pytest.approx(72.0 / 612.0)
+    assert bb.x1 == pytest.approx(540.0 / 612.0)
+    assert bb.y0 == pytest.approx((792.0 - 720.0) / 792.0)
+    assert bb.y1 == pytest.approx((792.0 - 600.0) / 792.0)
+    assert bb.source_space == "pdf_points"
+
+
+def test_table_to_block_cells_and_html_and_extras():
+    pm = PageMeta(index=1, width=612.0, height=792.0)
+    block = CamelotTool(config=CamelotConfig(flavor="stream"))._table_to_block(
+        _fake_table(), page_index=1, page_meta=pm, table_seq=0
+    )
+    assert block.table is not None
+    assert block.table.rows == 1
+    assert block.table.cols == 2
+    assert block.table.html == "<table><tr><td>A</td></tr></table>"
+    assert {c.text for c in block.table.cells} == {"A", "B"}
+    assert block.parser_extras["camelot_accuracy"] == 98.5
+    assert block.parser_extras["camelot_order"] == 1
+    assert block.parser_extras["camelot_flavor"] == "stream"
+
+
+def test_run_maps_pages_arg_and_invokes_camelot(monkeypatch):
+    calls = {}
+
+    def fake_read_pdf(path, **kwargs):
+        calls.update(kwargs)
+        calls["path"] = path
+        return [_fake_table()]
+
+    import app.cdm.adapters.local_pipeline.tools.camelot_tool as mod
+    monkeypatch.setattr(mod.camelot, "read_pdf", fake_read_pdf)
+
+    pm = {1: PageMeta(index=1, width=612.0, height=792.0)}
+    result = CamelotTool(page_meta=pm).run("/tmp/x.pdf", pages=[1])
+    # 0-based page 1 → camelot 1-indexed "2"
+    assert calls["pages"] == "2"
+    assert calls["flavor"] == "lattice"
+    assert len(result.blocks) == 1
+    assert result.blocks[0].id == "camelot:1:0"
+    assert result.blocks[0].id in result.native_by_block

--- a/backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
@@ -92,3 +92,35 @@ def test_run_maps_pages_arg_and_invokes_camelot(monkeypatch):
     assert len(result.blocks) == 1
     assert result.blocks[0].id == "camelot:1:0"
     assert result.blocks[0].id in result.native_by_block
+
+
+def test_run_lattice_omits_stream_only_kwargs(monkeypatch):
+    """camelot rejects edge_tol/row_tol with flavor='lattice'."""
+    calls = {}
+
+    def fake_read_pdf(path, **kwargs):
+        calls.update(kwargs)
+        return []
+
+    import app.cdm.adapters.local_pipeline.tools.camelot_tool as mod
+    monkeypatch.setattr(mod.camelot, "read_pdf", fake_read_pdf)
+
+    CamelotTool(config=CamelotConfig(flavor="lattice")).run("/tmp/x.pdf")
+    assert "edge_tol" not in calls
+    assert "row_tol" not in calls
+
+
+def test_run_stream_includes_tol_kwargs(monkeypatch):
+    """edge_tol/row_tol are valid (and useful) for flavor='stream'."""
+    calls = {}
+
+    def fake_read_pdf(path, **kwargs):
+        calls.update(kwargs)
+        return []
+
+    import app.cdm.adapters.local_pipeline.tools.camelot_tool as mod
+    monkeypatch.setattr(mod.camelot, "read_pdf", fake_read_pdf)
+
+    CamelotTool(config=CamelotConfig(flavor="stream", edge_tol=40, row_tol=3)).run("/tmp/x.pdf")
+    assert calls["edge_tol"] == 40
+    assert calls["row_tol"] == 3

--- a/backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
@@ -1,20 +1,12 @@
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
 from app.cdm.adapters.local_pipeline.config import CamelotConfig
 from app.cdm.adapters.local_pipeline.tools.base import PageMeta
 from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
 from app.cdm.models import BlockRole
-
-
-class _FakeDF:
-    def to_html(self):
-        return "<table><tr><td>A</td></tr></table>"
-
-    @property
-    def shape(self):
-        return (1, 2)
 
 
 def _fake_cell(x1, y1, x2, y2, text):
@@ -25,7 +17,7 @@ def _fake_table():
     # camelot bottom-left origin; page is 792pt tall.
     return SimpleNamespace(
         page=2,
-        df=_FakeDF(),
+        df=pd.DataFrame([["A", "B"]]),  # 1 row, 2 cols
         parsing_report={"accuracy": 98.5, "order": 1, "page": 2, "whitespace": 12.0},
         _bbox=(72.0, 600.0, 540.0, 720.0),  # x1,y1,x2,y2 bottom-left
         cells=[[_fake_cell(72.0, 700.0, 300.0, 720.0, "A"),
@@ -66,11 +58,23 @@ def test_table_to_block_cells_and_html_and_extras():
     assert block.table is not None
     assert block.table.rows == 1
     assert block.table.cols == 2
-    assert block.table.html == "<table><tr><td>A</td></tr></table>"
+    assert "A" in block.table.html and "B" in block.table.html
     assert {c.text for c in block.table.cells} == {"A", "B"}
     assert block.parser_extras["camelot_accuracy"] == 98.5
     assert block.parser_extras["camelot_order"] == 1
     assert block.parser_extras["camelot_flavor"] == "stream"
+
+
+def test_table_to_block_populates_block_level_content():
+    """The TABLE block itself must carry text/markdown/html so it surfaces in
+    full_text / full_markdown (block.table alone is not rendered)."""
+    pm = PageMeta(index=1, width=612.0, height=792.0)
+    block = CamelotTool()._table_to_block(
+        _fake_table(), page_index=1, page_meta=pm, table_seq=0
+    )
+    assert "A" in block.text and "B" in block.text
+    assert block.markdown is not None and "A" in block.markdown
+    assert block.html is not None and "A" in block.html
 
 
 def test_run_maps_pages_arg_and_invokes_camelot(monkeypatch):

--- a/backend/tests/cdm/adapters/local_pipeline/test_config.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_config.py
@@ -1,0 +1,49 @@
+import pytest
+
+from app.cdm.adapters.local_pipeline.config import (
+    CamelotConfig,
+    FitzConfig,
+    LocalPipelineConfig,
+    build_pipeline_config,
+)
+
+
+def test_fitz_config_defaults():
+    c = FitzConfig()
+    assert c.min_chars_threshold == 10
+    assert c.include_images is True
+    assert c.span_detail is False
+
+
+def test_camelot_config_defaults():
+    c = CamelotConfig()
+    assert c.flavor == "lattice"
+    assert c.edge_tol == 50
+    assert c.row_tol == 2
+    assert c.copy_text == []
+
+
+def test_build_pipeline_config_fitz_only():
+    cfg = build_pipeline_config({
+        "tools": [{"tool_id": "fitz", "config": {"min_chars_threshold": 5}}],
+        "eviction_overlap_threshold": 0.4,
+    })
+    assert isinstance(cfg, LocalPipelineConfig)
+    assert cfg.eviction_overlap_threshold == 0.4
+    assert [t.tool_id for t in cfg.tools] == ["fitz"]
+
+
+def test_build_pipeline_config_fitz_and_camelot_order_preserved():
+    cfg = build_pipeline_config({
+        "tools": [
+            {"tool_id": "fitz", "config": {}},
+            {"tool_id": "camelot", "config": {"flavor": "stream"}},
+        ],
+    })
+    assert [t.tool_id for t in cfg.tools] == ["fitz", "camelot"]
+    assert cfg.eviction_overlap_threshold == 0.5  # default
+
+
+def test_build_pipeline_config_rejects_unknown_tool():
+    with pytest.raises(ValueError, match="unknown tool"):
+        build_pipeline_config({"tools": [{"tool_id": "bogus", "config": {}}]})

--- a/backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py
@@ -1,10 +1,25 @@
+import json
 from pathlib import Path
 
+import fitz
+
 from app.cdm.adapters.local_pipeline.config import FitzConfig
-from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool, _json_safe
 from app.cdm.models import BlockRole
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _make_image_pdf(path: Path) -> None:
+    """Write a one-page PDF containing an embedded raster image."""
+    src = fitz.open()
+    png = src.new_page().get_pixmap().tobytes("png")
+    src.close()
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_image(fitz.Rect(50, 50, 150, 150), stream=png)
+    doc.save(str(path))
+    doc.close()
 
 
 def test_fitz_tool_id():
@@ -50,3 +65,22 @@ def test_fitz_span_detail_on_records_spans():
     para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
     assert "spans" in para.parser_extras
     assert isinstance(para.parser_extras["spans"], list)
+
+
+def test_json_safe_strips_bytes():
+    out = _json_safe({"image": b"\x00\x01", "nested": [{"x": b"ab"}], "n": 3})
+    assert isinstance(out["image"], str)
+    assert isinstance(out["nested"][0]["x"], str)
+    assert out["n"] == 3
+    json.dumps(out)  # must not raise
+
+
+def test_fitz_raw_is_json_serializable_with_images(tmp_path):
+    pdf = tmp_path / "with_image.pdf"
+    _make_image_pdf(pdf)
+    result = FitzTool().run(pdf)
+    # Sanity: an image block was extracted as a FIGURE.
+    assert any(b.role == BlockRole.FIGURE for b in result.blocks)
+    # The raw audit data must be JSON-serializable (no raw image bytes).
+    json.dumps(result.raw)
+    json.dumps(result.native_by_block)

--- a/backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from app.cdm.adapters.local_pipeline.config import FitzConfig
+from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+from app.cdm.models import BlockRole
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_fitz_tool_id():
+    assert FitzTool().tool_id == "fitz"
+
+
+def test_fitz_extracts_paragraph_blocks_with_normalized_bbox():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    assert result.tool_id == "fitz"
+    paras = [b for b in result.blocks if b.role == BlockRole.PARAGRAPH]
+    assert len(paras) > 0
+    b = paras[0]
+    assert b.text.strip() != ""
+    assert b.bbox is not None
+    for v in (b.bbox.x0, b.bbox.y0, b.bbox.x1, b.bbox.y1):
+        assert 0.0 <= v <= 1.0
+    assert b.bbox.source_space == "pdf_points"
+    assert b.parser_extras["fitz_block_type"] == 0
+
+
+def test_fitz_provides_page_meta_for_every_page():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    assert set(result.page_meta.keys()) == {0, 1}
+    assert result.page_meta[0].width > 0
+    assert result.page_meta[0].height > 0
+
+
+def test_fitz_native_record_keyed_by_provisional_id():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    b = result.blocks[0]
+    assert b.id in result.native_by_block
+    assert "bbox" in result.native_by_block[b.id]
+
+
+def test_fitz_span_detail_off_by_default():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
+    assert "spans" not in para.parser_extras
+
+
+def test_fitz_span_detail_on_records_spans():
+    result = FitzTool(config=FitzConfig(span_detail=True)).run(FIXTURES / "simple_text.pdf")
+    para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
+    assert "spans" in para.parser_extras
+    assert isinstance(para.parser_extras["spans"], list)

--- a/backend/tests/cdm/adapters/local_pipeline/test_merger.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_merger.py
@@ -1,0 +1,77 @@
+from app.cdm.adapters.local_pipeline.merger import merge, overlap_fraction
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta, ToolResult
+from app.cdm.models import BBox, Block, BlockRole
+
+
+def _bbox(x0, y0, x1, y1):
+    return BBox(x0=x0, y0=y0, x1=x1, y1=y1)
+
+
+def test_overlap_fraction_full_containment():
+    table = _bbox(0.0, 0.0, 1.0, 1.0)
+    fitz = _bbox(0.1, 0.1, 0.2, 0.2)
+    assert overlap_fraction(table, fitz) == 1.0
+
+
+def test_overlap_fraction_no_overlap():
+    table = _bbox(0.0, 0.0, 0.1, 0.1)
+    fitz = _bbox(0.5, 0.5, 0.6, 0.6)
+    assert overlap_fraction(table, fitz) == 0.0
+
+
+def _fitz_result():
+    blocks = [
+        Block(id="fitz:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+              text="heading", page_index=0, bbox=_bbox(0.1, 0.05, 0.9, 0.1)),
+        Block(id="fitz:0:1", role=BlockRole.PARAGRAPH, native_type="text",
+              text="inside table", page_index=0, bbox=_bbox(0.2, 0.55, 0.8, 0.65)),
+    ]
+    return ToolResult(
+        tool_id="fitz", blocks=blocks,
+        page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
+        raw={"pages": {}},
+        native_by_block={"fitz:0:0": {"k": "h"}, "fitz:0:1": {"k": "t"}},
+    )
+
+
+def _camelot_result():
+    block = Block(id="camelot:0:0", role=BlockRole.TABLE, native_type="table",
+                  page_index=0, bbox=_bbox(0.1, 0.5, 0.9, 0.7))
+    return ToolResult(
+        tool_id="camelot", blocks=[block], page_meta={},
+        raw={"tables": []}, native_by_block={"camelot:0:0": {"acc": 99}},
+    )
+
+
+def test_merge_evicts_overlapping_fitz_block():
+    result = merge(_fitz_result(), _camelot_result(),
+                   source_document_id="doc1", eviction_overlap_threshold=0.5)
+    texts = [b.text for b in result.blocks]
+    assert "heading" in texts
+    assert "inside table" not in texts  # evicted by the table
+    assert result.raw_output["evicted"][0]["reason"] == "spatial_overlap"
+    assert result.raw_output["evicted"][0]["won_by"].startswith("doc1:0:")
+
+
+def test_merge_mints_block_ids_and_reading_order():
+    result = merge(_fitz_result(), _camelot_result(),
+                   source_document_id="doc1", eviction_overlap_threshold=0.5)
+    for b in result.blocks:
+        assert b.id.startswith("doc1:0:")
+        assert b.reading_order is not None
+    # heading (y0=0.05) comes before the table (y0=0.5)
+    ordered = sorted(result.blocks, key=lambda b: b.reading_order)
+    assert ordered[0].text == "heading"
+    assert ordered[1].role == BlockRole.TABLE
+
+
+def test_merge_raw_output_has_tool_block_maps():
+    result = merge(_fitz_result(), _camelot_result(),
+                   source_document_id="doc1", eviction_overlap_threshold=0.5)
+    ro = result.raw_output
+    assert set(ro["tools"].keys()) == {"fitz", "camelot"}
+    assert "raw" in ro["tools"]["fitz"]
+    assert "block_map" in ro["tools"]["camelot"]
+    # surviving table maps to its native record
+    table_id = next(b.id for b in result.blocks if b.role == BlockRole.TABLE)
+    assert ro["tools"]["camelot"]["block_map"][table_id] == {"acc": 99}

--- a/backend/tests/cdm/adapters/local_pipeline/test_tools_base.py
+++ b/backend/tests/cdm/adapters/local_pipeline/test_tools_base.py
@@ -1,0 +1,31 @@
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta, ToolResult, clamp01
+from app.cdm.models import Block, BlockRole
+
+
+def test_clamp01_bounds():
+    assert clamp01(-0.5) == 0.0
+    assert clamp01(1.5) == 1.0
+    assert clamp01(0.25) == 0.25
+
+
+def test_page_meta_defaults():
+    pm = PageMeta(index=0, width=612.0, height=792.0)
+    assert pm.unit == "points"
+    assert pm.rotation == 0
+
+
+def test_tool_result_holds_blocks_and_native_records():
+    block = Block(id="fitz:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+                  text="hi", page_index=0)
+    result = ToolResult(
+        tool_id="fitz",
+        blocks=[block],
+        page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
+        raw={"pages": {}},
+        native_by_block={"fitz:0:0": {"type": 0}},
+    )
+    assert result.tool_id == "fitz"
+    assert result.blocks[0].text == "hi"
+    assert result.native_by_block["fitz:0:0"] == {"type": 0}
+    assert result.warnings == []
+    assert result.duration_ms == 0

--- a/backend/tests/services/parsing/test_local_pipeline_runner.py
+++ b/backend/tests/services/parsing/test_local_pipeline_runner.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.cdm.models import BlockRole, ParserKind
+from app.cdm.source import ParseRunStatus, SourceDocument
+from app.services.parsing.errors import LocalPipelineRunError
+from app.services.parsing.local_pipeline_runner import run_local_pipeline
+
+FIXTURES = Path(__file__).parents[2] / "cdm" / "adapters" / "local_pipeline" / "fixtures"
+
+
+def _source() -> SourceDocument:
+    return SourceDocument(
+        id="doc-xyz",
+        sha256="a" * 64,
+        filename="simple_text.pdf",
+        mime_type="application/pdf",
+        byte_size=1234,
+        storage_uri=str(FIXTURES / "simple_text.pdf"),
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_local_pipeline_fitz_only_succeeds():
+    config = {
+        "tools": [{"tool_id": "fitz", "config": {}}],
+        "eviction_overlap_threshold": 0.5,
+    }
+    run, doc = await run_local_pipeline(
+        source=_source(),
+        file_path=str(FIXTURES / "simple_text.pdf"),
+        representation_kind="extract_rich",
+        config=config,
+        client=None,
+    )
+    assert run.parser == ParserKind.LOCAL_PIPELINE
+    assert run.status == ParseRunStatus.SUCCEEDED
+    assert run.source_document_id == "doc-xyz"
+    assert run.raw_payload is not None
+    assert "tools" in run.raw_payload
+    assert "fitz" in run.raw_payload["tools"]
+    assert doc.parse_run_id == run.id
+    assert doc.page_count == 2
+    assert any(b.role == BlockRole.PARAGRAPH for b in doc.blocks)
+    # every block id is namespaced to the source document
+    assert all(b.id.startswith("doc-xyz:") for b in doc.blocks)
+
+
+@pytest.mark.asyncio
+async def test_run_local_pipeline_wraps_failure(tmp_path):
+    config = {"tools": [{"tool_id": "fitz", "config": {}}]}
+    with pytest.raises(LocalPipelineRunError) as ei:
+        await run_local_pipeline(
+            source=_source(),
+            file_path=str(tmp_path / "does_not_exist.pdf"),
+            representation_kind="extract_rich",
+            config=config,
+            client=None,
+        )
+    assert ei.value.run.status == ParseRunStatus.FAILED
+    assert ei.value.run.parser == ParserKind.LOCAL_PIPELINE

--- a/backend/tests/services/parsing/test_local_pipeline_runner.py
+++ b/backend/tests/services/parsing/test_local_pipeline_runner.py
@@ -1,6 +1,8 @@
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import fitz
 import pytest
 
 from app.cdm.models import BlockRole, ParserKind
@@ -47,6 +49,32 @@ async def test_run_local_pipeline_fitz_only_succeeds():
     assert any(b.role == BlockRole.PARAGRAPH for b in doc.blocks)
     # every block id is namespaced to the source document
     assert all(b.id.startswith("doc-xyz:") for b in doc.blocks)
+
+
+@pytest.mark.asyncio
+async def test_run_local_pipeline_raw_payload_json_serializable_with_images(tmp_path):
+    """Regression: fitz image bytes must not break the JSON raw_payload column."""
+    pdf = tmp_path / "with_image.pdf"
+    src = fitz.open()
+    png = src.new_page().get_pixmap().tobytes("png")
+    src.close()
+    doc_pdf = fitz.open()
+    page = doc_pdf.new_page()
+    page.insert_image(fitz.Rect(50, 50, 150, 150), stream=png)
+    doc_pdf.save(str(pdf))
+    doc_pdf.close()
+
+    config = {"tools": [{"tool_id": "fitz", "config": {}}]}
+    run, _ = await run_local_pipeline(
+        source=_source(),
+        file_path=str(pdf),
+        representation_kind="extract_rich",
+        config=config,
+        client=None,
+    )
+    assert run.status == ParseRunStatus.SUCCEEDED
+    # Must serialize cleanly — this is what the parse_runs INSERT does.
+    json.dumps(run.raw_payload)
 
 
 @pytest.mark.asyncio

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3812,6 +3812,7 @@ dependencies = [
     { name = "scipy" },
     { name = "slowapi" },
     { name = "sqlalchemy" },
+    { name = "tabulate" },
     { name = "tiktoken" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -3874,6 +3875,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "tabulate", specifier = ">=0.10.0" },
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -387,6 +387,26 @@ wheels = [
 ]
 
 [[package]]
+name = "camelot-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "playa-pdf" },
+    { name = "pypdfium2" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6c/3b6057077feb802ce6ef4e2ebd11a50c12b7065aeb946cc0d9296d195246/camelot_py-2.0.0.tar.gz", hash = "sha256:e96891d30707b3e2f1c08cb7ae15eea67abe72485ca92c7025b6308ba37bd3cd", size = 140937, upload-time = "2026-06-04T16:31:28.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/30/e220f65dda2cea102f538ae64f29d6a7a96884cc0ec2d286adf7d2c9dd3d/camelot_py-2.0.0-py3-none-any.whl", hash = "sha256:c2c6c7e4b0cb422b8050624c1d54026a8b3af1d86b7d7951eddeb18854fbcfb6", size = 113176, upload-time = "2026-06-04T16:31:27.422Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2578,6 +2598,24 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
+    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3040,6 +3078,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "playa-pdf"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/d2/9575801a5e41fdffbac0fc356a7aae462e11f58473b3e78070185a9e7ced/playa_pdf-1.1.0.tar.gz", hash = "sha256:6414a0779fdcc96284588767738c2bd71ed3aa65a1a8fa647a4ab09dce4ff017", size = 8644947, upload-time = "2026-03-09T16:53:02.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/da/ab3528bd7496092bb011bd21a48f19496f07ea607660a720186d6e41c733/playa_pdf-1.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56dbaccca34dfc0613bec658b67ed67fb0fb4efaf49aab86c60236bfd934ec89", size = 8542589, upload-time = "2026-03-09T16:52:12.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/29/cc729b12de1f0ca02e19aed463e42f58836824f6fc5e493bd6c3562e59ba/playa_pdf-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ac45f8ac08f8ec17ac834a189772293bc9d52aadb51c3c5eb839fa1c7e79fcb", size = 8524481, upload-time = "2026-03-09T16:52:15.053Z" },
+    { url = "https://files.pythonhosted.org/packages/25/28/7a4a4a0e898dfa45af62452ebe53ce449dac60d67c29cb6ad783e7098a7a/playa_pdf-1.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ffa371cfa8e7b8b3f62eb8fa5cd85015095861a20d7d4943971dce7dd15461b", size = 9128263, upload-time = "2026-03-09T16:52:17.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/41/56995025d8aabd741974a79edc8518b67db5a46ce33e7852ef7378d0fa90/playa_pdf-1.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b27df269246e48946870817b3b7727fcc2e7cf12e605abb4df51efb0af12afee", size = 9219020, upload-time = "2026-03-09T16:52:19.906Z" },
+    { url = "https://files.pythonhosted.org/packages/61/94/65088538e5c218fefb52244f0a23f670378a55baf57af7e86904929adc2c/playa_pdf-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:699799f656757aab1fdd923bbd0c4ae5438efa6458c943524a0b9a8e8f5e076b", size = 8238029, upload-time = "2026-03-09T16:52:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d5/fb9b218f85cf84ec0941e26c5769578189036fcba328cc9eaa795db781eb/playa_pdf-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c50a79c88e3ed52944f85a694f0d6b5867fbed5d4c9c4a3b84d876858608b854", size = 8541999, upload-time = "2026-03-09T16:52:24.119Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a6/afc951b706d034e8dbf91250c5c9d81ce12a4af1dfad1c54a2925928be3b/playa_pdf-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:95335f17b96437d55e8e192e9c13f085db9ca84eef608ac706f177d5ade19a23", size = 8523735, upload-time = "2026-03-09T16:52:26.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/d36b2e43cfe7f0299da48639b13530cc1735a12da1da2140e1d7bc99f540/playa_pdf-1.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b6eed3179d42a5e2db99c33ff931ca89014c2af2d9104a787f6b9079dab4f71", size = 9122951, upload-time = "2026-03-09T16:52:28.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/da/6f309f16802cf77883a18390d5e22571922128393cc1533e7d769cfd80e8/playa_pdf-1.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:783b25ed0e5fa435e488ad11551c897d7c622b9ac8a1376ede6860c28eaf2c11", size = 9212307, upload-time = "2026-03-09T16:52:30.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/07/2c1b93ead3d094fa9a5a60817618d815ff6876fc28c04eb7acbd735d5562/playa_pdf-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a786292d382a768ee029ad3461b4ea92df04dea10879ee3f57a11c2388e89746", size = 8237909, upload-time = "2026-03-09T16:52:33.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/aa/861f2f855bdb174e21bbe82f924e686346b910cc73c69920bf9a0713c225/playa_pdf-1.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:50c5dcb8908c94127ccfde1af6490ecdec3ff2865447e36f178c1bdff77e3e8e", size = 8581750, upload-time = "2026-03-09T16:52:35.417Z" },
+    { url = "https://files.pythonhosted.org/packages/48/e2/0e4c84ec682304551676f7e3b7650eaf80cd8fb2c3017346a16267fd6336/playa_pdf-1.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8827714630de811c35fe79f97b9934b411567d3a3b869a3c0df8704fd0850efd", size = 8521648, upload-time = "2026-03-09T16:52:37.968Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/41/814ac75b62d3fce17ce22f491d093e6d1ee4b813e81bee1763006a4d08b0/playa_pdf-1.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e43afdc20cde1b77a9b4cb5804d9499d8c6966f34f3348abd4cd0541c591fe83", size = 9138846, upload-time = "2026-03-09T16:52:40.296Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b3/e88f78d860b5a5d1a45719266af96acefe2a99192227ad1ca0e57e59770b/playa_pdf-1.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7afcd077ef47ea86455534ecdf692448ceb1af636d2a38583f8e203d252f2d85", size = 9226716, upload-time = "2026-03-09T16:52:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ef/80b18e577fc4215b6e3382f8f1d804ea8c02f1f608960cd69701f396c109/playa_pdf-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:4cd365fd111b1cb2354a6f6ec8da47e9e5d70c5a768fbe9534eee5247c7cacd2", size = 8444577, upload-time = "2026-03-09T16:52:45.062Z" },
+    { url = "https://files.pythonhosted.org/packages/23/22/28dd08a117897deaa41a233a0d1544b4b104f6249e17ae79ba9f5a2083e1/playa_pdf-1.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:581a31bdf1bc9961addbd252050d0e9ed38dd1ad223a56c205680e90f7b72575", size = 8653957, upload-time = "2026-03-09T16:52:48.587Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c1/0e39c952d689dc573f298e9aec7166996c8e0da1e2c78d4e6cb13ef5a4f9/playa_pdf-1.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:457edd5abb9fc43aadcdd812371705851906b1d532a077a6c04981546cda4260", size = 8595523, upload-time = "2026-03-09T16:52:51.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/24/5da4532afe99a9c30f23d2366e919b0f6e5e36b624ab5b36354db59445d3/playa_pdf-1.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88b7ebf95cd7d02459a26a5a941411258b323f3202e33c13dcc867ae730abc73", size = 9486583, upload-time = "2026-03-09T16:52:53.701Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9f/7f582cb7cadb5865ffff53f1710e49202436af7bf81fba74f3a9664e7302/playa_pdf-1.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e548a7542036f89a622f1c11c2a9c40b8476090b04f3abc335a8dd20142060aa", size = 9588033, upload-time = "2026-03-09T16:52:56.023Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dc/525b0f415c2dc9f23eaec6a858c41ead974f4debe0fce7c2874a5050dea3/playa_pdf-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c52597802d86fdd61a71a6e7f8e4b48fae51cc5ae38fcc727a14b6d4c075f6bd", size = 8556709, upload-time = "2026-03-09T16:52:58.444Z" },
 ]
 
 [[package]]
@@ -3705,6 +3774,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "authlib" },
     { name = "bcrypt" },
+    { name = "camelot-py" },
     { name = "cryptography" },
     { name = "docling" },
     { name = "email-validator" },
@@ -3763,6 +3833,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "authlib", specifier = ">=1.3.0" },
     { name = "bcrypt", specifier = ">=5.0.0" },
+    { name = "camelot-py", specifier = ">=2.0.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "docling", specifier = ">=2.105.0" },
     { name = "email-validator", specifier = ">=2.3.0" },

--- a/docs/superpowers/plans/2026-06-25-local-pipeline-parse-iteration-2.md
+++ b/docs/superpowers/plans/2026-06-25-local-pipeline-parse-iteration-2.md
@@ -1,0 +1,2107 @@
+# Local Pipeline Parse — Iteration 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a local-first, config-driven PDF parse pipeline (`FitzTool` + `CamelotTool` + `LocalParseRunner`) that produces a clean CDM `ParsedDocument` with a full audit trail in `ParseRun.raw_payload`, plus a frontend UI to create `local_pipeline` parse runs.
+
+**Architecture:** Tools (`FitzTool`, `CamelotTool`) read a PDF and emit CDM `Block`s with **normalized** bboxes at their boundary (tools speak CDM, spec §5.1). A pure `merger` module runs the spatial-overlap eviction pass, mints final block IDs, and assembles the serializable `raw_output` audit dict. The `LocalPipelineAdapter` is a thin pure assembler: given merged blocks + page metadata it builds the `ParsedDocument`. `run_local_pipeline` orchestrates: run tools → merge → adapt → build `ParseRun`, returning `(ParseRun, ParsedDocument)` exactly like `run_llamaparse`. It is registered in `ParsingService._RUNNERS` under `ParserKind.LOCAL_PIPELINE`. The frontend adds a `local_pipeline` entry to the existing `PARSER_REGISTRY` and a `LocalPipelineConfig` component, reusing the existing create-parse-run flow (`POST /documents/{id}/parse-runs`).
+
+> **Design note — resolving spec §6.2 vs §6.3.** The spec assigns eviction to the adapter (§6.3) but also makes `raw_output` a runner step (§6.2). Because the `ParserAdapter.adapt` protocol returns only `ParsedDocument` while `raw_output` must be persisted on `ParseRun.raw_payload`, this plan places eviction + `raw_output` assembly in a pure `merger.py` (the spec's own §8 module: "eviction logic, bbox overlap math, raw_output assembly"). The runner calls the merger, persists `raw_output`, and hands the merged blocks to the adapter. This honors the two-layer runner/adapter split, keeps `ParsedDocument` clean (design principle §2), and keeps every module single-responsibility.
+
+**Tech Stack:** Python 3.12, PyMuPDF (`fitz`, already a dependency), `camelot-py` (to be added), Pydantic v2, FastAPI, pytest / pytest-asyncio. Frontend: React 18 + TypeScript, shadcn/ui, Vitest + React Testing Library.
+
+## Global Constraints
+
+- `ParserKind.LOCAL_PIPELINE = "local_pipeline"` already exists in `backend/app/cdm/models.py:14-21` — do **not** re-add it.
+- Block ID format (spec §6.2 step 4): `f"{source_document_id}:{page_index}:{reading_order}"` where `page_index` is 0-based and `reading_order` is the 0-based position in the merged, non-evicted block list for that page.
+- All `BBox` coordinates are normalized to `[0, 1]`, origin **top-left** (`BBox.space = CoordSpace.NORMALIZED`). Preserve native coords in `BBox.source_space` / `BBox.source_coords`.
+- fitz uses top-left origin → `x_norm = x / page.width`, `y_norm = y / page.height` (no axis flip). camelot uses bottom-left origin → flip: `y_top = page_height - y_camelot` before normalizing.
+- `ParsedDocument` stays clean: **no** tool attribution, eviction data, or raw output on it. All run concerns go in `ParseRun.raw_payload` (the CDM field is `raw_payload`, **not** `raw_output`).
+- `raw_output` schema is append-only: new tools add keys under `tools`; never rename existing keys.
+- Tools speak CDM at their boundary: `LocalTool.run()` returns CDM `Block`s, with the native record preserved separately for the audit trail.
+- `local_pipeline` requires **no** API key — `_resolve_parser_key` in `documents.py:64` returns `(None, None)` for it, and `ParsingService._clients.get(LOCAL_PIPELINE)` returns `None`. The runner accepts a `client` arg and ignores it.
+- Backend test command (override coverage addopts): `uv run --directory backend python -m pytest -o "addopts=" <path>`.
+- Frontend test command: `npm --prefix frontend run test` → maps to `npx vitest run`. Use `npx --prefix frontend vitest run <path>` for a single file.
+
+---
+
+## File Structure
+
+```
+backend/app/cdm/adapters/local_pipeline/
+  __init__.py            # (exists) export new symbols
+  config.py              # NEW — FitzConfig, CamelotConfig, LocalPipelineConfig, TOOL_REGISTRY, build_pipeline_config
+  probe.py               # (exists, iteration 1) — untouched
+  adapter.py             # NEW — LocalPipelineAdapter (pure assembler)
+  merger.py              # NEW — eviction, bbox overlap math, raw_output assembly, MergeResult
+  tools/
+    __init__.py          # NEW
+    base.py              # NEW — PageMeta, ToolResult, LocalTool protocol, clamp01
+    fitz_tool.py         # NEW — FitzTool
+    camelot_tool.py      # NEW — CamelotTool
+
+backend/app/services/parsing/
+  local_pipeline_runner.py   # NEW — run_local_pipeline
+  errors.py                  # MODIFY — add LocalPipelineRunError
+  parsing_service.py         # MODIFY — register runner in _RUNNERS
+
+backend/tests/cdm/adapters/local_pipeline/
+  fixtures/simple_text.pdf       # (exists) — reused
+  test_tools_base.py             # NEW
+  test_fitz_tool.py              # NEW
+  test_camelot_tool.py           # NEW
+  test_merger.py                 # NEW
+  test_adapter.py                # NEW
+backend/tests/services/parsing/
+  test_local_pipeline_runner.py  # NEW
+
+frontend/src/types/parsing.ts                              # MODIFY — local pipeline config types
+frontend/src/components/documents/ParseMethodSelector.tsx  # MODIFY — register local_pipeline + render config
+frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx       # NEW
+frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx  # NEW
+```
+
+Backend dependency: `camelot-py` (added in Task 1).
+
+---
+
+## Task 1: Add camelot dependency + runner error class
+
+**Files:**
+- Modify: `backend/pyproject.toml` (dependencies array, around line 69-72)
+- Modify: `backend/app/services/parsing/errors.py:27`
+
+**Interfaces:**
+- Produces: `camelot` importable in backend; `LocalPipelineRunError(ParseRunError)` for Task 9.
+
+- [ ] **Step 1: Add camelot-py**
+
+Run: `uv add --directory backend camelot-py`
+
+Expected: `pyproject.toml` `dependencies` gains a `camelot-py>=0.11.0` (or current) line and `uv.lock` updates.
+
+> Note: camelot's `lattice` flavor needs Ghostscript + OpenCV at runtime. The unit tests in this plan mock `camelot.read_pdf` so they do **not** require Ghostscript. The container/runtime install of Ghostscript is a deployment concern tracked separately; flag it in the PR description.
+
+- [ ] **Step 2: Verify import works**
+
+Run: `uv run --directory backend python -c "import camelot; print('ok')"`
+Expected: prints `ok` (Ghostscript warnings are acceptable).
+
+- [ ] **Step 3: Add the runner error class**
+
+In `backend/app/services/parsing/errors.py`, after the `DoclingRunError` class (line 25-26), add:
+
+```python
+class LocalPipelineRunError(ParseRunError):
+    """Raised by local_pipeline_runner when a tool invocation fails."""
+```
+
+- [ ] **Step 4: Verify it imports**
+
+Run: `uv run --directory backend python -c "from app.services.parsing.errors import LocalPipelineRunError; print('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/pyproject.toml backend/uv.lock backend/app/services/parsing/errors.py
+git commit -m "feat(local-pipeline): add camelot-py dep and LocalPipelineRunError"
+```
+
+---
+
+## Task 2: Tool contracts (base.py)
+
+**Files:**
+- Create: `backend/app/cdm/adapters/local_pipeline/tools/__init__.py`
+- Create: `backend/app/cdm/adapters/local_pipeline/tools/base.py`
+- Test: `backend/tests/cdm/adapters/local_pipeline/test_tools_base.py`
+
+**Interfaces:**
+- Produces (consumed by Tasks 4-9):
+  - `PageMeta(index: int, width: float, height: float, unit: str = "points", rotation: int = 0)` — Pydantic model.
+  - `ToolResult(tool_id: str, blocks: list[Block], page_meta: dict[int, PageMeta], raw: Any = None, native_by_block: dict[str, Any] = {}, warnings: list[str] = [], duration_ms: int = 0)` — Pydantic model, `arbitrary_types_allowed=True`. `native_by_block` maps a block's **provisional** id to its serializable native record.
+  - `LocalTool` Protocol with `tool_id: str` and `run(self, pdf_path: Path, pages: Optional[list[int]] = None) -> ToolResult`.
+  - `clamp01(v: float) -> float` — clamps to `[0.0, 1.0]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/cdm/adapters/local_pipeline/test_tools_base.py`:
+
+```python
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta, ToolResult, clamp01
+from app.cdm.models import Block, BlockRole
+
+
+def test_clamp01_bounds():
+    assert clamp01(-0.5) == 0.0
+    assert clamp01(1.5) == 1.0
+    assert clamp01(0.25) == 0.25
+
+
+def test_page_meta_defaults():
+    pm = PageMeta(index=0, width=612.0, height=792.0)
+    assert pm.unit == "points"
+    assert pm.rotation == 0
+
+
+def test_tool_result_holds_blocks_and_native_records():
+    block = Block(id="fitz:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+                  text="hi", page_index=0)
+    result = ToolResult(
+        tool_id="fitz",
+        blocks=[block],
+        page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
+        raw={"pages": {}},
+        native_by_block={"fitz:0:0": {"type": 0}},
+    )
+    assert result.tool_id == "fitz"
+    assert result.blocks[0].text == "hi"
+    assert result.native_by_block["fitz:0:0"] == {"type": 0}
+    assert result.warnings == []
+    assert result.duration_ms == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_tools_base.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.cdm.adapters.local_pipeline.tools'`.
+
+- [ ] **Step 3: Create the package init**
+
+Create `backend/app/cdm/adapters/local_pipeline/tools/__init__.py` (empty file):
+
+```python
+```
+
+- [ ] **Step 4: Implement base.py**
+
+Create `backend/app/cdm/adapters/local_pipeline/tools/base.py`:
+
+```python
+"""Contracts shared by all local parsing tools.
+
+A LocalTool reads a PDF and returns CDM Blocks (with normalized bboxes) plus
+the native records that produced them, for the audit trail.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+from app.cdm.models import Block
+
+
+def clamp01(v: float) -> float:
+    """Clamp a coordinate fraction into the [0, 1] range."""
+    return max(0.0, min(1.0, v))
+
+
+class PageMeta(BaseModel):
+    """Authoritative page geometry, sourced from FitzTool."""
+    index: int
+    width: float       # PDF points
+    height: float      # PDF points
+    unit: str = "points"
+    rotation: int = 0  # degrees
+
+
+class ToolResult(BaseModel):
+    """Output of one LocalTool.run() invocation."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    tool_id: str
+    blocks: List[Block]
+    page_meta: Dict[int, PageMeta]          # keyed by 0-based page index
+    raw: Any = None                          # serializable native dump
+    native_by_block: Dict[str, Any] = {}     # provisional block id -> native record
+    warnings: List[str] = []
+    duration_ms: int = 0
+
+
+@runtime_checkable
+class LocalTool(Protocol):
+    tool_id: str
+
+    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult: ...
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_tools_base.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/tools/ backend/tests/cdm/adapters/local_pipeline/test_tools_base.py
+git commit -m "feat(local-pipeline): add LocalTool contracts (PageMeta, ToolResult, clamp01)"
+```
+
+---
+
+## Task 3: Tool configs + pipeline config (config.py)
+
+**Files:**
+- Create: `backend/app/cdm/adapters/local_pipeline/config.py`
+- Test: `backend/tests/cdm/adapters/local_pipeline/test_config.py`
+
+**Interfaces:**
+- Consumes: `FitzTool`/`CamelotTool` classes are referenced lazily inside `build_pipeline_config` (defined in Tasks 4-5); to keep this task self-contained, `TOOL_REGISTRY` maps `tool_id -> (config_class)` only, and `build_pipeline_config` imports tool classes at call time.
+- Produces (consumed by Task 9 runner):
+  - `FitzConfig(min_chars_threshold: int = 10, include_images: bool = True, span_detail: bool = False)`.
+  - `CamelotConfig(flavor: Literal["lattice","stream"] = "lattice", edge_tol: int = 50, row_tol: int = 2, copy_text: list[str] = [])`.
+  - `LocalPipelineConfig` — runtime dataclass: `tools: list[LocalTool]`, `eviction_overlap_threshold: float = 0.5`.
+  - `build_pipeline_config(config: dict, page_meta_provider=None) -> LocalPipelineConfig` — builds tool instances from the serialized config dict.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/cdm/adapters/local_pipeline/test_config.py`:
+
+```python
+import pytest
+
+from app.cdm.adapters.local_pipeline.config import (
+    CamelotConfig,
+    FitzConfig,
+    LocalPipelineConfig,
+    build_pipeline_config,
+)
+
+
+def test_fitz_config_defaults():
+    c = FitzConfig()
+    assert c.min_chars_threshold == 10
+    assert c.include_images is True
+    assert c.span_detail is False
+
+
+def test_camelot_config_defaults():
+    c = CamelotConfig()
+    assert c.flavor == "lattice"
+    assert c.edge_tol == 50
+    assert c.row_tol == 2
+    assert c.copy_text == []
+
+
+def test_build_pipeline_config_fitz_only():
+    cfg = build_pipeline_config({
+        "tools": [{"tool_id": "fitz", "config": {"min_chars_threshold": 5}}],
+        "eviction_overlap_threshold": 0.4,
+    })
+    assert isinstance(cfg, LocalPipelineConfig)
+    assert cfg.eviction_overlap_threshold == 0.4
+    assert [t.tool_id for t in cfg.tools] == ["fitz"]
+
+
+def test_build_pipeline_config_fitz_and_camelot_order_preserved():
+    cfg = build_pipeline_config({
+        "tools": [
+            {"tool_id": "fitz", "config": {}},
+            {"tool_id": "camelot", "config": {"flavor": "stream"}},
+        ],
+    })
+    assert [t.tool_id for t in cfg.tools] == ["fitz", "camelot"]
+    assert cfg.eviction_overlap_threshold == 0.5  # default
+
+
+def test_build_pipeline_config_rejects_unknown_tool():
+    with pytest.raises(ValueError, match="unknown tool"):
+        build_pipeline_config({"tools": [{"tool_id": "bogus", "config": {}}]})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_config.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `config`.
+
+- [ ] **Step 3: Implement config.py**
+
+Create `backend/app/cdm/adapters/local_pipeline/config.py`:
+
+```python
+"""Configs for the local pipeline tools and the pipeline itself.
+
+The per-tool configs are Pydantic models (serializable → ParseRun.config).
+LocalPipelineConfig is a runtime object holding instantiated tools; it is NOT
+persisted — the runner persists the raw config dict it received.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel
+
+from app.cdm.adapters.local_pipeline.tools.base import LocalTool, PageMeta
+
+
+class FitzConfig(BaseModel):
+    min_chars_threshold: int = 10   # pages below → emit warning
+    include_images: bool = True      # emit FIGURE blocks for image blocks
+    span_detail: bool = False        # store full span list in parser_extras
+
+
+class CamelotConfig(BaseModel):
+    flavor: Literal["lattice", "stream"] = "lattice"
+    edge_tol: int = 50
+    row_tol: int = 2
+    copy_text: List[str] = []
+
+
+# tool_id -> the Pydantic config class that validates its per-tool config dict.
+TOOL_REGISTRY: Dict[str, type[BaseModel]] = {
+    "fitz": FitzConfig,
+    "camelot": CamelotConfig,
+}
+
+
+@dataclass
+class LocalPipelineConfig:
+    """Runtime pipeline config — ordered tools (later = higher priority)."""
+    tools: List[LocalTool]
+    eviction_overlap_threshold: float = 0.5
+
+
+def build_pipeline_config(
+    config: Dict[str, Any],
+    page_meta: Optional[Dict[int, PageMeta]] = None,
+) -> LocalPipelineConfig:
+    """Build a runtime LocalPipelineConfig from a serialized config dict.
+
+    `page_meta` is passed to CamelotTool for bbox y-flip (the runner supplies
+    FitzTool's page_meta after FitzTool completes; for fitz-only configs it is
+    unused).
+    """
+    # Imported here to avoid a circular import (tools import nothing from config).
+    from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
+    from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+
+    tools: List[LocalTool] = []
+    for entry in config.get("tools", []):
+        tool_id = entry.get("tool_id")
+        raw_cfg = entry.get("config", {}) or {}
+        cfg_cls = TOOL_REGISTRY.get(tool_id)
+        if cfg_cls is None:
+            raise ValueError(f"unknown tool: {tool_id!r}")
+        tool_cfg = cfg_cls.model_validate(raw_cfg)
+        if tool_id == "fitz":
+            tools.append(FitzTool(config=tool_cfg))  # type: ignore[arg-type]
+        elif tool_id == "camelot":
+            tools.append(CamelotTool(config=tool_cfg, page_meta=page_meta or {}))  # type: ignore[arg-type]
+
+    threshold = config.get("eviction_overlap_threshold", 0.5)
+    return LocalPipelineConfig(tools=tools, eviction_overlap_threshold=threshold)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_config.py -v`
+Expected: PASS (5 tests). (This depends on Tasks 4 & 5 for the import inside `build_pipeline_config`; if running this task before 4-5, the 3 tests not calling `build_pipeline_config` pass and the 2 that do will error on import. Implement Tasks 4-5 then re-run — they are split out below. To keep TDD green, mark Step 4 done only after Task 5.)
+
+> **Sequencing note:** `build_pipeline_config` imports `FitzTool`/`CamelotTool` at call time. Implement Tasks 4 and 5 before relying on the two `build_pipeline_config` tests. The first three tests (config defaults) pass immediately.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/config.py backend/tests/cdm/adapters/local_pipeline/test_config.py
+git commit -m "feat(local-pipeline): add FitzConfig, CamelotConfig, LocalPipelineConfig builder"
+```
+
+---
+
+## Task 4: FitzTool
+
+**Files:**
+- Create: `backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py`
+- Test: `backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py`
+
+**Interfaces:**
+- Consumes: `FitzConfig` (Task 3), `PageMeta`/`ToolResult`/`clamp01` (Task 2), `Block`/`BlockRole`/`BBox` (CDM).
+- Produces: `FitzTool(config: FitzConfig | None = None)` with `tool_id = "fitz"` and `run(pdf_path, pages=None) -> ToolResult`. Provisional block ids: `f"fitz:{page_index}:{native_block_index}"`. `parser_extras["fitz_block_type"]` = 0 (text) or 1 (image).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py`:
+
+```python
+from pathlib import Path
+
+from app.cdm.adapters.local_pipeline.config import FitzConfig
+from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+from app.cdm.models import BlockRole
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_fitz_tool_id():
+    assert FitzTool().tool_id == "fitz"
+
+
+def test_fitz_extracts_paragraph_blocks_with_normalized_bbox():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    assert result.tool_id == "fitz"
+    paras = [b for b in result.blocks if b.role == BlockRole.PARAGRAPH]
+    assert len(paras) > 0
+    b = paras[0]
+    assert b.text.strip() != ""
+    assert b.bbox is not None
+    for v in (b.bbox.x0, b.bbox.y0, b.bbox.x1, b.bbox.y1):
+        assert 0.0 <= v <= 1.0
+    assert b.bbox.source_space == "pdf_points"
+    assert b.parser_extras["fitz_block_type"] == 0
+
+
+def test_fitz_provides_page_meta_for_every_page():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    assert set(result.page_meta.keys()) == {0, 1}
+    assert result.page_meta[0].width > 0
+    assert result.page_meta[0].height > 0
+
+
+def test_fitz_native_record_keyed_by_provisional_id():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    b = result.blocks[0]
+    assert b.id in result.native_by_block
+    assert "bbox" in result.native_by_block[b.id]
+
+
+def test_fitz_span_detail_off_by_default():
+    result = FitzTool().run(FIXTURES / "simple_text.pdf")
+    para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
+    assert "spans" not in para.parser_extras
+
+
+def test_fitz_span_detail_on_records_spans():
+    result = FitzTool(config=FitzConfig(span_detail=True)).run(FIXTURES / "simple_text.pdf")
+    para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
+    assert "spans" in para.parser_extras
+    assert isinstance(para.parser_extras["spans"], list)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_fitz_tool.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `fitz_tool`.
+
+- [ ] **Step 3: Implement fitz_tool.py**
+
+Create `backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py`:
+
+```python
+"""FitzTool — text + image extraction via PyMuPDF. Emits CDM Blocks."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import fitz  # PyMuPDF
+
+from app.cdm.adapters.local_pipeline.config import FitzConfig
+from app.cdm.adapters.local_pipeline.tools.base import (
+    PageMeta,
+    ToolResult,
+    clamp01,
+)
+from app.cdm.models import BBox, Block, BlockRole
+
+
+def _block_text(native_block: Dict[str, Any]) -> str:
+    """Join span texts within a fitz text block into a single string."""
+    parts: List[str] = []
+    for line in native_block.get("lines", []):
+        line_text = "".join(span.get("text", "") for span in line.get("spans", []))
+        parts.append(line_text)
+    return "\n".join(parts).strip()
+
+
+def _spans(native_block: Dict[str, Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for line in native_block.get("lines", []):
+        for span in line.get("spans", []):
+            out.append({
+                "text": span.get("text", ""),
+                "font": span.get("font"),
+                "size": span.get("size"),
+                "flags": span.get("flags"),
+                "bbox": span.get("bbox"),
+            })
+    return out
+
+
+class FitzTool:
+    tool_id = "fitz"
+
+    def __init__(self, config: Optional[FitzConfig] = None) -> None:
+        self.config = config or FitzConfig()
+
+    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+        t0 = time.perf_counter()
+        blocks: List[Block] = []
+        page_meta: Dict[int, PageMeta] = {}
+        native_raw: Dict[int, Any] = {}
+        native_by_block: Dict[str, Any] = {}
+        warnings: List[str] = []
+
+        doc = fitz.open(str(pdf_path))
+        try:
+            for i in range(len(doc)):
+                if pages is not None and i not in pages:
+                    continue
+                page = doc[i]
+                pd = page.get_text("dict")
+                width = float(pd["width"])
+                height = float(pd["height"])
+                page_meta[i] = PageMeta(
+                    index=i, width=width, height=height, rotation=page.rotation
+                )
+                native_raw[i] = pd
+
+                char_count = 0
+                for bi, blk in enumerate(pd.get("blocks", [])):
+                    btype = blk.get("type", 0)
+                    x0, y0, x1, y1 = blk["bbox"]
+                    bbox = BBox(
+                        x0=clamp01(x0 / width),
+                        y0=clamp01(y0 / height),
+                        x1=clamp01(x1 / width),
+                        y1=clamp01(y1 / height),
+                        source_space="pdf_points",
+                        source_coords=(float(x0), float(y0), float(x1), float(y1)),
+                    )
+                    prov_id = f"fitz:{i}:{bi}"
+
+                    if btype == 0:
+                        text = _block_text(blk)
+                        char_count += len(text)
+                        extras: Dict[str, Any] = {"fitz_block_type": 0}
+                        if self.config.span_detail:
+                            extras["spans"] = _spans(blk)
+                        block = Block(
+                            id=prov_id,
+                            role=BlockRole.PARAGRAPH,
+                            native_type="text",
+                            text=text,
+                            page_index=i,
+                            bbox=bbox,
+                            parser_extras=extras,
+                        )
+                        blocks.append(block)
+                        native_by_block[prov_id] = blk
+                    elif btype == 1 and self.config.include_images:
+                        block = Block(
+                            id=prov_id,
+                            role=BlockRole.FIGURE,
+                            native_type="image",
+                            page_index=i,
+                            bbox=bbox,
+                            parser_extras={"fitz_block_type": 1},
+                        )
+                        blocks.append(block)
+                        native_by_block[prov_id] = blk
+
+                if char_count < self.config.min_chars_threshold:
+                    warnings.append(
+                        f"page {i}: {char_count} chars below threshold "
+                        f"{self.config.min_chars_threshold} (possible CID corruption or scan)"
+                    )
+        finally:
+            doc.close()
+
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks=blocks,
+            page_meta=page_meta,
+            raw={"pages": native_raw},
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_fitz_tool.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/tools/fitz_tool.py backend/tests/cdm/adapters/local_pipeline/test_fitz_tool.py
+git commit -m "feat(local-pipeline): add FitzTool (text + image extraction → CDM)"
+```
+
+---
+
+## Task 5: CamelotTool
+
+**Files:**
+- Create: `backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py`
+- Test: `backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py`
+
+**Interfaces:**
+- Consumes: `CamelotConfig` (Task 3), `PageMeta`/`ToolResult`/`clamp01` (Task 2), `Block`/`BlockRole`/`BBox`/`Table`/`Cell` (CDM).
+- Produces: `CamelotTool(config: CamelotConfig | None = None, page_meta: dict[int, PageMeta] | None = None)` with `tool_id = "camelot"` and `run(pdf_path, pages=None) -> ToolResult`. Provisional block ids: `f"camelot:{page_index}:{table_seq}"`. Internal pure method `_table_to_block(table, page_index, page_meta, table_seq) -> Block` testable with a duck-typed fake. Camelot 1-indexed page numbers are converted to 0-based (`table.page - 1`); y-flip uses `page_meta[page_index].height`.
+
+> **Camelot Table attributes used:** `table.page` (1-indexed int), `table.df` (pandas DataFrame), `table.parsing_report` (dict: `accuracy`, `order`, `page`, `whitespace`), `table._bbox` (tuple `(x1, y1, x2, y2)` in PDF points, **bottom-left** origin), `table.cells` (list of rows; each cell has `.x1, .y1, .x2, .y2, .text`). These are stable across camelot 0.10–0.11.
+
+- [ ] **Step 1: Write the failing test (pure conversion, no Ghostscript)**
+
+Create `backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py`:
+
+```python
+from types import SimpleNamespace
+
+import pytest
+
+from app.cdm.adapters.local_pipeline.config import CamelotConfig
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta
+from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
+from app.cdm.models import BlockRole
+
+
+class _FakeDF:
+    def to_html(self):
+        return "<table><tr><td>A</td></tr></table>"
+
+    @property
+    def shape(self):
+        return (1, 2)
+
+
+def _fake_cell(x1, y1, x2, y2, text):
+    return SimpleNamespace(x1=x1, y1=y1, x2=x2, y2=y2, text=text)
+
+
+def _fake_table():
+    # camelot bottom-left origin; page is 792pt tall.
+    return SimpleNamespace(
+        page=2,
+        df=_FakeDF(),
+        parsing_report={"accuracy": 98.5, "order": 1, "page": 2, "whitespace": 12.0},
+        _bbox=(72.0, 600.0, 540.0, 720.0),  # x1,y1,x2,y2 bottom-left
+        cells=[[_fake_cell(72.0, 700.0, 300.0, 720.0, "A"),
+                _fake_cell(300.0, 700.0, 540.0, 720.0, "B")]],
+    )
+
+
+def test_camelot_tool_id():
+    assert CamelotTool().tool_id == "camelot"
+
+
+def test_table_to_block_role_and_page_index():
+    tool = CamelotTool(page_meta={1: PageMeta(index=1, width=612.0, height=792.0)})
+    block = tool._table_to_block(_fake_table(), page_index=1, page_meta=PageMeta(index=1, width=612.0, height=792.0), table_seq=0)
+    assert block.role == BlockRole.TABLE
+    assert block.page_index == 1
+    assert block.id == "camelot:1:0"
+
+
+def test_table_to_block_bbox_y_flipped_and_normalized():
+    pm = PageMeta(index=1, width=612.0, height=792.0)
+    block = CamelotTool()._table_to_block(_fake_table(), page_index=1, page_meta=pm, table_seq=0)
+    bb = block.bbox
+    # bottom-left (72,600,540,720) → top-left y: y0=(792-720)/792, y1=(792-600)/792
+    assert bb.x0 == pytest.approx(72.0 / 612.0)
+    assert bb.x1 == pytest.approx(540.0 / 612.0)
+    assert bb.y0 == pytest.approx((792.0 - 720.0) / 792.0)
+    assert bb.y1 == pytest.approx((792.0 - 600.0) / 792.0)
+    assert bb.source_space == "pdf_points"
+
+
+def test_table_to_block_cells_and_html_and_extras():
+    pm = PageMeta(index=1, width=612.0, height=792.0)
+    block = CamelotTool(config=CamelotConfig(flavor="stream"))._table_to_block(
+        _fake_table(), page_index=1, page_meta=pm, table_seq=0
+    )
+    assert block.table is not None
+    assert block.table.rows == 1
+    assert block.table.cols == 2
+    assert block.table.html == "<table><tr><td>A</td></tr></table>"
+    assert {c.text for c in block.table.cells} == {"A", "B"}
+    assert block.parser_extras["camelot_accuracy"] == 98.5
+    assert block.parser_extras["camelot_order"] == 1
+    assert block.parser_extras["camelot_flavor"] == "stream"
+
+
+def test_run_maps_pages_arg_and_invokes_camelot(monkeypatch):
+    calls = {}
+
+    def fake_read_pdf(path, **kwargs):
+        calls.update(kwargs)
+        calls["path"] = path
+        return [_fake_table()]
+
+    import app.cdm.adapters.local_pipeline.tools.camelot_tool as mod
+    monkeypatch.setattr(mod.camelot, "read_pdf", fake_read_pdf)
+
+    pm = {1: PageMeta(index=1, width=612.0, height=792.0)}
+    result = CamelotTool(page_meta=pm).run("/tmp/x.pdf", pages=[1])
+    # 0-based page 1 → camelot 1-indexed "2"
+    assert calls["pages"] == "2"
+    assert calls["flavor"] == "lattice"
+    assert len(result.blocks) == 1
+    assert result.blocks[0].id == "camelot:1:0"
+    assert result.blocks[0].id in result.native_by_block
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_camelot_tool.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `camelot_tool`.
+
+- [ ] **Step 3: Implement camelot_tool.py**
+
+Create `backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py`:
+
+```python
+"""CamelotTool — table extraction via camelot-py. Emits CDM TABLE Blocks.
+
+Camelot uses 1-indexed page numbers and a bottom-left coordinate origin.
+This tool converts to 0-based page indices and top-left normalized bboxes
+using page geometry supplied by FitzTool (via `page_meta`).
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import camelot
+
+from app.cdm.adapters.local_pipeline.config import CamelotConfig
+from app.cdm.adapters.local_pipeline.tools.base import (
+    PageMeta,
+    ToolResult,
+    clamp01,
+)
+from app.cdm.models import BBox, Block, BlockRole, Cell, Table
+
+
+class CamelotTool:
+    tool_id = "camelot"
+
+    def __init__(
+        self,
+        config: Optional[CamelotConfig] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+    ) -> None:
+        self.config = config or CamelotConfig()
+        self.page_meta = page_meta or {}
+
+    @staticmethod
+    def _pages_arg(pages: Optional[List[int]]) -> str:
+        """Translate 0-based CDM page indices to camelot's 1-indexed string."""
+        if not pages:
+            return "1-end"
+        return ",".join(str(p + 1) for p in sorted(pages))
+
+    def _norm_bbox(self, native_bbox, page_meta: PageMeta) -> BBox:
+        x1, y1, x2, y2 = native_bbox  # bottom-left origin
+        w, h = page_meta.width, page_meta.height
+        # Flip y: top-left y = page_height - bottom_left_y.
+        return BBox(
+            x0=clamp01(min(x1, x2) / w),
+            y0=clamp01((h - max(y1, y2)) / h),
+            x1=clamp01(max(x1, x2) / w),
+            y1=clamp01((h - min(y1, y2)) / h),
+            source_space="pdf_points",
+            source_coords=(float(x1), float(y1), float(x2), float(y2)),
+        )
+
+    def _cells(self, table: Any, page_meta: PageMeta) -> List[Cell]:
+        cells: List[Cell] = []
+        for r, row in enumerate(table.cells):
+            for c, cell in enumerate(row):
+                cells.append(Cell(
+                    row=r,
+                    col=c,
+                    text=(cell.text or "").strip(),
+                    bbox=self._norm_bbox(
+                        (cell.x1, cell.y1, cell.x2, cell.y2), page_meta
+                    ),
+                ))
+        return cells
+
+    def _table_to_block(
+        self, table: Any, page_index: int, page_meta: Optional[PageMeta], table_seq: int
+    ) -> Block:
+        report = table.parsing_report or {}
+        rows, cols = table.df.shape
+        cdm_table = Table(
+            rows=int(rows),
+            cols=int(cols),
+            cells=self._cells(table, page_meta) if page_meta else [],
+            html=table.df.to_html(),
+        )
+        bbox = self._norm_bbox(table._bbox, page_meta) if page_meta else None
+        return Block(
+            id=f"camelot:{page_index}:{table_seq}",
+            role=BlockRole.TABLE,
+            native_type="table",
+            page_index=page_index,
+            bbox=bbox,
+            table=cdm_table,
+            parser_extras={
+                "camelot_accuracy": report.get("accuracy"),
+                "camelot_order": report.get("order"),
+                "camelot_flavor": self.config.flavor,
+            },
+        )
+
+    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+        t0 = time.perf_counter()
+        warnings: List[str] = []
+        blocks: List[Block] = []
+        native_by_block: Dict[str, Any] = {}
+        raw_tables: List[Dict[str, Any]] = []
+
+        read_kwargs: Dict[str, Any] = {
+            "flavor": self.config.flavor,
+            "pages": self._pages_arg(pages),
+            "edge_tol": self.config.edge_tol,
+            "row_tol": self.config.row_tol,
+        }
+        if self.config.copy_text:
+            read_kwargs["copy_text"] = self.config.copy_text
+
+        tables = camelot.read_pdf(str(pdf_path), **read_kwargs)
+
+        seq_by_page: Dict[int, int] = {}
+        for table in tables:
+            page_index = int(table.page) - 1
+            seq = seq_by_page.get(page_index, 0)
+            seq_by_page[page_index] = seq + 1
+            pm = self.page_meta.get(page_index)
+            if pm is None:
+                warnings.append(
+                    f"page {page_index}: no page_meta; table bbox omitted"
+                )
+            block = self._table_to_block(table, page_index, pm, seq)
+            blocks.append(block)
+            native_record = {
+                "page": int(table.page),
+                "parsing_report": table.parsing_report,
+                "html": table.df.to_html(),
+            }
+            native_by_block[block.id] = native_record
+            raw_tables.append(native_record)
+
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks=blocks,
+            page_meta=self.page_meta,
+            raw={"tables": raw_tables},
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_camelot_tool.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Run the Task 3 config tests now that tools exist**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_config.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/tools/camelot_tool.py backend/tests/cdm/adapters/local_pipeline/test_camelot_tool.py
+git commit -m "feat(local-pipeline): add CamelotTool (table extraction → CDM with y-flip)"
+```
+
+---
+
+## Task 6: Merger — eviction, block-id minting, raw_output (merger.py)
+
+**Files:**
+- Create: `backend/app/cdm/adapters/local_pipeline/merger.py`
+- Test: `backend/tests/cdm/adapters/local_pipeline/test_merger.py`
+
+**Interfaces:**
+- Consumes: `ToolResult` (Task 2), `Block`/`BBox` (CDM).
+- Produces (consumed by Tasks 7-9):
+  - `overlap_fraction(table_bbox: BBox, fitz_bbox: BBox) -> float` — intersection area / area(fitz_bbox), in normalized space.
+  - `@dataclass MergeResult: blocks: list[Block]; raw_output: dict[str, Any]`.
+  - `merge(fitz_result: ToolResult, camelot_result: ToolResult, *, source_document_id: str, eviction_overlap_threshold: float = 0.5) -> MergeResult`. Final blocks: camelot TABLE blocks win; fitz blocks overlapping a TABLE beyond threshold are evicted. IDs minted `f"{source_document_id}:{page}:{reading_order}"`; per-page reading order sorts by `(bbox.y0, bbox.x0)` (blocks without bbox sort last). `raw_output` shape per Global Constraints / spec §6.2 step 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/cdm/adapters/local_pipeline/test_merger.py`:
+
+```python
+from app.cdm.adapters.local_pipeline.merger import merge, overlap_fraction
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta, ToolResult
+from app.cdm.models import BBox, Block, BlockRole
+
+
+def _bbox(x0, y0, x1, y1):
+    return BBox(x0=x0, y0=y0, x1=x1, y1=y1)
+
+
+def test_overlap_fraction_full_containment():
+    table = _bbox(0.0, 0.0, 1.0, 1.0)
+    fitz = _bbox(0.1, 0.1, 0.2, 0.2)
+    assert overlap_fraction(table, fitz) == 1.0
+
+
+def test_overlap_fraction_no_overlap():
+    table = _bbox(0.0, 0.0, 0.1, 0.1)
+    fitz = _bbox(0.5, 0.5, 0.6, 0.6)
+    assert overlap_fraction(table, fitz) == 0.0
+
+
+def _fitz_result():
+    blocks = [
+        Block(id="fitz:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+              text="heading", page_index=0, bbox=_bbox(0.1, 0.05, 0.9, 0.1)),
+        Block(id="fitz:0:1", role=BlockRole.PARAGRAPH, native_type="text",
+              text="inside table", page_index=0, bbox=_bbox(0.2, 0.55, 0.8, 0.65)),
+    ]
+    return ToolResult(
+        tool_id="fitz", blocks=blocks,
+        page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
+        raw={"pages": {}},
+        native_by_block={"fitz:0:0": {"k": "h"}, "fitz:0:1": {"k": "t"}},
+    )
+
+
+def _camelot_result():
+    block = Block(id="camelot:0:0", role=BlockRole.TABLE, native_type="table",
+                  page_index=0, bbox=_bbox(0.1, 0.5, 0.9, 0.7))
+    return ToolResult(
+        tool_id="camelot", blocks=[block], page_meta={},
+        raw={"tables": []}, native_by_block={"camelot:0:0": {"acc": 99}},
+    )
+
+
+def test_merge_evicts_overlapping_fitz_block():
+    result = merge(_fitz_result(), _camelot_result(),
+                   source_document_id="doc1", eviction_overlap_threshold=0.5)
+    texts = [b.text for b in result.blocks]
+    assert "heading" in texts
+    assert "inside table" not in texts  # evicted by the table
+    assert result.raw_output["evicted"][0]["reason"] == "spatial_overlap"
+    assert result.raw_output["evicted"][0]["won_by"].endswith(":0")  # the table got reading_order 0 or 1
+
+
+def test_merge_mints_block_ids_and_reading_order():
+    result = merge(_fitz_result(), _camelot_result(),
+                   source_document_id="doc1", eviction_overlap_threshold=0.5)
+    for b in result.blocks:
+        assert b.id.startswith("doc1:0:")
+        assert b.reading_order is not None
+    # heading (y0=0.05) comes before the table (y0=0.5)
+    ordered = sorted(result.blocks, key=lambda b: b.reading_order)
+    assert ordered[0].text == "heading"
+    assert ordered[1].role == BlockRole.TABLE
+
+
+def test_merge_raw_output_has_tool_block_maps():
+    result = merge(_fitz_result(), _camelot_result(),
+                   source_document_id="doc1", eviction_overlap_threshold=0.5)
+    ro = result.raw_output
+    assert set(ro["tools"].keys()) == {"fitz", "camelot"}
+    assert "raw" in ro["tools"]["fitz"]
+    assert "block_map" in ro["tools"]["camelot"]
+    # surviving table maps to its native record
+    table_id = next(b.id for b in result.blocks if b.role == BlockRole.TABLE)
+    assert ro["tools"]["camelot"]["block_map"][table_id] == {"acc": 99}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_merger.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `merger`.
+
+- [ ] **Step 3: Implement merger.py**
+
+Create `backend/app/cdm/adapters/local_pipeline/merger.py`:
+
+```python
+"""Merge tool outputs into a final ordered block list + an audit raw_output.
+
+Eviction rule (spec §6.2): later-declared tools win. A fitz PARAGRAPH block
+that overlaps a camelot TABLE block beyond the threshold is evicted (logged,
+not deleted).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+from app.cdm.adapters.local_pipeline.tools.base import ToolResult
+from app.cdm.models import BBox, Block
+
+
+def _area(b: BBox) -> float:
+    return max(0.0, b.x1 - b.x0) * max(0.0, b.y1 - b.y0)
+
+
+def overlap_fraction(table_bbox: BBox, fitz_bbox: BBox) -> float:
+    """Intersection area / area(fitz_bbox), in normalized coords."""
+    fitz_area = _area(fitz_bbox)
+    if fitz_area == 0.0:
+        return 0.0
+    ix0 = max(table_bbox.x0, fitz_bbox.x0)
+    iy0 = max(table_bbox.y0, fitz_bbox.y0)
+    ix1 = min(table_bbox.x1, fitz_bbox.x1)
+    iy1 = min(table_bbox.y1, fitz_bbox.y1)
+    inter = max(0.0, ix1 - ix0) * max(0.0, iy1 - iy0)
+    return inter / fitz_area
+
+
+@dataclass
+class MergeResult:
+    blocks: List[Block]              # final, non-evicted, ordered, ids minted
+    raw_output: Dict[str, Any]
+
+
+def _sort_key(block: Block) -> Tuple[float, float]:
+    if block.bbox is None:
+        return (1e9, 1e9)
+    return (block.bbox.y0, block.bbox.x0)
+
+
+def merge(
+    fitz_result: ToolResult,
+    camelot_result: ToolResult,
+    *,
+    source_document_id: str,
+    eviction_overlap_threshold: float = 0.5,
+) -> MergeResult:
+    table_blocks = list(camelot_result.blocks)
+
+    # 1. Eviction pass — fitz blocks overlapping any table beyond threshold.
+    evicted_records: List[Dict[str, Any]] = []
+    evicted_ids = set()
+    eviction_winner: Dict[str, str] = {}   # fitz prov id -> table prov id
+    eviction_overlap: Dict[str, float] = {}
+    for fb in fitz_result.blocks:
+        if fb.bbox is None:
+            continue
+        for tb in table_blocks:
+            if tb.page_index != fb.page_index or tb.bbox is None:
+                continue
+            frac = overlap_fraction(tb.bbox, fb.bbox)
+            if frac > eviction_overlap_threshold:
+                evicted_ids.add(fb.id)
+                eviction_winner[fb.id] = tb.id
+                eviction_overlap[fb.id] = frac
+                break
+
+    surviving_fitz = [b for b in fitz_result.blocks if b.id not in evicted_ids]
+    combined = surviving_fitz + table_blocks
+
+    # 2. Mint final ids + reading order, grouped per page.
+    by_page: Dict[int, List[Block]] = {}
+    for b in combined:
+        by_page.setdefault(b.page_index, []).append(b)
+
+    prov_to_final: Dict[str, str] = {}
+    final_blocks: List[Block] = []
+    for page_index in sorted(by_page.keys()):
+        ordered = sorted(by_page[page_index], key=_sort_key)
+        for reading_order, block in enumerate(ordered):
+            final_id = f"{source_document_id}:{page_index}:{reading_order}"
+            prov_to_final[block.id] = final_id
+            final_blocks.append(
+                block.model_copy(update={"id": final_id, "reading_order": reading_order})
+            )
+
+    # 3. Build raw_output (audit trail).
+    def _block_map(result: ToolResult) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for prov_id, native in result.native_by_block.items():
+            final_id = prov_to_final.get(prov_id)
+            if final_id is not None:  # skip evicted (no final id)
+                out[final_id] = native
+        return out
+
+    evicted_records = [
+        {
+            "block_id": prov_id,
+            "tool": "fitz",
+            "reason": "spatial_overlap",
+            "won_by": prov_to_final[eviction_winner[prov_id]],
+            "overlap_fraction": eviction_overlap[prov_id],
+            "raw_block": fitz_result.native_by_block.get(prov_id),
+        }
+        for prov_id in evicted_ids
+    ]
+
+    raw_output = {
+        "tools": {
+            "fitz": {"raw": fitz_result.raw, "block_map": _block_map(fitz_result)},
+            "camelot": {"raw": camelot_result.raw, "block_map": _block_map(camelot_result)},
+        },
+        "evicted": evicted_records,
+    }
+
+    return MergeResult(blocks=final_blocks, raw_output=raw_output)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_merger.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/merger.py backend/tests/cdm/adapters/local_pipeline/test_merger.py
+git commit -m "feat(local-pipeline): add merger (eviction, id minting, raw_output)"
+```
+
+---
+
+## Task 7: LocalPipelineAdapter (adapter.py)
+
+**Files:**
+- Create: `backend/app/cdm/adapters/local_pipeline/adapter.py`
+- Test: `backend/tests/cdm/adapters/local_pipeline/test_adapter.py`
+
+**Interfaces:**
+- Consumes: `SourceMeta` (`app.cdm.adapters.base`), `PageMeta` (Task 2), final `Block` list from merger (Task 6), CDM `ParsedDocument`/`Page`.
+- Produces (consumed by Task 9):
+  - `LocalPipelineAdapter` with `parser: ClassVar[ParserKind] = ParserKind.LOCAL_PIPELINE` and `adapt(self, raw: Any, source_meta: SourceMeta) -> ParsedDocument`. `raw` is a dict `{"page_meta": dict[int, PageMeta], "blocks": list[Block]}` (the runner constructs it). Builds `Page` objects (geometry from `page_meta`, `block_ids` in reading order), `full_text = "\n\n".join(b.text for b in blocks if b.text)`. Mints `ParsedDocument.id = str(uuid4())`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/cdm/adapters/local_pipeline/test_adapter.py`:
+
+```python
+from app.cdm.adapters.base import SourceMeta
+from app.cdm.adapters.local_pipeline.adapter import LocalPipelineAdapter
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta
+from app.cdm.models import BBox, Block, BlockRole, ParsedDocument, ParserKind
+
+
+def _bbox(y0):
+    return BBox(x0=0.1, y0=y0, x1=0.9, y1=y0 + 0.05)
+
+
+def _blocks():
+    return [
+        Block(id="doc1:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+              text="alpha", page_index=0, bbox=_bbox(0.1), reading_order=0),
+        Block(id="doc1:0:1", role=BlockRole.TABLE, native_type="table",
+              text="", page_index=0, bbox=_bbox(0.5), reading_order=1),
+        Block(id="doc1:1:0", role=BlockRole.PARAGRAPH, native_type="text",
+              text="beta", page_index=1, bbox=_bbox(0.2), reading_order=0),
+    ]
+
+
+def test_adapter_parser_kind():
+    assert LocalPipelineAdapter.parser == ParserKind.LOCAL_PIPELINE
+
+
+def test_adapter_builds_parsed_document():
+    raw = {
+        "page_meta": {
+            0: PageMeta(index=0, width=612.0, height=792.0),
+            1: PageMeta(index=1, width=612.0, height=792.0),
+        },
+        "blocks": _blocks(),
+    }
+    doc = LocalPipelineAdapter().adapt(raw, SourceMeta(
+        source_document_id="doc1", parse_run_id="run1", filename="x.pdf"
+    ))
+    assert isinstance(doc, ParsedDocument)
+    assert doc.source_document_id == "doc1"
+    assert doc.parse_run_id == "run1"
+    assert doc.page_count == 2
+    assert len(doc.blocks) == 3
+    assert doc.full_text == "alpha\n\nbeta"
+
+
+def test_adapter_page_block_ids_in_reading_order():
+    raw = {
+        "page_meta": {0: PageMeta(index=0, width=612.0, height=792.0),
+                      1: PageMeta(index=1, width=612.0, height=792.0)},
+        "blocks": _blocks(),
+    }
+    doc = LocalPipelineAdapter().adapt(raw, SourceMeta(
+        source_document_id="doc1", parse_run_id="run1"
+    ))
+    page0 = next(p for p in doc.pages if p.index == 0)
+    assert page0.block_ids == ["doc1:0:0", "doc1:0:1"]
+    assert page0.width == 612.0
+    assert page0.height == 792.0
+    assert page0.unit == "points"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_adapter.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `adapter`.
+
+- [ ] **Step 3: Implement adapter.py**
+
+Create `backend/app/cdm/adapters/local_pipeline/adapter.py`:
+
+```python
+"""LocalPipelineAdapter — pure assembler: merged blocks + page geometry → CDM.
+
+All heavy lifting (eviction, id minting, bbox normalization) happens upstream
+in the tools and the merger. This adapter only assembles the ParsedDocument.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, List
+from uuid import uuid4
+
+from app.cdm.adapters.base import SourceMeta
+from app.cdm.adapters.local_pipeline.tools.base import PageMeta
+from app.cdm.models import Block, Page, ParsedDocument, ParserKind
+
+
+class LocalPipelineAdapter:
+    parser: ClassVar[ParserKind] = ParserKind.LOCAL_PIPELINE
+
+    def adapt(self, raw: Any, source_meta: SourceMeta) -> ParsedDocument:
+        page_meta: Dict[int, PageMeta] = raw["page_meta"]
+        blocks: List[Block] = list(raw["blocks"])
+
+        blocks_by_page: Dict[int, List[Block]] = {}
+        for b in blocks:
+            blocks_by_page.setdefault(b.page_index, []).append(b)
+
+        page_indices = sorted(set(page_meta.keys()) | set(blocks_by_page.keys()))
+        pages: List[Page] = []
+        for idx in page_indices:
+            pm = page_meta.get(idx)
+            page_blocks = sorted(
+                blocks_by_page.get(idx, []),
+                key=lambda b: (b.reading_order if b.reading_order is not None else 1e9),
+            )
+            pages.append(Page(
+                index=idx,
+                width=pm.width if pm else None,
+                height=pm.height if pm else None,
+                unit=pm.unit if pm else None,
+                rotation=pm.rotation if pm else 0,
+                block_ids=[b.id for b in page_blocks],
+            ))
+
+        ordered_blocks = sorted(
+            blocks,
+            key=lambda b: (b.page_index, b.reading_order if b.reading_order is not None else 1e9),
+        )
+        full_text = "\n\n".join(b.text for b in ordered_blocks if b.text)
+
+        return ParsedDocument(
+            id=str(uuid4()),
+            source_document_id=source_meta.source_document_id,
+            parse_run_id=source_meta.parse_run_id,
+            source_filename=source_meta.filename,
+            page_count=len(pages),
+            pages=pages,
+            blocks=ordered_blocks,
+            full_text=full_text or None,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline/test_adapter.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/adapter.py backend/tests/cdm/adapters/local_pipeline/test_adapter.py
+git commit -m "feat(local-pipeline): add LocalPipelineAdapter (pure CDM assembler)"
+```
+
+---
+
+## Task 8: Export new symbols from package `__init__`
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/local_pipeline/__init__.py`
+
+**Interfaces:**
+- Produces: convenient imports for the runner and tests.
+
+- [ ] **Step 1: Read current __init__**
+
+Run: `uv run --directory backend python -c "import app.cdm.adapters.local_pipeline as m; print(m.__file__)"`
+Then Read that file to see existing exports (iteration 1 exported probe symbols).
+
+- [ ] **Step 2: Append iteration-2 exports**
+
+Add to `backend/app/cdm/adapters/local_pipeline/__init__.py` (preserve existing probe exports):
+
+```python
+from app.cdm.adapters.local_pipeline.adapter import LocalPipelineAdapter
+from app.cdm.adapters.local_pipeline.config import (
+    CamelotConfig,
+    FitzConfig,
+    LocalPipelineConfig,
+    build_pipeline_config,
+)
+from app.cdm.adapters.local_pipeline.merger import MergeResult, merge, overlap_fraction
+from app.cdm.adapters.local_pipeline.tools.base import LocalTool, PageMeta, ToolResult
+from app.cdm.adapters.local_pipeline.tools.camelot_tool import CamelotTool
+from app.cdm.adapters.local_pipeline.tools.fitz_tool import FitzTool
+```
+
+(Append these names to the existing `__all__` if one is defined.)
+
+- [ ] **Step 3: Verify imports**
+
+Run: `uv run --directory backend python -c "from app.cdm.adapters.local_pipeline import FitzTool, CamelotTool, LocalPipelineAdapter, merge, build_pipeline_config; print('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/cdm/adapters/local_pipeline/__init__.py
+git commit -m "feat(local-pipeline): export iteration-2 symbols from package init"
+```
+
+---
+
+## Task 9: LocalParseRunner + register in ParsingService
+
+**Files:**
+- Create: `backend/app/services/parsing/local_pipeline_runner.py`
+- Modify: `backend/app/services/parsing/parsing_service.py:23-37` (import + `_RUNNERS`)
+- Test: `backend/tests/services/parsing/test_local_pipeline_runner.py`
+
+**Interfaces:**
+- Consumes: `build_pipeline_config`, `merge`, `LocalPipelineAdapter`, `FitzTool`/`CamelotTool` (Tasks 3-8); `SourceMeta`; `ParseRun`/`ParseRunStatus`/`SourceDocument` (CDM); `LocalPipelineRunError` (Task 1).
+- Produces: `async def run_local_pipeline(*, source: SourceDocument, file_path: str, representation_kind: str, config: dict, client: Any = None, parse_run_id: Optional[str] = None) -> Tuple[ParseRun, ParsedDocument]`. Registered as `ParserKind.LOCAL_PIPELINE: run_local_pipeline` in `_RUNNERS`. `client` is ignored. On success: `ParseRun(parser=LOCAL_PIPELINE, config=config, status=SUCCEEDED, raw_payload=merge.raw_output, warnings=<tool warnings>)`. On failure: raise `LocalPipelineRunError(msg, run=failed)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/services/parsing/test_local_pipeline_runner.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from app.cdm.models import BlockRole, ParserKind
+from app.cdm.source import ParseRunStatus, SourceDocument
+from app.services.parsing.errors import LocalPipelineRunError
+from app.services.parsing.local_pipeline_runner import run_local_pipeline
+
+FIXTURES = Path(__file__).parents[1] / "cdm" / "adapters" / "local_pipeline" / "fixtures"
+
+
+def _source(tmp_path):
+    return SourceDocument(
+        id="doc-xyz",
+        sha256="abc",
+        filename="simple_text.pdf",
+        mime_type="application/pdf",
+        byte_size=1234,
+        storage_uri=str(FIXTURES / "simple_text.pdf"),
+    )
+
+
+async def test_run_local_pipeline_fitz_only_succeeds(tmp_path):
+    source = _source(tmp_path)
+    config = {
+        "tools": [{"tool_id": "fitz", "config": {}}],
+        "eviction_overlap_threshold": 0.5,
+    }
+    run, doc = await run_local_pipeline(
+        source=source,
+        file_path=str(FIXTURES / "simple_text.pdf"),
+        representation_kind="extract_rich",
+        config=config,
+        client=None,
+    )
+    assert run.parser == ParserKind.LOCAL_PIPELINE
+    assert run.status == ParseRunStatus.SUCCEEDED
+    assert run.source_document_id == "doc-xyz"
+    assert run.raw_payload is not None
+    assert "tools" in run.raw_payload
+    assert "fitz" in run.raw_payload["tools"]
+    assert doc.parse_run_id == run.id
+    assert doc.page_count == 2
+    assert any(b.role == BlockRole.PARAGRAPH for b in doc.blocks)
+    # every block id is namespaced to the source document
+    assert all(b.id.startswith("doc-xyz:") for b in doc.blocks)
+
+
+async def test_run_local_pipeline_wraps_failure(tmp_path):
+    source = _source(tmp_path)
+    config = {"tools": [{"tool_id": "fitz", "config": {}}]}
+    with pytest.raises(LocalPipelineRunError) as ei:
+        await run_local_pipeline(
+            source=source,
+            file_path=str(tmp_path / "does_not_exist.pdf"),
+            representation_kind="extract_rich",
+            config=config,
+            client=None,
+        )
+    assert ei.value.run.status == ParseRunStatus.FAILED
+    assert ei.value.run.parser == ParserKind.LOCAL_PIPELINE
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/services/parsing/test_local_pipeline_runner.py -v`
+Expected: FAIL with `ModuleNotFoundError` for `local_pipeline_runner`. (Create `backend/tests/services/parsing/__init__.py` if pytest reports a collection/import error for the new directory — match the existing tests layout.)
+
+- [ ] **Step 3: Implement local_pipeline_runner.py**
+
+Create `backend/app/services/parsing/local_pipeline_runner.py`:
+
+```python
+"""Drives the local tool pipeline end-to-end: tools → merge → CDM + ParseRun."""
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from app.cdm.adapters.base import SourceMeta
+from app.cdm.adapters.local_pipeline.adapter import LocalPipelineAdapter
+from app.cdm.adapters.local_pipeline.config import build_pipeline_config
+from app.cdm.adapters.local_pipeline.merger import merge
+from app.cdm.adapters.local_pipeline.tools.base import ToolResult
+from app.cdm.models import ParsedDocument, ParserKind
+from app.cdm.source import ParseRun, ParseRunStatus, SourceDocument
+from app.services.parsing.errors import LocalPipelineRunError
+
+
+async def run_local_pipeline(
+    *,
+    source: SourceDocument,
+    file_path: str,
+    representation_kind: str,
+    config: Dict[str, Any],
+    client: Any = None,           # unused — local pipeline needs no client
+    parse_run_id: Optional[str] = None,
+) -> Tuple[ParseRun, ParsedDocument]:
+    """Run the configured local tools, merge, and adapt to CDM.
+
+    Tools run sequentially; FitzTool runs first and supplies page geometry to
+    CamelotTool (spec §6.2). On any tool failure, a FAILED ParseRun is raised
+    inside LocalPipelineRunError.
+    """
+    run_id = parse_run_id or str(uuid.uuid4())
+    started_at = datetime.now(timezone.utc)
+    t0 = time.perf_counter()
+
+    def _fail(exc: Exception) -> LocalPipelineRunError:
+        finished_at = datetime.now(timezone.utc)
+        duration_ms = int((time.perf_counter() - t0) * 1000)
+        failed = ParseRun(
+            id=run_id,
+            source_document_id=source.id,
+            parser=ParserKind.LOCAL_PIPELINE,
+            representation_kind=representation_kind,
+            config=config,
+            status=ParseRunStatus.FAILED,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=duration_ms,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        return LocalPipelineRunError(f"Local pipeline failed: {exc}", run=failed)
+
+    try:
+        pdf_path = Path(file_path)
+
+        # Build fitz-stage config (FitzTool first; CamelotTool deferred until we
+        # have page_meta). We instantiate tools by walking the config in order.
+        pipeline = build_pipeline_config(config)
+
+        fitz_tool = next((t for t in pipeline.tools if t.tool_id == "fitz"), None)
+        if fitz_tool is None:
+            raise ValueError("local pipeline requires a 'fitz' tool")
+
+        fitz_result: ToolResult = fitz_tool.run(pdf_path)
+        warnings = list(fitz_result.warnings)
+
+        # CamelotTool needs fitz page_meta for y-flip; rebuild with page_meta.
+        camelot_entry = next(
+            (e for e in config.get("tools", []) if e.get("tool_id") == "camelot"),
+            None,
+        )
+        if camelot_entry is not None:
+            camelot_pipeline = build_pipeline_config(
+                {"tools": [camelot_entry]}, page_meta=fitz_result.page_meta
+            )
+            camelot_tool = camelot_pipeline.tools[0]
+            camelot_result = camelot_tool.run(pdf_path)
+            warnings.extend(camelot_result.warnings)
+        else:
+            camelot_result = ToolResult(tool_id="camelot", blocks=[], page_meta={},
+                                        raw={"tables": []})
+
+        merge_result = merge(
+            fitz_result,
+            camelot_result,
+            source_document_id=source.id,
+            eviction_overlap_threshold=pipeline.eviction_overlap_threshold,
+        )
+    except Exception as exc:  # noqa: BLE001 — wrap into a FAILED ParseRun
+        raise _fail(exc) from exc
+
+    finished_at = datetime.now(timezone.utc)
+    duration_ms = int((time.perf_counter() - t0) * 1000)
+
+    run = ParseRun(
+        id=run_id,
+        source_document_id=source.id,
+        parser=ParserKind.LOCAL_PIPELINE,
+        representation_kind=representation_kind,
+        config=config,
+        status=ParseRunStatus.SUCCEEDED,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        warnings=warnings,
+        raw_payload=merge_result.raw_output,
+    )
+
+    adapter = LocalPipelineAdapter()
+    doc = adapter.adapt(
+        {"page_meta": fitz_result.page_meta, "blocks": merge_result.blocks},
+        SourceMeta(
+            source_document_id=source.id,
+            parse_run_id=run.id,
+            filename=source.filename,
+            sha256=source.sha256,
+        ),
+    )
+    return run, doc
+```
+
+- [ ] **Step 4: Register the runner**
+
+In `backend/app/services/parsing/parsing_service.py`, add the import after line 27 (`from app.services.parsing.simple_runner import run_simple`):
+
+```python
+from app.services.parsing.local_pipeline_runner import run_local_pipeline
+```
+
+And add to the `_RUNNERS` dict (line 32-37):
+
+```python
+_RUNNERS: Dict[ParserKind, Callable] = {
+    ParserKind.LLAMAPARSE: run_llamaparse,
+    ParserKind.LANDING_AI: run_landingai,
+    ParserKind.SIMPLE:     run_simple,
+    ParserKind.DOCLING:    run_docling,
+    ParserKind.LOCAL_PIPELINE: run_local_pipeline,
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/services/parsing/test_local_pipeline_runner.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Run the whole local_pipeline backend suite**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline tests/services/parsing/test_local_pipeline_runner.py -v`
+Expected: all PASS. Confirm no regressions in the probe tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/parsing/local_pipeline_runner.py backend/app/services/parsing/parsing_service.py backend/tests/services/parsing/
+git commit -m "feat(local-pipeline): add run_local_pipeline runner and register it"
+```
+
+---
+
+## Task 10: Frontend — local pipeline config types
+
+**Files:**
+- Modify: `frontend/src/types/parsing.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 11-12):
+  - `LocalPipelineToolConfig { tool_id: string; config: Record<string, unknown> }`
+  - `LocalPipelineParseConfig { tools: LocalPipelineToolConfig[]; eviction_overlap_threshold: number }`
+
+- [ ] **Step 1: Add the types**
+
+Append to `frontend/src/types/parsing.ts`:
+
+```typescript
+export interface LocalPipelineToolConfig {
+  tool_id: string
+  config: Record<string, unknown>
+}
+
+export interface LocalPipelineParseConfig {
+  tools: LocalPipelineToolConfig[]
+  eviction_overlap_threshold: number
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `npm --prefix frontend run build`
+Expected: build succeeds (the pre-existing chunk-size warning is acceptable).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types/parsing.ts
+git commit -m "feat(local-pipeline): add frontend config types"
+```
+
+---
+
+## Task 11: Frontend — LocalPipelineConfig component
+
+**Files:**
+- Create: `frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx`
+- Test: `frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx`
+
+**Interfaces:**
+- Consumes: `ParseConfig` (`@/types/parsing`), shadcn `Select`, `Checkbox`, `Label`, `Slider`, `Input`. Optional `DocumentProfile` (`@/types/probe`) for the probe-context hint.
+- Produces: `LocalPipelineConfig({ config, onChange, disabled?, profile? })`. fitz is always present; camelot is toggled. Camelot, when on, exposes a `flavor` select (lattice/stream) and `edge_tol`/`row_tol` inputs. An `eviction_overlap_threshold` slider (0–1). When `profile` is provided, renders a "Suggested tools" hint.
+
+> Mirror the structure of `frontend/src/components/documents/parser-configs/LlamaParseConfig.tsx` (Select + Checkbox + Label) and `LandingAIConfig.tsx`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LocalPipelineConfig } from './LocalPipelineConfig'
+
+const fitzOnly = {
+  tools: [{ tool_id: 'fitz', config: { include_images: true, span_detail: false, min_chars_threshold: 10 } }],
+  eviction_overlap_threshold: 0.5,
+}
+
+describe('LocalPipelineConfig', () => {
+  it('renders fitz as always-on and camelot as a toggle', () => {
+    render(<LocalPipelineConfig config={fitzOnly} onChange={vi.fn()} />)
+    expect(screen.getByText(/fitz/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/camelot/i)).toBeInTheDocument()
+  })
+
+  it('adds camelot to tools when toggled on', () => {
+    const onChange = vi.fn()
+    render(<LocalPipelineConfig config={fitzOnly} onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText(/camelot/i))
+    const next = onChange.mock.calls[0][0]
+    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).toContain('camelot')
+  })
+
+  it('removes camelot when toggled off', () => {
+    const onChange = vi.fn()
+    const withCamelot = {
+      ...fitzOnly,
+      tools: [...fitzOnly.tools, { tool_id: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } }],
+    }
+    render(<LocalPipelineConfig config={withCamelot} onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText(/camelot/i))
+    const next = onChange.mock.calls[0][0]
+    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).not.toContain('camelot')
+  })
+
+  it('shows a suggested-tools hint when a profile is provided', () => {
+    render(
+      <LocalPipelineConfig
+        config={fitzOnly}
+        onChange={vi.fn()}
+        profile={{
+          source_document_id: 'd', filename: 'x.pdf', page_count: 1, pages: [],
+          has_text_layer: true, has_scanned_pages: false, has_cid_corruption: false,
+          table_signal: true, recommended_tools: ['fitz', 'camelot'],
+          duration_ms: 10, probed_at: '2026-06-25T00:00:00Z',
+        }}
+      />
+    )
+    expect(screen.getByText(/fitz, camelot/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx --prefix frontend vitest run src/components/documents/parser-configs/LocalPipelineConfig.test.tsx`
+Expected: FAIL — cannot resolve `./LocalPipelineConfig`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx`:
+
+```typescript
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Slider } from '@/components/ui/slider'
+import type { ParseConfig } from '@/types/parsing'
+import type { DocumentProfile } from '@/types/probe'
+
+interface ToolEntry {
+  tool_id: string
+  config: Record<string, unknown>
+}
+
+interface LocalPipelineConfigProps {
+  config: ParseConfig
+  onChange: (config: ParseConfig) => void
+  disabled?: boolean
+  profile?: DocumentProfile | null
+}
+
+const CAMELOT_DEFAULTS = { flavor: 'lattice', edge_tol: 50, row_tol: 2 }
+
+export function LocalPipelineConfig({
+  config,
+  onChange,
+  disabled = false,
+  profile,
+}: LocalPipelineConfigProps) {
+  const tools = (config.tools as ToolEntry[] | undefined) ?? []
+  const threshold = (config.eviction_overlap_threshold as number | undefined) ?? 0.5
+
+  const fitz = tools.find((t) => t.tool_id === 'fitz')
+  const camelot = tools.find((t) => t.tool_id === 'camelot')
+
+  const setTools = (next: ToolEntry[]) => onChange({ ...config, tools: next })
+
+  const updateTool = (toolId: string, patch: Record<string, unknown>) => {
+    setTools(
+      tools.map((t) =>
+        t.tool_id === toolId ? { ...t, config: { ...t.config, ...patch } } : t
+      )
+    )
+  }
+
+  const toggleCamelot = (on: boolean) => {
+    if (on) {
+      setTools([...tools, { tool_id: 'camelot', config: { ...CAMELOT_DEFAULTS } }])
+    } else {
+      setTools(tools.filter((t) => t.tool_id !== 'camelot'))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {profile && (
+        <p className="text-sm text-muted-foreground">
+          Suggested tools:{' '}
+          <span className="font-medium">{profile.recommended_tools.join(', ')}</span>
+        </p>
+      )}
+
+      {/* Fitz — always on */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div className="flex items-center justify-between">
+          <Label>fitz (text + images)</Label>
+          <span className="text-xs text-muted-foreground">always on</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="fitz-include-images"
+            checked={(fitz?.config.include_images as boolean) ?? true}
+            onCheckedChange={(c) => updateTool('fitz', { include_images: !!c })}
+            disabled={disabled}
+          />
+          <Label htmlFor="fitz-include-images">Include images (FIGURE blocks)</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="fitz-span-detail"
+            checked={(fitz?.config.span_detail as boolean) ?? false}
+            onCheckedChange={(c) => updateTool('fitz', { span_detail: !!c })}
+            disabled={disabled}
+          />
+          <Label htmlFor="fitz-span-detail">Record span detail</Label>
+        </div>
+      </div>
+
+      {/* Camelot — optional */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="enable-camelot"
+            checked={!!camelot}
+            onCheckedChange={(c) => toggleCamelot(!!c)}
+            disabled={disabled}
+          />
+          <Label htmlFor="enable-camelot">camelot (tables)</Label>
+        </div>
+
+        {camelot && (
+          <div className="space-y-3 pl-6">
+            <div className="space-y-1">
+              <Label htmlFor="camelot-flavor">Flavor</Label>
+              <Select
+                value={(camelot.config.flavor as string) ?? 'lattice'}
+                onValueChange={(v) => updateTool('camelot', { flavor: v })}
+                disabled={disabled}
+              >
+                <SelectTrigger id="camelot-flavor">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="lattice">lattice (ruled tables)</SelectItem>
+                  <SelectItem value="stream">stream (borderless tables)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="camelot-edge-tol">edge_tol</Label>
+                <Input
+                  id="camelot-edge-tol"
+                  type="number"
+                  value={(camelot.config.edge_tol as number) ?? 50}
+                  onChange={(e) =>
+                    updateTool('camelot', { edge_tol: Number(e.target.value) })
+                  }
+                  disabled={disabled}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="camelot-row-tol">row_tol</Label>
+                <Input
+                  id="camelot-row-tol"
+                  type="number"
+                  value={(camelot.config.row_tol as number) ?? 2}
+                  onChange={(e) =>
+                    updateTool('camelot', { row_tol: Number(e.target.value) })
+                  }
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Eviction threshold */}
+      <div className="space-y-2">
+        <Label htmlFor="eviction-threshold">
+          Eviction overlap threshold: {threshold.toFixed(2)}
+        </Label>
+        <Slider
+          id="eviction-threshold"
+          min={0}
+          max={1}
+          step={0.05}
+          value={[threshold]}
+          onValueChange={([v]) => onChange({ ...config, eviction_overlap_threshold: v })}
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+> **Note:** If `@/components/ui/slider` is not yet installed, add it: `npx --prefix frontend shadcn@latest add slider` (per the project memory it is listed as installed, so this should be a no-op).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx --prefix frontend vitest run src/components/documents/parser-configs/LocalPipelineConfig.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx
+git commit -m "feat(local-pipeline): add LocalPipelineConfig component"
+```
+
+---
+
+## Task 12: Frontend — register local_pipeline in ParseMethodSelector
+
+**Files:**
+- Modify: `frontend/src/components/documents/ParseMethodSelector.tsx`
+- Test: `frontend/src/components/documents/ParseMethodSelector.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `LocalPipelineConfig` (Task 11).
+- Produces: a `local_pipeline` entry in `PARSER_REGISTRY` and a conditional render of `LocalPipelineConfig` when `parserType === 'local_pipeline'`. Selecting it sets the default config so a create-parse-run submits `{parser_type: 'local_pipeline', config: {tools: [...fitz...], eviction_overlap_threshold: 0.5}}` through the existing flow.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `frontend/src/components/documents/ParseMethodSelector.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ParseMethodSelector } from './ParseMethodSelector'
+
+describe('ParseMethodSelector — local_pipeline', () => {
+  it('renders LocalPipelineConfig when local_pipeline is selected', () => {
+    render(
+      <ParseMethodSelector
+        parserType="local_pipeline"
+        config={{
+          tools: [{ tool_id: 'fitz', config: {} }],
+          eviction_overlap_threshold: 0.5,
+        }}
+        onParserTypeChange={vi.fn()}
+        onConfigChange={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/fitz \(text \+ images\)/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/camelot/i)).toBeInTheDocument()
+  })
+
+  it('applies the local_pipeline default config on selection', () => {
+    const onConfigChange = vi.fn()
+    const { getByText } = render(
+      <ParseMethodSelector
+        parserType="simple"
+        config={{}}
+        onParserTypeChange={vi.fn()}
+        onConfigChange={onConfigChange}
+      />
+    )
+    // The default config is exported for assertion; verify its shape directly.
+    expect(getByText(/parse method/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx --prefix frontend vitest run src/components/documents/ParseMethodSelector.test.tsx`
+Expected: FAIL — `local_pipeline` config not rendered (no `fitz (text + images)` text).
+
+- [ ] **Step 3: Register the parser + render the config**
+
+In `frontend/src/components/documents/ParseMethodSelector.tsx`:
+
+(a) Add the import near the other parser-config imports:
+
+```typescript
+import { LocalPipelineConfig } from './parser-configs/LocalPipelineConfig'
+```
+
+(b) Add to `PARSER_REGISTRY` (after the `docling` entry):
+
+```typescript
+  local_pipeline: {
+    label: 'Local pipeline',
+    description: 'Composable local tools (fitz + camelot). No cloud API — for prototyping and eval.',
+    defaultConfig: {
+      tools: [
+        {
+          tool_id: 'fitz',
+          config: { min_chars_threshold: 10, include_images: true, span_detail: false },
+        },
+      ],
+      eviction_overlap_threshold: 0.5,
+    },
+  },
+```
+
+(c) Add the conditional render alongside the existing `LlamaParseConfig` / `LandingAIConfig` blocks:
+
+```typescript
+      {parserType === 'local_pipeline' && (
+        <LocalPipelineConfig
+          config={config}
+          onChange={onConfigChange}
+          disabled={disabled}
+        />
+      )}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx --prefix frontend vitest run src/components/documents/ParseMethodSelector.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + build**
+
+Run: `npm --prefix frontend run lint`
+Run: `npm --prefix frontend run build`
+Expected: lint clean; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/documents/ParseMethodSelector.tsx frontend/src/components/documents/ParseMethodSelector.test.tsx
+git commit -m "feat(local-pipeline): register local_pipeline parser in ParseMethodSelector"
+```
+
+---
+
+## Task 13: Full-suite regression + manual smoke
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend suite**
+
+Run: `uv run --directory backend python -m pytest -o "addopts=" tests/cdm/adapters/local_pipeline tests/services/parsing -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Frontend suite**
+
+Run: `npx --prefix frontend vitest run src/components/documents`
+Expected: all PASS.
+
+- [ ] **Step 3: Manual smoke (optional, requires app running)**
+
+Per CLAUDE.md local-testing steps, with the app running and a PDF uploaded:
+1. Open a document's detail Sheet, open the re-parse / parse dialog.
+2. Select **Local pipeline** from the parse-method dropdown.
+3. Verify fitz shows as always-on, camelot can be toggled (flavor + tol inputs appear), and the eviction-threshold slider works.
+4. Submit. Confirm a `local_pipeline` parse run appears in the runs list and reaches `succeeded`, and the parsed document renders blocks (paragraphs + any tables).
+5. Inspect the run's raw payload — confirm `tools.fitz`, `tools.camelot`, and `evicted` keys are present.
+
+- [ ] **Step 4: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "test(local-pipeline): verify iteration-2 suite green"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (iteration 2 = spec §10 row 2):**
+- `FitzTool` (spec §5.2) → Task 4. Text + image blocks, normalized bboxes, `fitz_block_type`, span detail, min-chars warning. ✓
+- `CamelotTool` (spec §5.3) → Task 5. lattice/stream, y-flip, cell bboxes, `df.to_html()`, accuracy/order/flavor extras, 1-indexed page translation (open Q3). ✓
+- `LocalTool` protocol + `ToolResult` + `PageMeta` (spec §5.1) → Task 2. ✓
+- `LocalParseRunner` (spec §6) → Task 9. Fitz-first → page_meta → camelot → merge → adapt → ParseRun. Two-layer split (spec §6.3): runner + adapter + merger. ✓
+- `LocalPipelineConfig` (spec §6.1) → Task 3 (runtime) + Task 10/12 (serialized config). `eviction_overlap_threshold` default 0.5. ✓
+- Eviction pass + `raw_output` schema (spec §6.2 steps 3-5) → Task 6. Evicted records carry `block_id`, `tool`, `reason`, `won_by`, `overlap_fraction`, `raw_block`. ✓
+- Block-id minting `{src}:{page}:{reading_order}` (spec §6.2 step 4) → Task 6. ✓
+- `ParserKind.LOCAL_PIPELINE` (spec §7) → already present; registered in `_RUNNERS` in Task 9. ✓
+- Package layout (spec §8) → matches Task file structure (config/adapter/runner/merger/tools/*). `runner.py` location: this plan places the runner under `services/parsing/` to match the existing `*_runner.py` convention and the `_RUNNERS` registry, rather than `adapters/local_pipeline/runner.py`. Documented deviation — keeps all runners co-located and discoverable. ✓
+- Local pipeline parse run creation UI (spec §9 iteration 2) → Tasks 10-12. Tool selection + per-tool config; probe-profile context surfaced as an optional `profile` prop (full live-probe wiring into the dialog is deferred, consistent with iteration-1 having no probe persistence). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every test shows real assertions. ✓
+
+**Type consistency:** `ToolResult.native_by_block` (Task 2) is keyed by provisional id; merger (Task 6) maps provisional→final and looks up natives by provisional id — consistent. `merge(...)` signature is identical in Tasks 6 and 9. `LocalPipelineAdapter.adapt(raw, source_meta)` expects `raw = {"page_meta", "blocks"}` (Task 7) and the runner passes exactly that (Task 9). `build_pipeline_config(config, page_meta=None)` signature consistent across Tasks 3 and 9. Frontend `LocalPipelineParseConfig` shape (Task 10) matches the default config in Task 12 and the component reads (Task 11). ✓
+
+**Known limitations to flag in the PR:**
+- camelot `lattice` needs Ghostscript at runtime — add to the container image before shipping (Task 1 note).
+- The probe profile is not persisted (iteration 1), so the config UI's `profile` hint only appears if a profile is passed in by the parent; live re-probe-in-dialog is a follow-up.
+- `MarkitdownTool` / markdown derivation (open Q5), `stream` flavor eviction-threshold override (open Q4), and tabula backend (item 6) are explicitly out of iteration-2 scope.

--- a/frontend/src/components/documents/ParseMethodSelector.test.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.test.tsx
@@ -72,6 +72,29 @@ describe('ParseMethodSelector', () => {
     expect(screen.queryByText('Tier')).not.toBeInTheDocument()
   })
 
+  it('renders LocalPipelineConfig when local_pipeline selected', () => {
+    render(
+      <ParseMethodSelector
+        {...defaultProps}
+        parserType="local_pipeline"
+        config={{
+          tools: [{ tool_id: 'fitz', config: {} }],
+          eviction_overlap_threshold: 0.5,
+        }}
+      />
+    )
+    expect(screen.getByText(/fitz \(text \+ images\)/i)).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /camelot/i })).toBeInTheDocument()
+    expect(
+      screen.getByText(/Composable local tools \(fitz \+ camelot\)/i)
+    ).toBeInTheDocument()
+  })
+
+  it('hides local pipeline options when simple selected', () => {
+    render(<ParseMethodSelector {...defaultProps} parserType="simple" />)
+    expect(screen.queryByText(/fitz \(text \+ images\)/i)).not.toBeInTheDocument()
+  })
+
   it('resets config to parser defaultConfig when parser type changes', () => {
     const onConfigChange = vi.fn()
     const { rerender } = render(

--- a/frontend/src/components/documents/ParseMethodSelector.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.tsx
@@ -9,6 +9,7 @@ import {
 import type { ParseConfig } from '@/types/parsing'
 import { LandingAIConfig } from './parser-configs/LandingAIConfig'
 import { LlamaParseConfig } from './parser-configs/LlamaParseConfig'
+import { LocalPipelineConfig } from './parser-configs/LocalPipelineConfig'
 
 interface ParserMeta {
   label: string
@@ -36,6 +37,19 @@ const PARSER_REGISTRY: Record<string, ParserMeta> = {
     label: 'Docling',
     description: 'Local PDF parsing. Rich layout extraction with tables, headings, and figures.',
     defaultConfig: {},
+  },
+  local_pipeline: {
+    label: 'Local pipeline',
+    description: 'Composable local tools (fitz + camelot). No cloud API — for prototyping and eval.',
+    defaultConfig: {
+      tools: [
+        {
+          tool_id: 'fitz',
+          config: { min_chars_threshold: 10, include_images: true, span_detail: false },
+        },
+      ],
+      eviction_overlap_threshold: 0.5,
+    },
   },
 }
 
@@ -91,6 +105,9 @@ export function ParseMethodSelector({
       )}
       {parserType === 'landing_ai' && (
         <LandingAIConfig config={config} onChange={onConfigChange} disabled={disabled} />
+      )}
+      {parserType === 'local_pipeline' && (
+        <LocalPipelineConfig config={config} onChange={onConfigChange} disabled={disabled} />
       )}
     </div>
   )

--- a/frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx
+++ b/frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { LocalPipelineConfig } from './LocalPipelineConfig'
+
+const fitzOnly = {
+  tools: [
+    {
+      tool_id: 'fitz',
+      config: { include_images: true, span_detail: false, min_chars_threshold: 10 },
+    },
+  ],
+  eviction_overlap_threshold: 0.5,
+}
+
+describe('LocalPipelineConfig', () => {
+  it('renders fitz as always-on and camelot as a toggle', () => {
+    render(<LocalPipelineConfig config={fitzOnly} onChange={vi.fn()} />)
+    expect(screen.getByText(/fitz \(text \+ images\)/i)).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /camelot/i })).toBeInTheDocument()
+  })
+
+  it('adds camelot to tools when toggled on', async () => {
+    const onChange = vi.fn()
+    render(<LocalPipelineConfig config={fitzOnly} onChange={onChange} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: /camelot/i }))
+    const next = onChange.mock.calls[0][0]
+    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).toContain('camelot')
+  })
+
+  it('removes camelot when toggled off', async () => {
+    const onChange = vi.fn()
+    const withCamelot = {
+      ...fitzOnly,
+      tools: [
+        ...fitzOnly.tools,
+        { tool_id: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } },
+      ],
+    }
+    render(<LocalPipelineConfig config={withCamelot} onChange={onChange} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: /camelot/i }))
+    const next = onChange.mock.calls[0][0]
+    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).not.toContain('camelot')
+  })
+
+  it('shows camelot flavor select when camelot is enabled', () => {
+    const withCamelot = {
+      ...fitzOnly,
+      tools: [
+        ...fitzOnly.tools,
+        { tool_id: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } },
+      ],
+    }
+    render(<LocalPipelineConfig config={withCamelot} onChange={vi.fn()} />)
+    expect(screen.getByText('Flavor')).toBeInTheDocument()
+  })
+
+  it('shows a suggested-tools hint when a profile is provided', () => {
+    render(
+      <LocalPipelineConfig
+        config={fitzOnly}
+        onChange={vi.fn()}
+        profile={{
+          source_document_id: 'd',
+          filename: 'x.pdf',
+          page_count: 1,
+          pages: [],
+          has_text_layer: true,
+          has_scanned_pages: false,
+          has_cid_corruption: false,
+          table_signal: true,
+          recommended_tools: ['fitz', 'camelot'],
+          duration_ms: 10,
+          probed_at: '2026-06-25T00:00:00Z',
+        }}
+      />
+    )
+    expect(screen.getByText(/fitz, camelot/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx
+++ b/frontend/src/components/documents/parser-configs/LocalPipelineConfig.test.tsx
@@ -55,6 +55,32 @@ describe('LocalPipelineConfig', () => {
     expect(screen.getByText('Flavor')).toBeInTheDocument()
   })
 
+  it('hides edge_tol/row_tol for lattice flavor', () => {
+    const withLattice = {
+      ...fitzOnly,
+      tools: [
+        ...fitzOnly.tools,
+        { tool_id: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } },
+      ],
+    }
+    render(<LocalPipelineConfig config={withLattice} onChange={vi.fn()} />)
+    expect(screen.queryByText('edge_tol')).not.toBeInTheDocument()
+    expect(screen.queryByText('row_tol')).not.toBeInTheDocument()
+  })
+
+  it('shows edge_tol/row_tol for stream flavor', () => {
+    const withStream = {
+      ...fitzOnly,
+      tools: [
+        ...fitzOnly.tools,
+        { tool_id: 'camelot', config: { flavor: 'stream', edge_tol: 50, row_tol: 2 } },
+      ],
+    }
+    render(<LocalPipelineConfig config={withStream} onChange={vi.fn()} />)
+    expect(screen.getByText('edge_tol')).toBeInTheDocument()
+    expect(screen.getByText('row_tol')).toBeInTheDocument()
+  })
+
   it('shows a suggested-tools hint when a profile is provided', () => {
     render(
       <LocalPipelineConfig

--- a/frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx
+++ b/frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx
@@ -1,0 +1,171 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Slider } from '@/components/ui/slider'
+import type { ParseConfig } from '@/types/parsing'
+import type { DocumentProfile } from '@/types/probe'
+
+interface ToolEntry {
+  tool_id: string
+  config: Record<string, unknown>
+}
+
+interface LocalPipelineConfigProps {
+  config: ParseConfig
+  onChange: (config: ParseConfig) => void
+  disabled?: boolean
+  profile?: DocumentProfile | null
+}
+
+const CAMELOT_DEFAULTS = { flavor: 'lattice', edge_tol: 50, row_tol: 2 }
+
+export function LocalPipelineConfig({
+  config,
+  onChange,
+  disabled = false,
+  profile,
+}: LocalPipelineConfigProps) {
+  const tools = (config.tools as ToolEntry[] | undefined) ?? []
+  const threshold = (config.eviction_overlap_threshold as number | undefined) ?? 0.5
+
+  const fitz = tools.find((t) => t.tool_id === 'fitz')
+  const camelot = tools.find((t) => t.tool_id === 'camelot')
+
+  const setTools = (next: ToolEntry[]) => onChange({ ...config, tools: next })
+
+  const updateTool = (toolId: string, patch: Record<string, unknown>) => {
+    setTools(
+      tools.map((t) =>
+        t.tool_id === toolId ? { ...t, config: { ...t.config, ...patch } } : t
+      )
+    )
+  }
+
+  const toggleCamelot = (on: boolean) => {
+    if (on) {
+      setTools([...tools, { tool_id: 'camelot', config: { ...CAMELOT_DEFAULTS } }])
+    } else {
+      setTools(tools.filter((t) => t.tool_id !== 'camelot'))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {profile && (
+        <p className="text-sm text-muted-foreground">
+          Suggested tools:{' '}
+          <span className="font-medium">{profile.recommended_tools.join(', ')}</span>
+        </p>
+      )}
+
+      {/* Fitz — always on */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div className="flex items-center justify-between">
+          <Label>fitz (text + images)</Label>
+          <span className="text-xs text-muted-foreground">always on</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="fitz-include-images"
+            checked={(fitz?.config.include_images as boolean) ?? true}
+            onCheckedChange={(c) => updateTool('fitz', { include_images: !!c })}
+            disabled={disabled}
+          />
+          <Label htmlFor="fitz-include-images">Include images (FIGURE blocks)</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="fitz-span-detail"
+            checked={(fitz?.config.span_detail as boolean) ?? false}
+            onCheckedChange={(c) => updateTool('fitz', { span_detail: !!c })}
+            disabled={disabled}
+          />
+          <Label htmlFor="fitz-span-detail">Record span detail</Label>
+        </div>
+      </div>
+
+      {/* Camelot — optional */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="enable-camelot"
+            checked={!!camelot}
+            onCheckedChange={(c) => toggleCamelot(!!c)}
+            disabled={disabled}
+          />
+          <Label htmlFor="enable-camelot">camelot (tables)</Label>
+        </div>
+
+        {camelot && (
+          <div className="space-y-3 pl-6">
+            <div className="space-y-1">
+              <Label htmlFor="camelot-flavor">Flavor</Label>
+              <Select
+                value={(camelot.config.flavor as string) ?? 'lattice'}
+                onValueChange={(v) => updateTool('camelot', { flavor: v })}
+                disabled={disabled}
+              >
+                <SelectTrigger id="camelot-flavor">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="lattice">lattice (ruled tables)</SelectItem>
+                  <SelectItem value="stream">stream (borderless tables)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="camelot-edge-tol">edge_tol</Label>
+                <Input
+                  id="camelot-edge-tol"
+                  type="number"
+                  value={(camelot.config.edge_tol as number) ?? 50}
+                  onChange={(e) =>
+                    updateTool('camelot', { edge_tol: Number(e.target.value) })
+                  }
+                  disabled={disabled}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="camelot-row-tol">row_tol</Label>
+                <Input
+                  id="camelot-row-tol"
+                  type="number"
+                  value={(camelot.config.row_tol as number) ?? 2}
+                  onChange={(e) =>
+                    updateTool('camelot', { row_tol: Number(e.target.value) })
+                  }
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Eviction threshold */}
+      <div className="space-y-2">
+        <Label htmlFor="eviction-threshold">
+          Eviction overlap threshold: {threshold.toFixed(2)}
+        </Label>
+        <Slider
+          id="eviction-threshold"
+          min={0}
+          max={1}
+          step={0.05}
+          value={[threshold]}
+          onValueChange={([v]) => onChange({ ...config, eviction_overlap_threshold: v })}
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx
+++ b/frontend/src/components/documents/parser-configs/LocalPipelineConfig.tsx
@@ -121,32 +121,36 @@ export function LocalPipelineConfig({
                 </SelectContent>
               </Select>
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1">
-                <Label htmlFor="camelot-edge-tol">edge_tol</Label>
-                <Input
-                  id="camelot-edge-tol"
-                  type="number"
-                  value={(camelot.config.edge_tol as number) ?? 50}
-                  onChange={(e) =>
-                    updateTool('camelot', { edge_tol: Number(e.target.value) })
-                  }
-                  disabled={disabled}
-                />
+            {/* edge_tol / row_tol only apply to stream flavor — camelot
+                rejects them for lattice. */}
+            {(camelot.config.flavor as string) === 'stream' && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label htmlFor="camelot-edge-tol">edge_tol</Label>
+                  <Input
+                    id="camelot-edge-tol"
+                    type="number"
+                    value={(camelot.config.edge_tol as number) ?? 50}
+                    onChange={(e) =>
+                      updateTool('camelot', { edge_tol: Number(e.target.value) })
+                    }
+                    disabled={disabled}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="camelot-row-tol">row_tol</Label>
+                  <Input
+                    id="camelot-row-tol"
+                    type="number"
+                    value={(camelot.config.row_tol as number) ?? 2}
+                    onChange={(e) =>
+                      updateTool('camelot', { row_tol: Number(e.target.value) })
+                    }
+                    disabled={disabled}
+                  />
+                </div>
               </div>
-              <div className="space-y-1">
-                <Label htmlFor="camelot-row-tol">row_tol</Label>
-                <Input
-                  id="camelot-row-tol"
-                  type="number"
-                  value={(camelot.config.row_tol as number) ?? 2}
-                  onChange={(e) =>
-                    updateTool('camelot', { row_tol: Number(e.target.value) })
-                  }
-                  disabled={disabled}
-                />
-              </div>
-            </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/documents/parser-configs/index.ts
+++ b/frontend/src/components/documents/parser-configs/index.ts
@@ -1,2 +1,3 @@
 export { LlamaParseConfig } from './LlamaParseConfig'
 export { LandingAIConfig } from './LandingAIConfig'
+export { LocalPipelineConfig } from './LocalPipelineConfig'

--- a/frontend/src/types/parsing.ts
+++ b/frontend/src/types/parsing.ts
@@ -12,3 +12,13 @@ export type ParseConfig = {
   model?: string
   [key: string]: unknown
 }
+
+export interface LocalPipelineToolConfig {
+  tool_id: string
+  config: Record<string, unknown>
+}
+
+export interface LocalPipelineParseConfig {
+  tools: LocalPipelineToolConfig[]
+  eviction_overlap_threshold: number
+}


### PR DESCRIPTION
Closes #118.

Iteration 2 of the local-first PDF parse pipeline (spec §10). Builds the composable local tool pipeline and a parse-run creation UI for it. Iteration 1 (DocumentProbe) shipped previously.

## What's included

**Backend** (`backend/app/cdm/adapters/local_pipeline/`)
- `tools/base.py` — `LocalTool` protocol, `ToolResult`, `PageMeta`, `clamp01`
- `tools/fitz_tool.py` — `FitzTool`: text + image extraction → normalized (top-left) CDM blocks; `fitz_block_type` extra; optional span detail; low-char-page warnings
- `tools/camelot_tool.py` — `CamelotTool`: table extraction with bottom-left→top-left y-flip, cell bboxes, `df.to_html()`, accuracy/order/flavor extras; 0-based↔camelot 1-indexed page translation
- `config.py` — `FitzConfig`, `CamelotConfig`, runtime `LocalPipelineConfig`, `build_pipeline_config`
- `merger.py` — spatial-overlap eviction (later tool wins), block-id minting `{src}:{page}:{reading_order}`, append-only `raw_output` audit trail
- `adapter.py` — `LocalPipelineAdapter`: pure assembler producing a clean CDM `ParsedDocument`
- `services/parsing/local_pipeline_runner.py` — `run_local_pipeline`, registered in `ParsingService._RUNNERS`; no API key required

**Frontend**
- `local_pipeline` registered in `PARSER_REGISTRY`
- `LocalPipelineConfig` component (fitz always-on, camelot toggle + flavor/tol, eviction-threshold slider, optional probe-profile hint)
- Reuses the existing `POST /documents/{id}/parse-runs` flow

## Design note
The spec's §6.2 (runner builds `raw_output`) and §6.3 (adapter does eviction) conflict given the adapter protocol returns only `ParsedDocument` while `raw_output` lands on `ParseRun.raw_payload`. Resolved by putting eviction + `raw_output` in pure `merger.py`; the runner owns the `ParseRun`; the adapter stays a thin assembler — keeping `ParsedDocument` clean.

## Testing
- Backend: 81 tests pass (`tests/cdm/adapters/local_pipeline` + `tests/services/parsing`), TDD throughout
- Frontend: 23 tests pass (`src/components/documents`); lint + build clean

## Notes / follow-ups
- camelot `lattice` flavor needs Ghostscript at runtime — add to the container image before relying on lattice in deployment (unit tests mock `camelot.read_pdf`, so they don't require it).
- Probe profile is not persisted (iteration 1), so the config UI's profile hint only renders when a profile is passed in; live re-probe-in-dialog is a follow-up.
- `MarkitdownTool`, per-flavor eviction-threshold override, and a tabula backend are out of iteration-2 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)