### PR TITLE
refactor(cdm): rename BlockRole.PARAGRAPH to BlockRole.TEXT

### DIFF
--- a/backend/alembic/versions/30add7b93531_rename_block_role_paragraph_to_text.py
+++ b/backend/alembic/versions/30add7b93531_rename_block_role_paragraph_to_text.py
@@ -1,0 +1,174 @@
+"""rename_block_role_paragraph_to_text
+
+Revision ID: 30add7b93531
+Revises: f2a3b4c5d6e7
+Create Date: 2026-07-02 12:48:04.824242
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = '30add7b93531'
+down_revision: Union[str, None] = 'f2a3b4c5d6e7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # parsed_documents: rewrite role field on each block in the blocks array
+    op.execute("""
+        UPDATE parsed_documents
+        SET content = jsonb_set(
+            content,
+            '{blocks}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        WHEN elem->>'role' = 'paragraph'
+                        THEN jsonb_set(elem, '{role}', '"text"')
+                        ELSE elem
+                    END
+                )
+                FROM jsonb_array_elements(content->'blocks') AS elem
+            )
+        )
+        WHERE EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(content->'blocks') AS elem
+            WHERE elem->>'role' = 'paragraph'
+        )
+    """)
+
+    # chunks: rewrite role values in block_roles array
+    op.execute("""
+        UPDATE chunks
+        SET chunk_metadata = (
+            jsonb_set(
+                chunk_metadata::jsonb,
+                '{block_roles}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"paragraph"' THEN '"text"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+                )
+            )
+        )::json
+        WHERE chunk_metadata::jsonb ? 'block_roles'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+            WHERE elem::text = '"paragraph"'
+          )
+    """)
+
+    # indexes: rewrite role values in blockRoleFilter array
+    op.execute("""
+        UPDATE indexes
+        SET config = (
+            jsonb_set(
+                config::jsonb,
+                '{blockRoleFilter}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"paragraph"' THEN '"text"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+                )
+            )
+        )::json
+        WHERE config::jsonb ? 'blockRoleFilter'
+          AND config::jsonb->'blockRoleFilter' IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+            WHERE elem::text = '"paragraph"'
+          )
+    """)
+
+
+def downgrade() -> None:
+    # parsed_documents: revert text → paragraph
+    op.execute("""
+        UPDATE parsed_documents
+        SET content = jsonb_set(
+            content,
+            '{blocks}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        WHEN elem->>'role' = 'text'
+                        THEN jsonb_set(elem, '{role}', '"paragraph"')
+                        ELSE elem
+                    END
+                )
+                FROM jsonb_array_elements(content->'blocks') AS elem
+            )
+        )
+        WHERE EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(content->'blocks') AS elem
+            WHERE elem->>'role' = 'text'
+        )
+    """)
+
+    # chunks: revert text → paragraph
+    op.execute("""
+        UPDATE chunks
+        SET chunk_metadata = (
+            jsonb_set(
+                chunk_metadata::jsonb,
+                '{block_roles}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"text"' THEN '"paragraph"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+                )
+            )
+        )::json
+        WHERE chunk_metadata::jsonb ? 'block_roles'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+            WHERE elem::text = '"text"'
+          )
+    """)
+
+    # indexes: revert text → paragraph
+    op.execute("""
+        UPDATE indexes
+        SET config = (
+            jsonb_set(
+                config::jsonb,
+                '{blockRoleFilter}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"text"' THEN '"paragraph"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+                )
+            )
+        )::json
+        WHERE config::jsonb ? 'blockRoleFilter'
+          AND config::jsonb->'blockRoleFilter' IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+            WHERE elem::text = '"text"'
+          )
+    """)

--- a/backend/app/cdm/adapters/custom_pipeline/merger.py
+++ b/backend/app/cdm/adapters/custom_pipeline/merger.py
@@ -1,6 +1,6 @@
 """Merge tool outputs into a final ordered block list + an audit raw_output.
 
-Eviction rule: later-declared tools win. A fitz PARAGRAPH block that overlaps
+Eviction rule: later-declared tools win. A fitz TEXT block that overlaps
 a table block beyond the threshold is evicted (logged, not deleted).
 """
 from __future__ import annotations

--- a/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py
@@ -105,7 +105,7 @@ class FitzTool:
                             extras["spans"] = _spans(blk)
                         block = Block(
                             id=prov_id,
-                            role=BlockRole.PARAGRAPH,
+                            role=BlockRole.TEXT,
                             native_type="text",
                             text=text,
                             page_index=i,

--- a/backend/app/cdm/adapters/docling.py
+++ b/backend/app/cdm/adapters/docling.py
@@ -19,8 +19,8 @@ from app.cdm.models import (
 _ROLE_MAP: Dict[str, BlockRole] = {
     "title":               BlockRole.TITLE,
     "section_header":      BlockRole.HEADING,
-    "text":                BlockRole.PARAGRAPH,
-    "paragraph":           BlockRole.PARAGRAPH,
+    "text":                BlockRole.TEXT,
+    "paragraph":           BlockRole.TEXT,
     "list_item":           BlockRole.LIST,
     "table":               BlockRole.TABLE,
     "picture":             BlockRole.FIGURE,

--- a/backend/app/cdm/adapters/landing_ai.py
+++ b/backend/app/cdm/adapters/landing_ai.py
@@ -51,11 +51,11 @@ def _first_content_line(markdown: str) -> str:
 
 
 def _detect_text_role(markdown: str) -> BlockRole:
-    """Map a text chunk's markdown to TITLE, HEADING, or PARAGRAPH."""
+    """Map a text chunk's markdown to TITLE, HEADING, or TEXT."""
     first = _first_content_line(markdown)
     m = _HEADING_RE.match(first)
     if not m:
-        return BlockRole.PARAGRAPH
+        return BlockRole.TEXT
     return BlockRole.TITLE if len(m.group(1)) == 1 else BlockRole.HEADING
 
 

--- a/backend/app/cdm/adapters/llamaparse.py
+++ b/backend/app/cdm/adapters/llamaparse.py
@@ -22,7 +22,7 @@ from app.cdm.models import (
 
 _ROLE_MAP: Dict[str, BlockRole] = {
     "heading": BlockRole.HEADING,
-    "text":    BlockRole.PARAGRAPH,
+    "text":    BlockRole.TEXT,
     "list":    BlockRole.LIST,
     "table":   BlockRole.TABLE,
     "image":   BlockRole.FIGURE,

--- a/backend/app/cdm/adapters/simple_text.py
+++ b/backend/app/cdm/adapters/simple_text.py
@@ -33,7 +33,7 @@ class SimpleTextAdapter:
                 block_id = f"{source_meta.source_document_id}:p{page_index}:b0"
                 block = Block(
                     id=block_id,
-                    role=BlockRole.PARAGRAPH,
+                    role=BlockRole.TEXT,
                     native_type="text",
                     text=page_text,
                     page_index=page_index,
@@ -50,7 +50,7 @@ class SimpleTextAdapter:
             block_id = f"{source_meta.source_document_id}:p0:b0"
             blocks = [Block(
                 id=block_id,
-                role=BlockRole.PARAGRAPH,
+                role=BlockRole.TEXT,
                 native_type="text",
                 text=full_text.strip(),
                 page_index=0,

--- a/backend/app/cdm/eval/fixtures/landing_ai_cleanshelf.expected.json
+++ b/backend/app/cdm/eval/fixtures/landing_ai_cleanshelf.expected.json
@@ -32,7 +32,7 @@
   "blocks": [
     {
       "id": "structural-test-src:p0:b0",
-      "role": "paragraph",
+      "role": "text",
       "native_type": "text",
       "native_label": null,
       "text": "<a id='b821b0d0-8cf9-4fca-b136-2ca4ac18767d'></a>\n\nCLEANSHELF SUPERMARKETS LIMITED\nKIKUYU\nP.O Box 1/08 0021/,1 IMURU",
@@ -112,7 +112,7 @@
     },
     {
       "id": "structural-test-src:p0:b2",
-      "role": "paragraph",
+      "role": "text",
       "native_type": "text",
       "native_label": null,
       "text": "<a id='11a45a0b-7b25-4990-848a-b5435d27870b'></a>\n\nSBN . P051147119.. VAT Reg 0125810H\nTel No. : 0110090570 Tax\nTill No. : 1 Cash Sale $ 103\nDate : 12-Apr 26 Time : 12:45:PM Branch : 13",
@@ -2400,7 +2400,7 @@
     },
     {
       "id": "structural-test-src:p0:b4",
-      "role": "paragraph",
+      "role": "text",
       "native_type": "text",
       "native_label": null,
       "text": "<a id='80d828c4-2a69-4339-bfb9-64c3057fd310'></a>\n\nTOTAL : 2,718.00\nM-PAY : 2,718.00",
@@ -2442,7 +2442,7 @@
     },
     {
       "id": "structural-test-src:p0:b5",
-      "role": "paragraph",
+      "role": "text",
       "native_type": "text",
       "native_label": null,
       "text": "<a id='a91a4fdd-c701-4e4a-aca0-83d3f35e6d0b'></a>\n\n***\n*** MPESA DETAILS ***\n***\nTransaction No.: UDOOGORZCH\nMobile No : 0722 ### 673\n***",
@@ -2971,7 +2971,7 @@
     },
     {
       "id": "structural-test-src:p0:b7",
-      "role": "paragraph",
+      "role": "text",
       "native_type": "text",
       "native_label": null,
       "text": "<a id='760eb065-4575-4cca-bf2d-61b2a0cc555d'></a>\n\nTSIN : 131131204261243189\n\nCUIN : 0170495670001143165\n\nCUSN : KRAMW017202207049567\n\nDATE : 2026-04-12 12:46",
@@ -3051,7 +3051,7 @@
     },
     {
       "id": "structural-test-src:p0:b9",
-      "role": "paragraph",
+      "role": "text",
       "native_type": "text",
       "native_label": null,
       "text": "<a id='ea12bc31-3b53-4942-bbf9-09b4479c7137'></a>\n\nPRICES INCLUSIVE OF VAT WHERE APPLICABLE",

--- a/backend/app/cdm/models.py
+++ b/backend/app/cdm/models.py
@@ -24,7 +24,7 @@ class ParserKind(str, Enum):
 class BlockRole(str, Enum):
     TITLE      = "title"
     HEADING    = "heading"
-    PARAGRAPH  = "paragraph"
+    TEXT       = "text"
     LIST       = "list"
     TABLE      = "table"
     FIGURE     = "figure"

--- a/backend/app/services/block_chunking_service.py
+++ b/backend/app/services/block_chunking_service.py
@@ -10,7 +10,7 @@ Grouping algorithm (per spec slice 3):
    - TITLE/HEADING: closes any open group, opens a new one with this block.
    - TABLE/FIGURE: never split. If group_by_heading and a group is open,
      append; else close the current group and emit a single-block group.
-   - Other content roles (PARAGRAPH/LIST/CAPTION/CODE/FORMULA): append to
+   - Other content roles (TEXT/LIST/CAPTION/CODE/FORMULA): append to
      the open group; if no group is open, start one without a heading.
 4. If appending would push current group over max_blocks_per_chunk and the
    incoming block is NOT a TABLE/FIGURE, close the group and start a new one.

--- a/backend/tests/adapters/extraction/chunking/test_token_budget.py
+++ b/backend/tests/adapters/extraction/chunking/test_token_budget.py
@@ -8,7 +8,7 @@ def _doc(n_pages: int, chars_per_page: int = 400) -> ParsedDocument:
     pages, blocks = [], []
     for i in range(n_pages):
         blocks.append(Block(
-            id=f"b{i}", role=BlockRole.PARAGRAPH, native_type="text",
+            id=f"b{i}", role=BlockRole.TEXT, native_type="text",
             text="x" * chars_per_page, markdown="x" * chars_per_page,
             page_index=i, reading_order=0,
         ))

--- a/backend/tests/adapters/extraction/preprocess/test_block_filter.py
+++ b/backend/tests/adapters/extraction/preprocess/test_block_filter.py
@@ -6,7 +6,7 @@ from app.cdm.models import Block, BlockRole, Page, ParsedDocument
 def _doc():
     blocks = [
         Block(id="h", role=BlockRole.HEADER, native_type="t", text="hdr", page_index=0),
-        Block(id="p", role=BlockRole.PARAGRAPH, native_type="t", text="body", page_index=0),
+        Block(id="p", role=BlockRole.TEXT, native_type="t", text="body", page_index=0),
         Block(id="f", role=BlockRole.FOOTER, native_type="t", text="ftr", page_index=0),
     ]
     return ParsedDocument(

--- a/backend/tests/adapters/extraction/test_llm_context.py
+++ b/backend/tests/adapters/extraction/test_llm_context.py
@@ -27,7 +27,7 @@ def _make_parsed_doc(blocks=None, full_markdown=None) -> ParsedDocument:
 def _make_block(id_, text, page_index=0, reading_order=None, markdown=None):
     return Block(
         id=id_,
-        role=BlockRole.PARAGRAPH,
+        role=BlockRole.TEXT,
         native_type="paragraph",
         text=text,
         markdown=markdown,

--- a/backend/tests/adapters/extraction/test_pipeline.py
+++ b/backend/tests/adapters/extraction/test_pipeline.py
@@ -15,7 +15,7 @@ _SCHEMA = {"type": "object", "properties": {
 def _doc(n_pages: int, chars=400):
     pages, blocks = [], []
     for i in range(n_pages):
-        blocks.append(Block(id=f"b{i}", role=BlockRole.PARAGRAPH, native_type="t",
+        blocks.append(Block(id=f"b{i}", role=BlockRole.TEXT, native_type="t",
                             text="x" * chars, markdown="x" * chars, page_index=i))
         pages.append(Page(index=i, block_ids=[f"b{i}"]))
     return ParsedDocument(id="d", source_document_id="s", parse_run_id=str(_RUN),
@@ -72,7 +72,7 @@ async def test_preprocess_runs_before_extraction():
         provider_response_raw=None, extraction_metadata={}))
     px = PipelineExtractor(
         inner=inner,
-        preprocess=[{"stage": "block_filter", "config": {"drop": ["paragraph"]}}],
+        preprocess=[{"stage": "block_filter", "config": {"drop": ["text"]}}],
         chunking=None,
     )
     await px.extract(_doc(1), _SCHEMA)

--- a/backend/tests/cdm/adapters/custom_pipeline/test_adapter.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_adapter.py
@@ -10,12 +10,12 @@ def _bbox(y0):
 
 def _blocks():
     return [
-        Block(id="doc1:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+        Block(id="doc1:0:0", role=BlockRole.TEXT, native_type="text",
               text="alpha", page_index=0, bbox=_bbox(0.1), reading_order=0),
         Block(id="doc1:0:1", role=BlockRole.TABLE, native_type="table",
               text="A | B", markdown="| A | B |", page_index=0, bbox=_bbox(0.5),
               reading_order=1),
-        Block(id="doc1:1:0", role=BlockRole.PARAGRAPH, native_type="text",
+        Block(id="doc1:1:0", role=BlockRole.TEXT, native_type="text",
               text="beta", page_index=1, bbox=_bbox(0.2), reading_order=0),
     ]
 

--- a/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
@@ -29,7 +29,7 @@ def test_fitz_tool_id():
 def test_fitz_extracts_paragraph_blocks_with_normalized_bbox():
     result = FitzTool().run(FIXTURES / "simple_text.pdf")
     assert result.tool_id == "fitz"
-    paras = [b for b in result.blocks if b.role == BlockRole.PARAGRAPH]
+    paras = [b for b in result.blocks if b.role == BlockRole.TEXT]
     assert len(paras) > 0
     b = paras[0]
     assert b.text.strip() != ""
@@ -56,13 +56,13 @@ def test_fitz_native_record_keyed_by_provisional_id():
 
 def test_fitz_span_detail_off_by_default():
     result = FitzTool().run(FIXTURES / "simple_text.pdf")
-    para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
+    para = next(b for b in result.blocks if b.role == BlockRole.TEXT)
     assert "spans" not in para.parser_extras
 
 
 def test_fitz_span_detail_on_records_spans():
     result = FitzTool(config=FitzConfig(span_detail=True)).run(FIXTURES / "simple_text.pdf")
-    para = next(b for b in result.blocks if b.role == BlockRole.PARAGRAPH)
+    para = next(b for b in result.blocks if b.role == BlockRole.TEXT)
     assert "spans" in para.parser_extras
     assert isinstance(para.parser_extras["spans"], list)
 

--- a/backend/tests/cdm/adapters/custom_pipeline/test_merger.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_merger.py
@@ -21,9 +21,9 @@ def test_overlap_fraction_no_overlap():
 
 def _fitz_result():
     blocks = [
-        Block(id="fitz:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+        Block(id="fitz:0:0", role=BlockRole.TEXT, native_type="text",
               text="heading", page_index=0, bbox=_bbox(0.1, 0.05, 0.9, 0.1)),
-        Block(id="fitz:0:1", role=BlockRole.PARAGRAPH, native_type="text",
+        Block(id="fitz:0:1", role=BlockRole.TEXT, native_type="text",
               text="inside table", page_index=0, bbox=_bbox(0.2, 0.55, 0.8, 0.65)),
     ]
     return ToolResult(

--- a/backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
@@ -15,7 +15,7 @@ def test_page_meta_defaults():
 
 
 def test_tool_result_holds_blocks_and_native_records():
-    block = Block(id="fitz:0:0", role=BlockRole.PARAGRAPH, native_type="text",
+    block = Block(id="fitz:0:0", role=BlockRole.TEXT, native_type="text",
                   text="hi", page_index=0)
     result = ToolResult(
         tool_id="fitz",

--- a/backend/tests/cdm/adapters/test_docling_adapter.py
+++ b/backend/tests/cdm/adapters/test_docling_adapter.py
@@ -144,8 +144,8 @@ def test_map_role_known_labels():
     cases = [
         ("title",          BlockRole.TITLE),
         ("section_header", BlockRole.HEADING),
-        ("text",           BlockRole.PARAGRAPH),
-        ("paragraph",      BlockRole.PARAGRAPH),
+        ("text",           BlockRole.TEXT),
+        ("paragraph",      BlockRole.TEXT),
         ("list_item",      BlockRole.LIST),
         ("table",          BlockRole.TABLE),
         ("picture",        BlockRole.FIGURE),

--- a/backend/tests/cdm/adapters/test_llamaparse_adapter.py
+++ b/backend/tests/cdm/adapters/test_llamaparse_adapter.py
@@ -49,7 +49,7 @@ def test_union_bbox_empty_returns_none():
 
 @pytest.mark.parametrize("llama_type,expected_role", [
     ("heading", BlockRole.HEADING),
-    ("text", BlockRole.PARAGRAPH),
+    ("text", BlockRole.TEXT),
     ("list", BlockRole.LIST),
     ("table", BlockRole.TABLE),
     ("image", BlockRole.FIGURE),
@@ -141,7 +141,7 @@ def test_adapter_produces_blocks_with_normalized_bboxes():
     assert 0.0 <= heading.bbox.x0 <= heading.bbox.x1 <= 1.0
     assert heading.markdown == "# Title"
     assert heading.text == "Title"
-    assert body.role.value == "paragraph"
+    assert body.role.value == "text"
 
 
 def test_adapter_populates_quality_from_confidence():

--- a/backend/tests/cdm/adapters/test_simple_text_adapter.py
+++ b/backend/tests/cdm/adapters/test_simple_text_adapter.py
@@ -34,7 +34,7 @@ def test_two_pages_produces_two_pages_and_two_blocks():
 
 def test_block_role_is_paragraph():
     doc = SimpleTextAdapter().adapt(TWO_PAGE_RAW, SOURCE_META)
-    assert all(b.role == BlockRole.PARAGRAPH for b in doc.blocks)
+    assert all(b.role == BlockRole.TEXT for b in doc.blocks)
 
 
 def test_block_ids_are_unique_and_referenced_by_pages():

--- a/backend/tests/cdm/eval/fixtures/multi_column.expected.json
+++ b/backend/tests/cdm/eval/fixtures/multi_column.expected.json
@@ -34,7 +34,7 @@
         "notes": null
       },
       "reading_order": 0,
-      "role": "paragraph",
+      "role": "text",
       "spans": [],
       "style": null,
       "table": null,
@@ -74,7 +74,7 @@
         "notes": null
       },
       "reading_order": 1,
-      "role": "paragraph",
+      "role": "text",
       "spans": [],
       "style": null,
       "table": null,
@@ -114,7 +114,7 @@
         "notes": null
       },
       "reading_order": 2,
-      "role": "paragraph",
+      "role": "text",
       "spans": [],
       "style": null,
       "table": null,
@@ -154,7 +154,7 @@
         "notes": null
       },
       "reading_order": 3,
-      "role": "paragraph",
+      "role": "text",
       "spans": [],
       "style": null,
       "table": null,

--- a/backend/tests/cdm/eval/fixtures/one_page_text.expected.json
+++ b/backend/tests/cdm/eval/fixtures/one_page_text.expected.json
@@ -74,7 +74,7 @@
         "notes": null
       },
       "reading_order": 1,
-      "role": "paragraph",
+      "role": "text",
       "spans": [],
       "style": null,
       "table": null,

--- a/backend/tests/cdm/test_landing_ai_adapter.py
+++ b/backend/tests/cdm/test_landing_ai_adapter.py
@@ -102,7 +102,7 @@ def test_bbox_normalized(doc):
 
 def test_block_roles(doc):
     roles = {b.role for b in doc.blocks}
-    assert BlockRole.PARAGRAPH in roles
+    assert BlockRole.TEXT in roles
     assert BlockRole.TABLE in roles
 
 
@@ -128,7 +128,7 @@ def test_table_html_preserved(doc):
 
 
 def test_quality_from_grounding(doc):
-    text_block = next(b for b in doc.blocks if b.role == BlockRole.PARAGRAPH)
+    text_block = next(b for b in doc.blocks if b.role == BlockRole.TEXT)
     assert text_block.quality is not None
     assert text_block.quality.confidence == pytest.approx(0.97)
 
@@ -278,11 +278,11 @@ from app.cdm.adapters.landing_ai import _detect_text_role
 
 
 def test_detect_plain_text_is_paragraph():
-    assert _detect_text_role("Hello world.") == BlockRole.PARAGRAPH
+    assert _detect_text_role("Hello world.") == BlockRole.TEXT
 
 
 def test_detect_anchor_then_plain_text_is_paragraph():
-    assert _detect_text_role("<a id='x'></a>\n\nPlain paragraph.") == BlockRole.PARAGRAPH
+    assert _detect_text_role("<a id='x'></a>\n\nPlain paragraph.") == BlockRole.TEXT
 
 
 def test_detect_h1_is_title():
@@ -308,15 +308,15 @@ def test_detect_h4_is_heading():
 
 def test_detect_hash_without_space_is_paragraph():
     # ##NoSpace is not a valid ATX heading; treat as paragraph
-    assert _detect_text_role("##NoSpace") == BlockRole.PARAGRAPH
+    assert _detect_text_role("##NoSpace") == BlockRole.TEXT
 
 
 def test_detect_empty_markdown_is_paragraph():
-    assert _detect_text_role("") == BlockRole.PARAGRAPH
+    assert _detect_text_role("") == BlockRole.TEXT
 
 
 def test_detect_anchor_only_is_paragraph():
-    assert _detect_text_role("<a id='x'></a>\n\n") == BlockRole.PARAGRAPH
+    assert _detect_text_role("<a id='x'></a>\n\n") == BlockRole.TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -368,7 +368,7 @@ def test_plain_text_chunk_remains_paragraph():
         "markdown": None, "metadata": {}, "splits": [], "grounding": {},
     }
     doc = LandingAIAdapter().adapt(raw, _META)
-    assert doc.blocks[0].role == BlockRole.PARAGRAPH
+    assert doc.blocks[0].role == BlockRole.TEXT
 
 
 def test_mixed_roles_across_chunks():
@@ -406,4 +406,4 @@ def test_mixed_roles_across_chunks():
     assert by_id["c-title"].role == BlockRole.TITLE
     assert by_id["c-h2"].role == BlockRole.HEADING
     assert by_id["c-h3"].role == BlockRole.HEADING
-    assert by_id["c-para"].role == BlockRole.PARAGRAPH
+    assert by_id["c-para"].role == BlockRole.TEXT

--- a/backend/tests/cdm/test_models.py
+++ b/backend/tests/cdm/test_models.py
@@ -14,7 +14,7 @@ def test_parser_kind_values():
 def test_block_role_has_coarse_taxonomy():
     # Closed taxonomy — ~14 values.
     assert BlockRole.TITLE.value == "title"
-    assert BlockRole.PARAGRAPH.value == "paragraph"
+    assert BlockRole.TEXT.value == "text"
     assert BlockRole.TABLE.value == "table"
     assert BlockRole.OTHER.value == "other"
 
@@ -84,7 +84,7 @@ def test_table_requires_dimensions_and_cells():
 def test_block_minimum_fields():
     b = Block(
         id="b1",
-        role=BlockRole.PARAGRAPH,
+        role=BlockRole.TEXT,
         native_type="text",
         page_index=0,
     )
@@ -153,7 +153,7 @@ def test_parsed_document_json_round_trip():
         pages=[Page(index=0, block_ids=["b1"])],
         blocks=[Block(
             id="b1",
-            role=BlockRole.PARAGRAPH,
+            role=BlockRole.TEXT,
             native_type="text",
             text="hello",
             page_index=0,

--- a/backend/tests/cdm/test_workloads.py
+++ b/backend/tests/cdm/test_workloads.py
@@ -9,7 +9,7 @@ def _make_doc() -> ParsedDocument:
     blocks = [
         Block(
             id=f"b{i}",
-            role=BlockRole.PARAGRAPH,
+            role=BlockRole.TEXT,
             native_type="paragraph",
             text=f"text on page {i}",
             page_index=i,

--- a/backend/tests/repositories/test_classification_run_repository.py
+++ b/backend/tests/repositories/test_classification_run_repository.py
@@ -75,9 +75,9 @@ async def test_get_annotated_blocks(test_db):
             "blocks": [
                 {"id": "b-1", "role": "heading", "native_type": "heading",
                  "text": "Balance Sheet", "page_index": 0},
-                {"id": "b-2", "role": "paragraph", "native_type": "paragraph",
+                {"id": "b-2", "role": "text", "native_type": "paragraph",
                  "text": "Assets data", "page_index": 0},
-                {"id": "b-3", "role": "paragraph", "native_type": "paragraph",
+                {"id": "b-3", "role": "text", "native_type": "paragraph",
                  "text": "Notes", "page_index": 1},
             ],
         },

--- a/backend/tests/repositories/test_parsed_document_round_trip.py
+++ b/backend/tests/repositories/test_parsed_document_round_trip.py
@@ -55,7 +55,7 @@ async def test_cdm_parsed_document_round_trip(test_db: AsyncSession):
         blocks=[Block(
             id="b1",
             page_index=0,
-            role=BlockRole.PARAGRAPH,
+            role=BlockRole.TEXT,
             native_type="text",
             text="hello world",
             markdown="hello world",

--- a/backend/tests/routers/test_classification_router.py
+++ b/backend/tests/routers/test_classification_router.py
@@ -63,8 +63,8 @@ async def test_get_blocks_returns_annotated_list(
             "page_count": 1,
             "pages": [{"index": 0}],
             "blocks": [
-                {"id": "b-1", "role": "paragraph", "native_type": "paragraph", "text": "Foo", "page_index": 0},
-                {"id": "b-2", "role": "paragraph", "native_type": "paragraph", "text": "Bar", "page_index": 0},
+                {"id": "b-1", "role": "text", "native_type": "paragraph", "text": "Foo", "page_index": 0},
+                {"id": "b-2", "role": "text", "native_type": "paragraph", "text": "Bar", "page_index": 0},
             ],
         },
     )
@@ -109,7 +109,7 @@ async def test_get_blocks_returns_annotated_list(
     assert len(data) == 2
     assert data[0]["blockId"] == "b-1"
     assert data[0]["label"] == "section_a"
-    assert data[0]["role"] == "paragraph"
+    assert data[0]["role"] == "text"
     assert data[0]["text"] == "Foo"
     assert data[0]["pageIndex"] == 0
     assert data[1]["blockId"] == "b-2"

--- a/backend/tests/schemas/test_index_config_schema.py
+++ b/backend/tests/schemas/test_index_config_schema.py
@@ -110,8 +110,8 @@ def test_block_role_filter_accepts_camel_case_alias():
         "chunkingStrategy": "block",
         "groupByHeading": False,
         "maxBlocksPerChunk": 5,
-        "blockRoleFilter": ["paragraph"],
+        "blockRoleFilter": ["text"],
     })
     assert cfg.group_by_heading is False
     assert cfg.max_blocks_per_chunk == 5
-    assert cfg.block_role_filter == ["paragraph"]
+    assert cfg.block_role_filter == ["text"]

--- a/backend/tests/services/classification/test_assembler.py
+++ b/backend/tests/services/classification/test_assembler.py
@@ -12,7 +12,7 @@ def _make_doc(page_count: int) -> ParsedDocument:
     blocks = [
         Block(
             id=f"b{i}",
-            role=BlockRole.PARAGRAPH,
+            role=BlockRole.TEXT,
             native_type="paragraph",
             text=f"page {i}",
             page_index=i,

--- a/backend/tests/services/classification/test_llm_classifier.py
+++ b/backend/tests/services/classification/test_llm_classifier.py
@@ -8,7 +8,7 @@ from app.services.llm.types import CompletionResult, TokenUsage
 def _make_doc() -> ParsedDocument:
     pages = [Page(index=i, block_ids=[f"b{i}"]) for i in range(3)]
     blocks = [
-        Block(id=f"b{i}", role=BlockRole.PARAGRAPH, native_type="p",
+        Block(id=f"b{i}", role=BlockRole.TEXT, native_type="p",
               text=f"page {i}", page_index=i, reading_order=0)
         for i in range(3)
     ]

--- a/backend/tests/services/classification/test_serializer.py
+++ b/backend/tests/services/classification/test_serializer.py
@@ -7,7 +7,7 @@ def _make_doc(page_count: int) -> ParsedDocument:
     blocks = [
         Block(
             id=f"b{i}",
-            role=BlockRole.PARAGRAPH,
+            role=BlockRole.TEXT,
             native_type="paragraph",
             text=f"content on page {i}",
             page_index=i,
@@ -28,8 +28,8 @@ def _make_doc(page_count: int) -> ParsedDocument:
 def test_serialize_pages_format():
     doc = _make_doc(3)
     text = serialize_pages(doc, 0, 1)
-    assert "[page 0, paragraph] content on page 0" in text
-    assert "[page 1, paragraph] content on page 1" in text
+    assert "[page 0, text] content on page 0" in text
+    assert "[page 1, text] content on page 1" in text
     assert "page 2" not in text
 
 

--- a/backend/tests/services/classification/test_service.py
+++ b/backend/tests/services/classification/test_service.py
@@ -9,7 +9,7 @@ from app.services.classification.port import ClassificationResult
 def _make_doc() -> ParsedDocument:
     pages = [Page(index=i, block_ids=[f"b{i}"]) for i in range(3)]
     blocks = [
-        Block(id=f"b{i}", role=BlockRole.PARAGRAPH, native_type="p",
+        Block(id=f"b{i}", role=BlockRole.TEXT, native_type="p",
               text=f"page {i}", page_index=i, reading_order=0)
         for i in range(3)
     ]

--- a/backend/tests/services/parsing/test_custom_pipeline_runner.py
+++ b/backend/tests/services/parsing/test_custom_pipeline_runner.py
@@ -46,7 +46,7 @@ async def test_run_custom_pipeline_fitz_only_succeeds():
     assert "fitz" in run.raw_payload["tools"]
     assert doc.parse_run_id == run.id
     assert doc.page_count == 2
-    assert any(b.role == BlockRole.PARAGRAPH for b in doc.blocks)
+    assert any(b.role == BlockRole.TEXT for b in doc.blocks)
     # every block id is namespaced to the source document
     assert all(b.id.startswith("doc-xyz:") for b in doc.blocks)
 

--- a/backend/tests/services/test_block_chunking_service.py
+++ b/backend/tests/services/test_block_chunking_service.py
@@ -44,8 +44,8 @@ def test_block_chunking_groups_by_heading():
     svc = BlockChunkingService()
     blocks = [
         _block("b1", BlockRole.HEADING, "Q3 Financial Results", y0=0.0).model_dump(),
-        _block("b2", BlockRole.PARAGRAPH, "Revenue grew 12%.", y0=0.1).model_dump(),
-        _block("b3", BlockRole.PARAGRAPH, "Margins held steady.", y0=0.2).model_dump(),
+        _block("b2", BlockRole.TEXT, "Revenue grew 12%.", y0=0.1).model_dump(),
+        _block("b3", BlockRole.TEXT, "Margins held steady.", y0=0.2).model_dump(),
     ]
     chunks = svc.chunk_blocks(blocks=blocks, config=_config())
 
@@ -54,7 +54,7 @@ def test_block_chunking_groups_by_heading():
     assert "Revenue grew 12%." in chunks[0].content
     assert "Margins held steady." in chunks[0].content
     assert chunks[0].metadata["block_ids"] == ["b1", "b2", "b3"]
-    assert chunks[0].metadata["block_roles"] == ["heading", "paragraph", "paragraph"]
+    assert chunks[0].metadata["block_roles"] == ["heading", "text", "text"]
 
 
 def test_block_chunking_table_not_split_when_cap_would_force_it():
@@ -63,8 +63,8 @@ def test_block_chunking_table_not_split_when_cap_would_force_it():
     svc = BlockChunkingService()
     blocks = [
         _block("h1", BlockRole.HEADING, "Section", y0=0.0).model_dump(),
-        _block("p1", BlockRole.PARAGRAPH, "Para 1", y0=0.1).model_dump(),
-        _block("p2", BlockRole.PARAGRAPH, "Para 2", y0=0.2).model_dump(),
+        _block("p1", BlockRole.TEXT, "Para 1", y0=0.1).model_dump(),
+        _block("p2", BlockRole.TEXT, "Para 2", y0=0.2).model_dump(),
         _block("t1", BlockRole.TABLE, "table-text", y0=0.3).model_dump(),
     ]
     chunks = svc.chunk_blocks(blocks=blocks, config=_config(max_blocks_per_chunk=3))
@@ -98,7 +98,7 @@ def test_block_chunking_max_blocks_cap_emits_continuation_with_context():
     blocks = [
         _block("h1", BlockRole.HEADING, "Big Section", y0=0.0).model_dump(),
         *[
-            _block(f"p{i}", BlockRole.PARAGRAPH, f"para {i}", y0=0.1 + i * 0.01).model_dump()
+            _block(f"p{i}", BlockRole.TEXT, f"para {i}", y0=0.1 + i * 0.01).model_dump()
             for i in range(6)
         ],
     ]
@@ -118,7 +118,7 @@ def test_block_chunking_role_filter_applies_whitelist():
     svc = BlockChunkingService()
     blocks = [
         _block("h1", BlockRole.HEADING, "H", y0=0.0).model_dump(),
-        _block("p1", BlockRole.PARAGRAPH, "para", y0=0.1).model_dump(),
+        _block("p1", BlockRole.TEXT, "para", y0=0.1).model_dump(),
         _block("t1", BlockRole.TABLE, "tab", y0=0.2).model_dump(),
     ]
     chunks = svc.chunk_blocks(
@@ -135,7 +135,7 @@ def test_block_chunking_skips_layout_blocks():
     blocks = [
         _block("hd", BlockRole.HEADER, "running header", y0=0.0).model_dump(),
         _block("h1", BlockRole.HEADING, "Real heading", y0=0.05).model_dump(),
-        _block("p1", BlockRole.PARAGRAPH, "real para", y0=0.1).model_dump(),
+        _block("p1", BlockRole.TEXT, "real para", y0=0.1).model_dump(),
         _block("ft", BlockRole.FOOTER, "page 1 of 5", y0=0.95).model_dump(),
         _block("mg", BlockRole.MARGINALIA, "[note]", y0=0.5).model_dump(),
     ]
@@ -153,10 +153,10 @@ def test_block_chunking_layout_skipped_even_when_in_filter():
     svc = BlockChunkingService()
     blocks = [
         _block("hd", BlockRole.HEADER, "noise", y0=0.0).model_dump(),
-        _block("p1", BlockRole.PARAGRAPH, "real", y0=0.1).model_dump(),
+        _block("p1", BlockRole.TEXT, "real", y0=0.1).model_dump(),
     ]
     chunks = svc.chunk_blocks(
-        blocks=blocks, config=_config(block_role_filter=["header", "paragraph"])
+        blocks=blocks, config=_config(block_role_filter=["header", "text"])
     )
     all_ids = {bid for c in chunks for bid in c.metadata["block_ids"]}
     assert "hd" not in all_ids
@@ -166,7 +166,7 @@ def test_block_chunking_layout_skipped_even_when_in_filter():
 def test_block_chunking_no_headings_groups_all_content():
     svc = BlockChunkingService()
     blocks = [
-        _block(f"p{i}", BlockRole.PARAGRAPH, f"para {i}", y0=0.1 * i).model_dump()
+        _block(f"p{i}", BlockRole.TEXT, f"para {i}", y0=0.1 * i).model_dump()
         for i in range(4)
     ]
     chunks = svc.chunk_blocks(blocks=blocks, config=_config(max_blocks_per_chunk=10))
@@ -180,8 +180,8 @@ def test_block_chunking_provenance_fields_populated():
     svc = BlockChunkingService()
     blocks = [
         _block("h1", BlockRole.HEADING, "Heading", page=2, y0=0.0).model_dump(),
-        _block("p1", BlockRole.PARAGRAPH, "paragraph A", page=2, y0=0.1).model_dump(),
-        _block("p2", BlockRole.PARAGRAPH, "paragraph B", page=3, y0=0.0).model_dump(),
+        _block("p1", BlockRole.TEXT, "paragraph A", page=2, y0=0.1).model_dump(),
+        _block("p2", BlockRole.TEXT, "paragraph B", page=3, y0=0.0).model_dump(),
     ]
     chunks = svc.chunk_blocks(
         blocks=blocks,
@@ -193,7 +193,7 @@ def test_block_chunking_provenance_fields_populated():
     meta = chunks[0].metadata
     assert meta["block_ids"] == ["h1", "p1", "p2"]
     assert meta["page_indices"] == [2, 3]
-    assert meta["block_roles"] == ["heading", "paragraph", "paragraph"]
+    assert meta["block_roles"] == ["heading", "text", "text"]
     assert len(meta["bboxes"]) == 3
     for bb in meta["bboxes"]:
         assert set(bb.keys()) == {"x0", "y0", "x1", "y1"}
@@ -205,7 +205,7 @@ def test_block_chunking_bbox_null_when_block_has_no_bbox():
     svc = BlockChunkingService()
     block_dict = Block(
         id="b1",
-        role=BlockRole.PARAGRAPH,
+        role=BlockRole.TEXT,
         native_type="p",
         page_index=0,
         text="no bbox",
@@ -226,7 +226,7 @@ def test_block_chunking_skips_chunk_when_heading_has_no_text():
     blocks = [
         _block("h1", BlockRole.HEADING, "", y0=0.0).model_dump(),   # empty text
         _block("h2", BlockRole.HEADING, "Real Heading", y0=0.1).model_dump(),
-        _block("p1", BlockRole.PARAGRAPH, "content", y0=0.2).model_dump(),
+        _block("p1", BlockRole.TEXT, "content", y0=0.2).model_dump(),
     ]
     chunks = svc.chunk_blocks(blocks=blocks, config=_config())
 
@@ -241,7 +241,7 @@ def test_block_chunking_skips_chunk_when_table_has_no_text():
     svc = BlockChunkingService()
     blocks = [
         _block("t1", BlockRole.TABLE, "", y0=0.0).model_dump(),     # empty text
-        _block("p1", BlockRole.PARAGRAPH, "caption text", y0=0.1).model_dump(),
+        _block("p1", BlockRole.TEXT, "caption text", y0=0.1).model_dump(),
     ]
     chunks = svc.chunk_blocks(blocks=blocks, config=_config())
 

--- a/backend/tests/services/test_chunking_dispatcher.py
+++ b/backend/tests/services/test_chunking_dispatcher.py
@@ -63,7 +63,7 @@ def test_dispatch_blocks_source_routes_to_block_service():
         ).model_dump(),
         Block(
             id="b2",
-            role=BlockRole.PARAGRAPH,
+            role=BlockRole.TEXT,
             native_type="p",
             page_index=0,
             bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}),
@@ -81,7 +81,7 @@ def test_dispatch_blocks_source_routes_to_block_service():
     assert len(chunks) == 1
     assert chunks[0].metadata["block_ids"] == ["b1", "b2"]
     assert chunks[0].metadata["page_indices"] == [0]
-    assert chunks[0].metadata["block_roles"] == ["heading", "paragraph"]
+    assert chunks[0].metadata["block_roles"] == ["heading", "text"]
 
 
 def test_dispatch_empty_text_returns_empty_list():

--- a/backend/tests/services/test_extraction_service.py
+++ b/backend/tests/services/test_extraction_service.py
@@ -18,7 +18,7 @@ def _make_cdm_doc(parse_run_id: str, source_document_id: str) -> ParsedDocument:
         parse_run_id=parse_run_id,
         page_count=1,
         pages=[Page(index=0, block_ids=["b1"])],
-        blocks=[Block(id="b1", role=BlockRole.PARAGRAPH, native_type="p", text="hello", page_index=0)],
+        blocks=[Block(id="b1", role=BlockRole.TEXT, native_type="p", text="hello", page_index=0)],
         full_markdown="hello",
     )
 

--- a/backend/tests/services/test_index_processing_cdm.py
+++ b/backend/tests/services/test_index_processing_cdm.py
@@ -256,8 +256,8 @@ async def test_process_index_block_source_produces_block_chunks():
     bbox = BBox(x0=0.1, y0=0.0, x1=0.9, y1=0.05, space=CoordSpace.NORMALIZED)
     blocks = [
         Block(id="b1", role=BlockRole.HEADING, native_type="h1", page_index=0, bbox=bbox, text="Heading").model_dump(),
-        Block(id="b2", role=BlockRole.PARAGRAPH, native_type="p", page_index=0, bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}), text="para 1").model_dump(),
-        Block(id="b3", role=BlockRole.PARAGRAPH, native_type="p", page_index=0, bbox=bbox.model_copy(update={"y0": 0.2, "y1": 0.3}), text="para 2").model_dump(),
+        Block(id="b2", role=BlockRole.TEXT, native_type="p", page_index=0, bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}), text="para 1").model_dump(),
+        Block(id="b3", role=BlockRole.TEXT, native_type="p", page_index=0, bbox=bbox.model_copy(update={"y0": 0.2, "y1": 0.3}), text="para 2").model_dump(),
     ]
 
     parsed_doc = MagicMock()
@@ -313,5 +313,5 @@ async def test_process_index_block_source_produces_block_chunks():
     assert chunk["source_type"] == "block"
     assert chunk["parse_run_id"] == str(parse_run_id)
     assert chunk["chunk_metadata"]["block_ids"] == ["b1", "b2", "b3"]
-    assert chunk["chunk_metadata"]["block_roles"] == ["heading", "paragraph", "paragraph"]
+    assert chunk["chunk_metadata"]["block_roles"] == ["heading", "text", "text"]
     assert chunk["chunk_metadata"]["page_indices"] == [0]

--- a/backend/tests/services/test_query_citation.py
+++ b/backend/tests/services/test_query_citation.py
@@ -85,7 +85,7 @@ async def test_citation_resolution_block_resolves_against_parsed_doc(monkeypatch
             bbox=bbox, text="Heading", quality=Quality(confidence=0.95),
         ).model_dump(),
         Block(
-            id="b2", role=BlockRole.PARAGRAPH, native_type="p", page_index=2,
+            id="b2", role=BlockRole.TEXT, native_type="p", page_index=2,
             bbox=bbox.model_copy(update={"y0": 0.1, "y1": 0.2}),
             text="body", quality=Quality(confidence=0.6),
         ).model_dump(),
@@ -112,7 +112,7 @@ async def test_citation_resolution_block_resolves_against_parsed_doc(monkeypatch
     cit = result.citation
     assert cit.block_ids == ["b1", "b2"]
     assert cit.page_indices == [2]
-    assert cit.block_roles == ["heading", "paragraph"]
+    assert cit.block_roles == ["heading", "text"]
     assert len(cit.bboxes) == 2
     assert cit.confidence == pytest.approx(0.6)
     repo_get.assert_awaited_once_with(parse_run_id)
@@ -160,7 +160,7 @@ async def test_block_chunk_page_indices_converted_to_1based_page_numbers():
         chunk_metadata={
             "block_ids": ["b1"],
             "page_indices": [0, 1],  # 0-based: pages 1 and 2 in the document
-            "block_roles": ["paragraph"],
+            "block_roles": ["text"],
             "bboxes": [None],
         },
     )

--- a/docs/superpowers/plans/2026-07-02-block-role-paragraph-to-text.md
+++ b/docs/superpowers/plans/2026-07-02-block-role-paragraph-to-text.md
@@ -1,0 +1,756 @@
+# BlockRole.PARAGRAPH → BlockRole.TEXT Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename `BlockRole.PARAGRAPH = "paragraph"` to `BlockRole.TEXT = "text"` across the entire codebase, including a data migration for existing JSONB/JSON columns.
+
+**Architecture:** Single-PR rename — no backward-compat alias needed (no prod data). Change the enum member name and serialized value in `models.py`, sweep all code/test references, and write an Alembic data migration that rewrites `"paragraph"` → `"text"` strings in the three JSON columns that store block roles.
+
+**Tech Stack:** Python 3.12, Alembic, PostgreSQL JSONB, React/TypeScript
+
+## Global Constraints
+
+- No new tests — existing suite is the verification harness; update it, don't extend it
+- `native_type` strings (`"text"`, `"paragraph"`) are parser vocabulary — never change them
+- `_ROLE_MAP` keys in adapter files are parser vocabulary — never change them; only update right-hand side enum references
+- Commit message style: `type(scope): description` (e.g. `refactor(cdm): rename BlockRole.PARAGRAPH to TEXT`)
+- Branch off `main`; link PR to the GitHub issue created in Task 1
+
+---
+
+## File Map
+
+**Modified — backend:**
+- `backend/app/cdm/models.py` — enum member rename
+- `backend/app/cdm/adapters/docling.py` — `_ROLE_MAP` right-hand sides
+- `backend/app/cdm/adapters/llamaparse.py` — `_ROLE_MAP` right-hand side
+- `backend/app/cdm/adapters/landing_ai.py` — fallback return + docstring
+- `backend/app/cdm/adapters/simple_text.py` — two `Block(role=...)` constructors
+- `backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py` — `Block(role=...)` constructor
+- `backend/app/cdm/adapters/custom_pipeline/merger.py` — comment only
+- `backend/app/services/block_chunking_service.py` — comment only
+- All test files referencing `BlockRole.PARAGRAPH` or `"paragraph"` as a role value (listed per task below)
+
+**Modified — frontend:**
+- `frontend/src/types/index.ts` — `BlockRole` union type + `BLOCK_ROLE_OPTIONS`
+- `frontend/src/components/parse-runs/DocumentPdfViewer.tsx` — color map key
+
+**Created — migration:**
+- `backend/alembic/versions/<hash>_rename_block_role_paragraph_to_text.py`
+
+---
+
+## Task 1: Setup — GitHub issue and feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Create GitHub issue**
+
+```bash
+gh issue create \
+  --title "refactor(cdm): rename BlockRole.PARAGRAPH to BlockRole.TEXT" \
+  --body "## Summary
+Rename the CDM block role from \`PARAGRAPH = \"paragraph\"\` to \`TEXT = \"text\"\` for semantic accuracy. Parsers emit this role for single words, labels, and empty strings — the name \"paragraph\" falsely implies multi-sentence prose.
+
+## Acceptance Criteria
+- [ ] \`BlockRole.TEXT = \"text\"\` exists; \`BlockRole.PARAGRAPH\` does not
+- [ ] Alembic migration rewrites \`\"paragraph\"\` → \`\"text\"\` in \`parsed_documents.content\`, \`chunks.chunk_metadata\`, \`indexes.config\`
+- [ ] All adapters produce \`BlockRole.TEXT\` for generic text blocks
+- [ ] All tests pass with no \`PARAGRAPH\` references remaining in app code
+- [ ] Frontend \`BlockRole\` type and color map updated
+
+## References
+- Spec: \`docs/superpowers/specs/2026-07-02-block-role-paragraph-to-text-design.md\`
+- Plan: \`docs/superpowers/plans/2026-07-02-block-role-paragraph-to-text.md\`"
+```
+
+Note the issue number printed — you'll need it for the PR.
+
+- [ ] **Step 2: Create feature branch**
+
+```bash
+git checkout -b refactor/block-role-paragraph-to-text
+```
+
+---
+
+## Task 2: Alembic data migration
+
+**Files:**
+- Create: `backend/alembic/versions/<hash>_rename_block_role_paragraph_to_text.py`
+
+**Interfaces:**
+- Produces: Alembic migration that rewrites `"paragraph"` → `"text"` in `parsed_documents.content[blocks][*].role`, `chunks.chunk_metadata[block_roles][*]`, `indexes.config[blockRoleFilter][*]`
+
+- [ ] **Step 1: Generate the migration file**
+
+```bash
+cd backend && alembic revision -m "rename_block_role_paragraph_to_text"
+```
+
+Alembic prints the new file path, e.g.:
+```
+Generating .../alembic/versions/abc123_rename_block_role_paragraph_to_text.py
+```
+
+- [ ] **Step 2: Write the migration**
+
+Open the generated file and replace its entire contents with:
+
+```python
+"""rename block role paragraph to text
+
+Revision ID: <keep the auto-generated value>
+Revises: <keep the auto-generated value>
+Create Date: <keep the auto-generated value>
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "<keep>"
+down_revision: Union[str, None] = "<keep>"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # parsed_documents: rewrite role field on each block in the blocks array
+    op.execute("""
+        UPDATE parsed_documents
+        SET content = jsonb_set(
+            content,
+            '{blocks}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        WHEN elem->>'role' = 'paragraph'
+                        THEN jsonb_set(elem, '{role}', '"text"')
+                        ELSE elem
+                    END
+                )
+                FROM jsonb_array_elements(content->'blocks') AS elem
+            )
+        )
+        WHERE EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(content->'blocks') AS elem
+            WHERE elem->>'role' = 'paragraph'
+        )
+    """)
+
+    # chunks: rewrite role values in block_roles array
+    op.execute("""
+        UPDATE chunks
+        SET chunk_metadata = (
+            jsonb_set(
+                chunk_metadata::jsonb,
+                '{block_roles}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"paragraph"' THEN '"text"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+                )
+            )
+        )::json
+        WHERE chunk_metadata::jsonb ? 'block_roles'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+            WHERE elem::text = '"paragraph"'
+          )
+    """)
+
+    # indexes: rewrite role values in blockRoleFilter array
+    op.execute("""
+        UPDATE indexes
+        SET config = (
+            jsonb_set(
+                config::jsonb,
+                '{blockRoleFilter}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"paragraph"' THEN '"text"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+                )
+            )
+        )::json
+        WHERE config::jsonb ? 'blockRoleFilter'
+          AND config::jsonb->'blockRoleFilter' IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+            WHERE elem::text = '"paragraph"'
+          )
+    """)
+
+
+def downgrade() -> None:
+    # parsed_documents: revert text → paragraph
+    op.execute("""
+        UPDATE parsed_documents
+        SET content = jsonb_set(
+            content,
+            '{blocks}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        WHEN elem->>'role' = 'text'
+                        THEN jsonb_set(elem, '{role}', '"paragraph"')
+                        ELSE elem
+                    END
+                )
+                FROM jsonb_array_elements(content->'blocks') AS elem
+            )
+        )
+        WHERE EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(content->'blocks') AS elem
+            WHERE elem->>'role' = 'text'
+        )
+    """)
+
+    # chunks: revert text → paragraph
+    op.execute("""
+        UPDATE chunks
+        SET chunk_metadata = (
+            jsonb_set(
+                chunk_metadata::jsonb,
+                '{block_roles}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"text"' THEN '"paragraph"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+                )
+            )
+        )::json
+        WHERE chunk_metadata::jsonb ? 'block_roles'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+            WHERE elem::text = '"text"'
+          )
+    """)
+
+    # indexes: revert text → paragraph
+    op.execute("""
+        UPDATE indexes
+        SET config = (
+            jsonb_set(
+                config::jsonb,
+                '{blockRoleFilter}',
+                (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN elem::text = '"text"' THEN '"paragraph"'::jsonb
+                            ELSE elem
+                        END
+                    )
+                    FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+                )
+            )
+        )::json
+        WHERE config::jsonb ? 'blockRoleFilter'
+          AND config::jsonb->'blockRoleFilter' IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+            WHERE elem::text = '"text"'
+          )
+    """)
+```
+
+- [ ] **Step 3: Verify the migration runs**
+
+```bash
+cd backend && alembic upgrade head
+```
+
+Expected: no errors, migration applies cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/alembic/versions/
+git commit -m "feat(cdm): alembic migration — rename block role paragraph to text in JSONB columns"
+```
+
+---
+
+## Task 3: Backend enum rename and full code sweep
+
+**Files:**
+- Modify: `backend/app/cdm/models.py`
+- Modify: `backend/app/cdm/adapters/docling.py`
+- Modify: `backend/app/cdm/adapters/llamaparse.py`
+- Modify: `backend/app/cdm/adapters/landing_ai.py`
+- Modify: `backend/app/cdm/adapters/simple_text.py`
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py`
+- Modify: `backend/app/cdm/adapters/custom_pipeline/merger.py`
+- Modify: `backend/app/services/block_chunking_service.py`
+- Modify: all backend test files listed below
+
+**Rule — applies to every file in this task:**
+- `BlockRole.PARAGRAPH` → `BlockRole.TEXT` everywhere
+- String literals `"paragraph"` used as a CDM role value → `"text"` (in `role=`, `"role": "paragraph"`, `block_role_filter`, `block_roles`, `drop` config lists)
+- `native_type="paragraph"` — leave alone (parser vocabulary)
+- `_ROLE_MAP` keys (left-hand side) — leave alone (parser vocabulary)
+
+- [ ] **Step 1: Rename the enum member in models.py**
+
+In `backend/app/cdm/models.py`, change:
+```python
+PARAGRAPH  = "paragraph"
+```
+to:
+```python
+TEXT       = "text"
+```
+
+- [ ] **Step 2: Update adapter files**
+
+**`backend/app/cdm/adapters/docling.py`** — update two map entries:
+```python
+_ROLE_MAP: Dict[str, BlockRole] = {
+    "title":               BlockRole.TITLE,
+    "section_header":      BlockRole.HEADING,
+    "text":                BlockRole.TEXT,       # was PARAGRAPH
+    "paragraph":           BlockRole.TEXT,       # was PARAGRAPH; key stays
+    ...
+}
+```
+
+**`backend/app/cdm/adapters/llamaparse.py`** — update one map entry:
+```python
+_ROLE_MAP: Dict[str, BlockRole] = {
+    "heading": BlockRole.HEADING,
+    "text":    BlockRole.TEXT,    # was PARAGRAPH
+    ...
+}
+```
+
+**`backend/app/cdm/adapters/landing_ai.py`** — update the fallback return and docstring:
+```python
+def _detect_text_role(markdown: str) -> BlockRole:
+    """Map a text chunk's markdown to TITLE, HEADING, or TEXT."""  # was PARAGRAPH
+    first = _first_content_line(markdown)
+    m = _HEADING_RE.match(first)
+    if not m:
+        return BlockRole.TEXT   # was PARAGRAPH
+    return BlockRole.TITLE if len(m.group(1)) == 1 else BlockRole.HEADING
+```
+
+**`backend/app/cdm/adapters/simple_text.py`** — update both Block constructors:
+```python
+# boundary-based block (line ~36)
+block = Block(
+    id=block_id,
+    role=BlockRole.TEXT,     # was PARAGRAPH
+    native_type="text",
+    ...
+)
+
+# fallback single-block (line ~52)
+blocks = [Block(
+    id=block_id,
+    role=BlockRole.TEXT,     # was PARAGRAPH
+    native_type="text",
+    ...
+)]
+```
+
+**`backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py`** — update Block constructor (~line 108):
+```python
+block = Block(
+    id=prov_id,
+    role=BlockRole.TEXT,     # was PARAGRAPH
+    native_type="text",
+    ...
+)
+```
+
+**`backend/app/cdm/adapters/custom_pipeline/merger.py`** — update comment:
+```python
+# Before: "A fitz PARAGRAPH block that overlaps..."
+# After:  "A fitz TEXT block that overlaps..."
+```
+
+**`backend/app/services/block_chunking_service.py`** — update comment (~line 13):
+```python
+#    - Other content roles (TEXT/LIST/CAPTION/CODE/FORMULA): append to   # was PARAGRAPH/LIST/...
+```
+
+- [ ] **Step 3: Update backend test files**
+
+Apply the rule at the top of this task to every file below. For each file, the change is mechanical: `BlockRole.PARAGRAPH` → `BlockRole.TEXT`, and `"paragraph"` → `"text"` where it is a role value (not a `native_type`).
+
+**`backend/tests/cdm/test_models.py`** — also update the value assertion:
+```python
+assert BlockRole.TEXT.value == "text"   # was PARAGRAPH.value == "paragraph"
+```
+
+**`backend/tests/cdm/adapters/test_docling_adapter.py`** — update parametrize tuples:
+```python
+("text",      BlockRole.TEXT),   # was PARAGRAPH
+("paragraph", BlockRole.TEXT),   # was PARAGRAPH; key string stays
+```
+
+**`backend/tests/cdm/adapters/test_llamaparse_adapter.py`**:
+```python
+("text", BlockRole.TEXT),        # was PARAGRAPH
+
+# and assertion:
+assert body.role.value == "text"  # was "paragraph"
+```
+
+**`backend/tests/cdm/test_landing_ai_adapter.py`** — update all `BlockRole.PARAGRAPH` references and role value assertions:
+```python
+assert _detect_text_role("Hello world.") == BlockRole.TEXT    # was PARAGRAPH
+assert _detect_text_role("...") == BlockRole.TEXT             # all fallback cases
+assert doc.blocks[0].role == BlockRole.TEXT
+assert by_id["c-para"].role == BlockRole.TEXT
+assert BlockRole.TEXT in roles
+```
+
+**`backend/tests/cdm/adapters/test_simple_text_adapter.py`**:
+```python
+assert all(b.role == BlockRole.TEXT for b in doc.blocks)   # was PARAGRAPH
+```
+
+**`backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py`**:
+```python
+paras = [b for b in result.blocks if b.role == BlockRole.TEXT]   # was PARAGRAPH
+para  = next(b for b in result.blocks if b.role == BlockRole.TEXT)
+```
+
+**`backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py`**:
+```python
+block = Block(id="fitz:0:0", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+```
+
+**`backend/tests/cdm/adapters/custom_pipeline/test_merger.py`**:
+```python
+Block(id="fitz:0:0", role=BlockRole.TEXT, ...),   # both blocks
+Block(id="fitz:0:1", role=BlockRole.TEXT, ...),
+```
+
+**`backend/tests/cdm/adapters/custom_pipeline/test_adapter.py`**:
+```python
+Block(id="doc1:0:0", role=BlockRole.TEXT, ...),
+Block(id="doc1:1:0", role=BlockRole.TEXT, ...),
+```
+
+**`backend/tests/cdm/test_workloads.py`**:
+```python
+role=BlockRole.TEXT,
+native_type="paragraph",   # ← leave alone (native type string)
+```
+
+**`backend/tests/cdm/test_models.py`** (covered above in Step 3 opener).
+
+**`backend/tests/repositories/test_parsed_document_round_trip.py`**:
+```python
+role=BlockRole.TEXT,   # was PARAGRAPH
+```
+
+**`backend/tests/services/test_block_chunking_service.py`** — update all `BlockRole.PARAGRAPH` and `"paragraph"` role-value strings:
+```python
+_block("b2", BlockRole.TEXT, ...)
+_block("p1", BlockRole.TEXT, ...)
+# ...all _block() calls that use PARAGRAPH
+
+# filter lists:
+config=_config(block_role_filter=["header", "text"])   # was "paragraph"
+
+# assertions on block_roles metadata:
+assert chunks[0].metadata["block_roles"] == ["heading", "text", "text"]  # was "paragraph"
+assert meta["block_roles"] == ["heading", "text", "text"]
+```
+
+**`backend/tests/services/test_chunking_dispatcher.py`**:
+```python
+role=BlockRole.TEXT,   # was PARAGRAPH
+assert chunks[0].metadata["block_roles"] == ["heading", "text"]   # was "paragraph"
+```
+
+**`backend/tests/services/test_index_processing_cdm.py`**:
+```python
+role=BlockRole.TEXT,   # was PARAGRAPH
+```
+
+**`backend/tests/services/test_extraction_service.py`**:
+```python
+Block(id="b1", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+```
+
+**`backend/tests/services/test_query_citation.py`**:
+```python
+# ~line 88 — Block constructor
+id="b2", role=BlockRole.TEXT, native_type="p", page_index=2,   # was PARAGRAPH
+
+# ~line 115 — assertion on block_roles list
+assert cit.block_roles == ["heading", "text"]   # was "paragraph"
+
+# ~line 163 — raw dict
+"block_roles": ["text"],   # was "paragraph"
+```
+
+**`backend/tests/services/classification/test_service.py`**:
+```python
+Block(id=f"b{i}", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+```
+
+**`backend/tests/services/classification/test_serializer.py`**:
+```python
+role=BlockRole.TEXT,
+native_type="paragraph",   # ← leave alone (native type string)
+```
+
+**`backend/tests/services/classification/test_assembler.py`**:
+```python
+role=BlockRole.TEXT,
+native_type="paragraph",   # ← leave alone
+```
+
+**`backend/tests/services/classification/test_llm_classifier.py`**:
+```python
+Block(id=f"b{i}", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+```
+
+**`backend/tests/services/parsing/test_custom_pipeline_runner.py`**:
+```python
+assert any(b.role == BlockRole.TEXT for b in doc.blocks)   # was PARAGRAPH
+```
+
+**`backend/tests/adapters/extraction/test_pipeline.py`**:
+```python
+Block(id=f"b{i}", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+
+# block_filter drop config — this IS a role value, not a native_type:
+preprocess=[{"stage": "block_filter", "config": {"drop": ["text"]}}]   # was "paragraph"
+```
+
+**`backend/tests/adapters/extraction/test_llm_context.py`**:
+```python
+role=BlockRole.TEXT,
+native_type="paragraph",   # ← leave alone
+```
+
+**`backend/tests/adapters/extraction/preprocess/test_block_filter.py`**:
+```python
+Block(id="p", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+```
+
+**`backend/tests/adapters/extraction/chunking/test_token_budget.py`**:
+```python
+Block(id=f"b{i}", role=BlockRole.TEXT, ...)   # was PARAGRAPH
+```
+
+**`backend/tests/routers/test_classification_router.py`** — raw dict fixtures and assertions:
+```python
+{"id": "b-1", "role": "text", "native_type": "paragraph", "text": "Foo", ...},  # role → "text"; native_type stays
+{"id": "b-2", "role": "text", "native_type": "paragraph", "text": "Bar", ...},
+
+assert data[0]["role"] == "text"   # was "paragraph"
+```
+
+**`backend/tests/repositories/test_classification_run_repository.py`** — raw dict fixtures:
+```python
+{"id": "b-2", "role": "text", "native_type": "paragraph", ...},   # role → "text"
+{"id": "b-3", "role": "text", "native_type": "paragraph", ...},
+```
+
+**`backend/tests/schemas/test_index_config_schema.py`** — filter list:
+```python
+"blockRoleFilter": ["text"],         # was "paragraph"
+assert cfg.block_role_filter == ["text"]   # was "paragraph"
+```
+
+- [ ] **Step 4: Run the full backend test suite**
+
+```bash
+cd backend && uv run python -m pytest -o "addopts="
+```
+
+Expected: all tests pass. If any test fails with `AttributeError: PARAGRAPH`, you missed a reference — search for it:
+
+```bash
+grep -r "BlockRole\.PARAGRAPH\|\"role\".*paragraph\|role.*=.*paragraph" backend/ --include="*.py"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/
+git commit -m "refactor(cdm): rename BlockRole.PARAGRAPH to BlockRole.TEXT"
+```
+
+---
+
+## Task 4: Frontend sweep
+
+**Files:**
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/components/parse-runs/DocumentPdfViewer.tsx`
+- Modify: `frontend/src/components/parse-runs/ParsedDocumentPane.test.tsx`
+- Modify: `frontend/src/components/parse-runs/DocumentPdfViewer.test.tsx`
+- Modify: `frontend/src/hooks/useClassificationRuns.test.ts`
+- Modify: `frontend/src/pages/IndexDetailPage.test.tsx`
+- Modify: `frontend/src/components/indexes/BlockConfigPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: backend API now returns `"text"` as role value for generic text blocks (from Task 3)
+
+- [ ] **Step 1: Update types/index.ts**
+
+In `frontend/src/types/index.ts`, make two changes:
+
+```typescript
+// BlockRole union type — change 'paragraph' to 'text'
+export type BlockRole =
+  | 'title'
+  | 'heading'
+  | 'text'         // was 'paragraph'
+  | 'list'
+  | 'table'
+  | 'figure'
+  | 'caption'
+  | 'header'
+  | 'footer'
+  | 'marginalia'
+  | 'code'
+  | 'formula'
+  | 'link'
+  | 'other'
+
+// BLOCK_ROLE_OPTIONS array
+export const BLOCK_ROLE_OPTIONS: BlockRole[] = [
+  'title', 'heading', 'text', 'list', 'table', 'figure',   // was 'paragraph'
+  'caption', 'code', 'formula', 'link', 'other',
+]
+```
+
+- [ ] **Step 2: Update DocumentPdfViewer.tsx color map**
+
+In `frontend/src/components/parse-runs/DocumentPdfViewer.tsx`, change the color map key:
+
+```typescript
+// was:  paragraph: 'rgb(107,114,128)',
+text: 'rgb(107,114,128)',
+```
+
+- [ ] **Step 3: Update frontend test files**
+
+Apply the rule: `'paragraph'` → `'text'` where it is a role value.
+
+**`frontend/src/components/parse-runs/ParsedDocumentPane.test.tsx`**:
+```typescript
+{ id: 'b1', page_index: 0, role: 'text', text: 'Block one' },   // was 'paragraph'
+expect(screen.getAllByText('text').length).toBeGreaterThan(0)      // was 'paragraph'
+// second occurrence:
+blocks: [{ id: 'b1', page_index: 0, role: 'text', text: 'Block one' }],  // was 'paragraph'
+```
+
+**`frontend/src/components/parse-runs/DocumentPdfViewer.test.tsx`**:
+```typescript
+role: 'text',   // was 'paragraph'
+```
+
+**`frontend/src/hooks/useClassificationRuns.test.ts`**:
+```typescript
+{ blockId: 'b-1', pageIndex: 0, role: 'text', ... },   // was 'paragraph'
+{ blockId: 'b-2', pageIndex: 1, role: 'text', ... },   // was 'paragraph'
+```
+
+**`frontend/src/pages/IndexDetailPage.test.tsx`**:
+```typescript
+blockRoleFilter: ['text', 'heading'],                  // was ['paragraph', 'heading']
+expect(screen.getByText('text, heading')).toBeInTheDocument()   // was 'paragraph, heading'
+```
+
+**`frontend/src/components/indexes/BlockConfigPanel.test.tsx`**:
+```typescript
+config={{ ...baseConfig, blockRoleFilter: ['table', 'text'] }}   // was 'paragraph'
+expect(screen.getByRole('button', { name: /^text$/i }))          // was /^paragraph$/i
+```
+
+- [ ] **Step 4: Run frontend tests and lint**
+
+```bash
+cd frontend && npx vitest run && npm run lint
+```
+
+Expected: all tests pass, no lint errors. If any test fails with a `'paragraph'` reference, search:
+
+```bash
+grep -r "paragraph" frontend/src --include="*.ts" --include="*.tsx"
+```
+
+Any remaining `'paragraph'` hits that are role values (not comments or unrelated UI copy like "Attach paragraphs and tables…") need updating.
+
+- [ ] **Step 5: Build to verify no type errors**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: clean build with no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/
+git commit -m "refactor(cdm): update frontend BlockRole type paragraph → text"
+```
+
+---
+
+## Task 5: PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin refactor/block-role-paragraph-to-text
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "refactor(cdm): rename BlockRole.PARAGRAPH to BlockRole.TEXT" \
+  --body "Closes #<issue-number>
+
+## Summary
+- Renames \`BlockRole.PARAGRAPH = \"paragraph\"\` → \`BlockRole.TEXT = \"text\"\` in the CDM enum
+- Alembic data migration rewrites \`\"paragraph\"\` → \`\"text\"\` in \`parsed_documents.content\`, \`chunks.chunk_metadata\`, \`indexes.config\`
+- Full sweep of ~45 backend files and 5 frontend files
+- No new tests — existing suite updated
+
+## Why
+\`PARAGRAPH\` is a misnomer. Every parser maps their native \"text\" type to this role, and the content is often a single word or label, not a paragraph. \`TEXT\` is accurate and matches parser vocabulary (LlamaParse: \`\"text\"\`, fitz: \`native_type=\"text\"\`, Docling: \`\"text\"\`).
+
+## Notes for reviewer
+- \`native_type\` strings (\`\"paragraph\"\`, \`\"text\"\`) are parser vocabulary and are intentionally unchanged
+- \`_ROLE_MAP\` keys in adapter files are parser vocabulary and intentionally unchanged
+- No prod data exists; migration handles dev data only
+
+## Test plan
+- [ ] \`cd backend && uv run python -m pytest -o \"addopts=\"\` — all pass
+- [ ] \`cd frontend && npx vitest run && npm run lint && npm run build\` — all pass
+- [ ] \`alembic upgrade head\` applies cleanly
+- [ ] \`alembic downgrade -1\` reverses cleanly"
+```

--- a/docs/superpowers/specs/2026-07-02-block-role-paragraph-to-text-design.md
+++ b/docs/superpowers/specs/2026-07-02-block-role-paragraph-to-text-design.md
@@ -1,0 +1,193 @@
+# Design: Rename `BlockRole.PARAGRAPH` → `BlockRole.TEXT`
+
+**Date:** 2026-07-02  
+**Status:** Approved  
+**Scope:** Single PR — enum rename + Alembic data migration + full code/test sweep  
+**No prod data** — no backward-compat alias required
+
+---
+
+## 1. Problem
+
+`BlockRole.PARAGRAPH` is the CDM's catch-all "generic text block" role, but the name is misleading. Every parser maps their native "text" type to it:
+
+| Parser | Native type → CDM role |
+|---|---|
+| fitz (PyMuPDF) | `btype == 0` → `PARAGRAPH` |
+| LlamaParse | `"text"` → `PARAGRAPH` |
+| Docling | `"text"`, `"paragraph"` → `PARAGRAPH` |
+| LandingAI | fallback default → `PARAGRAPH` |
+| SimpleText | every line → `PARAGRAPH` |
+
+A block with `role=PARAGRAPH` is frequently a single word, a label, or an empty string. The name implies multi-sentence prose — a semantic claim the CDM cannot make and parsers do not support.
+
+`TEXT` is the accurate label: it means "a block of extracted text whose internal structure we do not know."
+
+---
+
+## 2. Decision
+
+Rename the enum member and its serialized string value:
+
+```python
+# before
+PARAGRAPH = "paragraph"
+
+# after
+TEXT = "text"
+```
+
+No backward-compat alias. No staged migration. Single PR.
+
+---
+
+## 3. Database Migration
+
+`"paragraph"` is stored as a plain string in three JSONB/JSON columns. No typed Postgres `ENUM` is involved, so no `ALTER TYPE` is needed — only targeted `UPDATE` statements via `op.execute()` in a new Alembic migration.
+
+| Table | Column | JSON path |
+|---|---|---|
+| `parsed_documents` | `content` (JSONB) | `blocks[*].role` |
+| `chunks` | `chunk_metadata` (JSON) | `block_roles[*]` |
+| `indexes` | `config` (JSON) | `blockRoleFilter[*]` |
+
+Classification tables (`classification_runs`, `classification_regions`) do **not** store block roles independently — roles are derived live by deserializing `parsed_documents.content` at query time. No migration needed there.
+
+### Migration SQL (upgrade)
+
+```sql
+-- parsed_documents: rewrite role in each block
+UPDATE parsed_documents
+SET content = jsonb_set(
+  content,
+  '{blocks}',
+  (
+    SELECT jsonb_agg(
+      CASE
+        WHEN elem->>'role' = 'paragraph'
+        THEN jsonb_set(elem, '{role}', '"text"')
+        ELSE elem
+      END
+    )
+    FROM jsonb_array_elements(content->'blocks') AS elem
+  )
+)
+WHERE content->'blocks' @> '[{"role": "paragraph"}]';
+
+-- chunks: rewrite role values in block_roles array
+UPDATE chunks
+SET chunk_metadata = jsonb_set(
+  chunk_metadata::jsonb,
+  '{block_roles}',
+  (
+    SELECT jsonb_agg(
+      CASE
+        WHEN elem::text = '"paragraph"' THEN '"text"'::jsonb
+        ELSE elem
+      END
+    )
+    FROM jsonb_array_elements(chunk_metadata::jsonb->'block_roles') AS elem
+  )
+)
+WHERE chunk_metadata::jsonb @> '{"block_roles": ["paragraph"]}';
+
+-- indexes: rewrite role values in blockRoleFilter array
+UPDATE indexes
+SET config = jsonb_set(
+  config::jsonb,
+  '{blockRoleFilter}',
+  (
+    SELECT jsonb_agg(
+      CASE
+        WHEN elem::text = '"paragraph"' THEN '"text"'::jsonb
+        ELSE elem
+      END
+    )
+    FROM jsonb_array_elements(config::jsonb->'blockRoleFilter') AS elem
+  )
+)
+WHERE config::jsonb->'blockRoleFilter' IS NOT NULL
+  AND config::jsonb @> '{"blockRoleFilter": ["paragraph"]}';
+```
+
+The downgrade reverses each substitution (`"text"` → `"paragraph"`).
+
+---
+
+## 4. Code Sweep
+
+### Backend (~60 files)
+
+**Rule:** If it is a `BlockRole.*` enum member reference → update. If it is a `_ROLE_MAP` key or `native_type` string (parser vocabulary) → leave alone.
+
+**`backend/app/cdm/models.py`**
+```python
+PARAGRAPH = "paragraph"  →  TEXT = "text"
+```
+
+**Adapter `_ROLE_MAP` right-hand sides** (`docling.py`, `llamaparse.py`):
+```python
+# before
+"text":      BlockRole.PARAGRAPH,
+"paragraph": BlockRole.PARAGRAPH,   # docling only
+
+# after
+"text":      BlockRole.TEXT,
+"paragraph": BlockRole.TEXT,        # key stays — docling's own label
+```
+
+**`fitz_tool.py`** — inline Block constructor:
+```python
+# before
+Block(role=BlockRole.PARAGRAPH, native_type="text", ...)
+# after
+Block(role=BlockRole.TEXT, native_type="text", ...)
+# native_type="text" unchanged — that's what fitz calls it
+```
+
+**`landing_ai.py`** — fallback return in `_detect_text_role`:
+```python
+return BlockRole.PARAGRAPH  →  return BlockRole.TEXT
+```
+
+**`simple_text.py`** — two inline Block constructors.
+
+**All other backend files** — sweep `BlockRole.PARAGRAPH` → `BlockRole.TEXT`.
+
+### Frontend (2 files)
+
+**`frontend/src/types/index.ts`**:
+```typescript
+// BlockRole union type
+| 'paragraph'  →  | 'text'
+
+// BLOCK_ROLE_OPTIONS array
+'paragraph'  →  'text'
+```
+
+**`frontend/src/components/parse-runs/DocumentPdfViewer.tsx`**:
+```typescript
+// color map key
+paragraph: 'rgb(107,114,128)'  →  text: 'rgb(107,114,128)'
+```
+
+---
+
+## 5. Test Sweep
+
+No new tests. Existing suite covers the rename fully.
+
+- All `BlockRole.PARAGRAPH` → `BlockRole.TEXT`
+- Role-value string literals `"paragraph"` → `"text"` in fixtures (`role="paragraph"`, `block_role_filter=["paragraph"]`, assertions on `block_roles`)
+- `native_type="paragraph"` in test fixtures **stays** — it's docling adapter source vocabulary
+
+Key test: `test_models.py:17` asserts `BlockRole.PARAGRAPH.value == "paragraph"` → becomes `BlockRole.TEXT.value == "text"`.
+
+---
+
+## 6. What Does NOT Change
+
+- `native_type` strings throughout — `"text"`, `"paragraph"` as parser-native labels are untouched
+- `_ROLE_MAP` keys in adapter files
+- The docling adapter's `"paragraph"` key (Docling's own element label)
+- Color, display logic, chunking logic — only the string value and enum name change

--- a/frontend/src/components/indexes/BlockConfigPanel.test.tsx
+++ b/frontend/src/components/indexes/BlockConfigPanel.test.tsx
@@ -35,14 +35,14 @@ describe('BlockConfigPanel', () => {
   it('shows existing role filter as selected', () => {
     render(
       <BlockConfigPanel
-        config={{ ...baseConfig, blockRoleFilter: ['table', 'paragraph'] }}
+        config={{ ...baseConfig, blockRoleFilter: ['table', 'text'] }}
         onUpdate={vi.fn()}
       />
     )
     expect(screen.getByRole('button', { name: /^table$/i })).toHaveAttribute(
       'aria-pressed', 'true'
     )
-    expect(screen.getByRole('button', { name: /^paragraph$/i })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: /^text$/i })).toHaveAttribute(
       'aria-pressed', 'true'
     )
   })

--- a/frontend/src/components/parse-runs/DocumentPdfViewer.test.tsx
+++ b/frontend/src/components/parse-runs/DocumentPdfViewer.test.tsx
@@ -27,7 +27,7 @@ const makeBlocks = (): Block[] => [
   {
     id: 'b1',
     page_index: 0,
-    role: 'paragraph',
+    role: 'text',
     text: 'Hello',
     bbox: { x0: 0.1, y0: 0.1, x1: 0.5, y1: 0.2 },
   },

--- a/frontend/src/components/parse-runs/DocumentPdfViewer.tsx
+++ b/frontend/src/components/parse-runs/DocumentPdfViewer.tsx
@@ -18,7 +18,7 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1'
 const ROLE_COLOR: Record<string, string> = {
   title: 'rgb(59,130,246)',
   heading: 'rgb(99,102,241)',
-  paragraph: 'rgb(107,114,128)',
+  text: 'rgb(107,114,128)',
   list: 'rgb(245,158,11)',
   table: 'rgb(16,185,129)',
   figure: 'rgb(139,92,246)',

--- a/frontend/src/components/parse-runs/ParsedDocumentPane.test.tsx
+++ b/frontend/src/components/parse-runs/ParsedDocumentPane.test.tsx
@@ -14,7 +14,7 @@ const makeDoc = (overrides = {}): ParsedDocumentDetail => ({
   content: {
     pages: [{ index: 0 }],
     blocks: [
-      { id: 'b1', page_index: 0, role: 'paragraph', text: 'Block one' },
+      { id: 'b1', page_index: 0, role: 'text', text: 'Block one' },
       { id: 'b2', page_index: 0, role: 'table', text: 'Block two' },
     ],
   },
@@ -24,7 +24,7 @@ const makeDoc = (overrides = {}): ParsedDocumentDetail => ({
 describe('ParsedDocumentPane', () => {
   it('renders block roles', () => {
     render(<ParsedDocumentPane parsedDocument={makeDoc()} />)
-    expect(screen.getAllByText('paragraph').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('text').length).toBeGreaterThan(0)
     expect(screen.getAllByText('table').length).toBeGreaterThan(0)
   })
 
@@ -69,7 +69,7 @@ describe('ParsedDocumentPane — label overlays', () => {
     fullMarkdown: '# Hello',
     content: {
       pages: [{ index: 0 }],
-      blocks: [{ id: 'b1', page_index: 0, role: 'paragraph', text: 'Block one' }],
+      blocks: [{ id: 'b1', page_index: 0, role: 'text', text: 'Block one' }],
     },
   })
 

--- a/frontend/src/hooks/useClassificationRuns.test.ts
+++ b/frontend/src/hooks/useClassificationRuns.test.ts
@@ -12,8 +12,8 @@ import * as api from '@/api/classification'
 const mockGetBlocks = vi.mocked(api.getClassificationRunBlocks)
 
 const mockBlocks: AnnotatedBlock[] = [
-  { blockId: 'b-1', pageIndex: 0, role: 'paragraph', text: 'Hello', markdown: null, label: 'intro' },
-  { blockId: 'b-2', pageIndex: 1, role: 'paragraph', text: 'World', markdown: null, label: null },
+  { blockId: 'b-1', pageIndex: 0, role: 'text', text: 'Hello', markdown: null, label: 'intro' },
+  { blockId: 'b-2', pageIndex: 1, role: 'text', text: 'World', markdown: null, label: null },
 ]
 
 beforeEach(() => {

--- a/frontend/src/pages/IndexDetailPage.test.tsx
+++ b/frontend/src/pages/IndexDetailPage.test.tsx
@@ -302,7 +302,7 @@ describe('IndexDetailPage — full config panel', () => {
           chunkingStrategy: 'block' as const,
           groupByHeading: true,
           maxBlocksPerChunk: 5,
-          blockRoleFilter: ['paragraph', 'heading'],
+          blockRoleFilter: ['text', 'heading'],
         },
       },
       chunks: null,
@@ -319,7 +319,7 @@ describe('IndexDetailPage — full config panel', () => {
 
     expect(screen.getByText('Yes')).toBeInTheDocument()
     expect(screen.getByText('5')).toBeInTheDocument()
-    expect(screen.getByText('paragraph, heading')).toBeInTheDocument()
+    expect(screen.getByText('text, heading')).toBeInTheDocument()
   })
 
   it('shows "all" for role filter when blockRoleFilter is null', async () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -46,7 +46,7 @@ export interface IndexConfig {
 export type BlockRole =
   | 'title'
   | 'heading'
-  | 'paragraph'
+  | 'text'
   | 'list'
   | 'table'
   | 'figure'
@@ -60,7 +60,7 @@ export type BlockRole =
   | 'other'
 
 export const BLOCK_ROLE_OPTIONS: BlockRole[] = [
-  'title', 'heading', 'paragraph', 'list', 'table', 'figure',
+  'title', 'heading', 'text', 'list', 'table', 'figure',
   'caption', 'code', 'formula', 'link', 'other',
 ]
 


### PR DESCRIPTION
Closes #137

## Summary

- Renames `BlockRole.PARAGRAPH = "paragraph"` → `BlockRole.TEXT = "text"` in the CDM enum (`backend/app/cdm/models.py`)
- Adds Alembic data migration (`30add7b93531`) that rewrites `"role": "paragraph"` → `"role": "text"` in `parsed_documents.content`, `chunks.chunk_metadata`, and `indexes.config`
- Updates all adapter `_ROLE_MAP` right-hand sides to `BlockRole.TEXT` (map keys unchanged — they are parser vocabulary)
- Sweeps all backend and frontend code, tests, and snapshot fixtures

## Test plan

- [x] Backend: `uv run python -m pytest -o "addopts="` — 1143+ passed, 0 failures introduced by this change
- [x] Frontend: `npx vitest run` — all tests pass; the 1 pre-existing failure in `ParseMethodSelector.test.tsx` (unrelated camelot checkbox) is present on `main` too
- [x] Frontend lint: `npm run lint` — clean
- [x] Frontend build: `npm run build` — successful
- [x] Alembic migration: run `alembic upgrade head` inside Docker to verify SQL executes cleanly against live data

## Notes

- `native_type` strings (e.g. `"paragraph"` in docling adapter map keys) are parser vocabulary and are intentionally unchanged
- No production data exists yet; migration is safe to run without a backup guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)