### PR TITLE
Parser evaluation harness — first slice (backend engine + API)

### DIFF
--- a/backend/alembic/versions/8da704a351d2_add_parser_eval_tables.py
+++ b/backend/alembic/versions/8da704a351d2_add_parser_eval_tables.py
@@ -1,0 +1,115 @@
+"""add_parser_eval_tables
+
+Revision ID: 8da704a351d2
+Revises: 30add7b93531
+Create Date: 2026-07-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from alembic import op
+
+
+revision: str = '8da704a351d2'
+down_revision: Union[str, None] = '30add7b93531'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create parser_eval_dimension enum (shared by parser_eval_targets and parser_eval_results)
+    parser_eval_dimension = postgresql.ENUM(
+        'text',
+        name='parser_eval_dimension',
+        create_type=False,
+    )
+    parser_eval_dimension.create(op.get_bind(), checkfirst=True)
+
+    # Create parser_eval_run_status enum
+    parser_eval_run_status = postgresql.ENUM(
+        'pending', 'running', 'completed', 'failed',
+        name='parser_eval_run_status',
+        create_type=False,
+    )
+    parser_eval_run_status.create(op.get_bind(), checkfirst=True)
+
+    # parser_eval_cases
+    op.create_table(
+        'parser_eval_cases',
+        sa.Column('id', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('project_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('doc_type', sa.String(64), nullable=True),
+        sa.Column('source_document_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('source_filename', sa.String(512), nullable=True),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['source_document_id'], ['source_documents.id'], ondelete='RESTRICT'),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id']),
+    )
+    op.create_index('ix_parser_eval_cases_project_id', 'parser_eval_cases', ['project_id'])
+
+    # parser_eval_targets
+    op.create_table(
+        'parser_eval_targets',
+        sa.Column('id', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('case_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('dimension', postgresql.ENUM('text', name='parser_eval_dimension', create_type=False), nullable=False),
+        sa.Column('expected', sa.JSON(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['case_id'], ['parser_eval_cases.id'], ondelete='CASCADE'),
+        sa.UniqueConstraint('case_id', 'dimension', name='uq_parser_eval_targets_case_dim'),
+    )
+    op.create_index('ix_parser_eval_targets_case_id', 'parser_eval_targets', ['case_id'])
+
+    # parser_eval_runs
+    op.create_table(
+        'parser_eval_runs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('project_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('parsers', sa.JSON(), server_default='[]', nullable=False),
+        sa.Column('case_ids', sa.JSON(), server_default='[]', nullable=False),
+        sa.Column('status', postgresql.ENUM('pending', 'running', 'completed', 'failed', name='parser_eval_run_status', create_type=False), server_default='pending', nullable=False),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id']),
+    )
+    op.create_index('ix_parser_eval_runs_project_id', 'parser_eval_runs', ['project_id'])
+
+    # parser_eval_results
+    op.create_table(
+        'parser_eval_results',
+        sa.Column('id', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('run_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('case_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('parser', sa.String(64), nullable=False),
+        sa.Column('dimension', postgresql.ENUM('text', name='parser_eval_dimension', create_type=False), nullable=False),
+        sa.Column('score', sa.Float(), nullable=False),
+        sa.Column('details', sa.JSON(), nullable=True),
+        sa.Column('cost', sa.JSON(), nullable=True),
+        sa.Column('latency_ms', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('NOW()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['run_id'], ['parser_eval_runs.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['case_id'], ['parser_eval_cases.id'], ondelete='CASCADE'),
+        sa.UniqueConstraint('run_id', 'case_id', 'parser', 'dimension', name='uq_parser_eval_results_run_case_parser_dim'),
+    )
+    op.create_index('ix_parser_eval_results_run_id', 'parser_eval_results', ['run_id'])
+
+
+def downgrade() -> None:
+    op.drop_table('parser_eval_results')
+    op.drop_table('parser_eval_runs')
+    op.drop_table('parser_eval_targets')
+    op.drop_table('parser_eval_cases')
+    op.execute('DROP TYPE IF EXISTS parser_eval_run_status')
+    op.execute('DROP TYPE IF EXISTS parser_eval_dimension')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.config import settings
-from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_runs, parse_run_configs, parsed_documents, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings, classification, source_documents, result_transforms
+from app.routers import auth, oauth, otel_proxy, projects, users, documents, folders, indexes, provider_keys, golden_sets, eval_runs, experiments, parse_runs, parse_run_configs, parsed_documents, extraction, extraction_ground_truth, extraction_eval, agent, data_stores, export_mappings, classification, source_documents, result_transforms, parser_eval
 from app.utils.oauth import setup_oauth
 
 # Import database engine for SQLAlchemy instrumentation
@@ -173,3 +173,4 @@ app.include_router(classification.documents_router, prefix="/api/v1")
 app.include_router(classification.runs_router, prefix="/api/v1")
 app.include_router(source_documents.router, prefix="/api/v1")
 app.include_router(result_transforms.router, prefix="/api/v1")
+app.include_router(parser_eval.router, prefix="/api/v1")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,10 @@ from app.models.extraction_schema import ExtractionSchema
 from app.models.extraction_result import ExtractionResult, ExtractionResultStatus
 from app.models.extraction_ground_truth import ExtractionGroundTruthSet, ExtractionGroundTruthItem
 from app.models.extraction_eval import ExtractionEvalRun, ExtractionEvalRunStatus, ExtractionEvalResult
+from app.models.parser_eval import (
+    ParserEvalCase, ParserEvalTarget, ParserEvalRun, ParserEvalResult,
+    ParserEvalDimension, ParserEvalRunStatus,
+)
 from app.models.agent_definition import AgentDefinition
 from app.models.agent_run import AgentRun, AgentRunStatus
 from app.models.project_data_store import ProjectDataStore
@@ -64,6 +68,12 @@ __all__ = [
     "ExtractionEvalRun",
     "ExtractionEvalRunStatus",
     "ExtractionEvalResult",
+    "ParserEvalCase",
+    "ParserEvalTarget",
+    "ParserEvalRun",
+    "ParserEvalResult",
+    "ParserEvalDimension",
+    "ParserEvalRunStatus",
     "AgentDefinition",
     "AgentRun",
     "AgentRunStatus",

--- a/backend/app/models/parser_eval.py
+++ b/backend/app/models/parser_eval.py
@@ -1,0 +1,126 @@
+"""Models for parser evaluation — scoring parser CDM output against per-dimension ground truth."""
+from datetime import datetime
+from uuid import UUID, uuid4
+import enum
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, Enum, Float, ForeignKey, Integer, String, Text, JSON
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class ParserEvalDimension(str, enum.Enum):
+    text = "text"          # first slice; table/reading_order/roles added later (seam #1)
+
+
+class ParserEvalRunStatus(str, enum.Enum):
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+
+
+class ParserEvalCase(Base):
+    """A benchmark document plus its per-dimension ground-truth targets."""
+    __tablename__ = "parser_eval_cases"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    doc_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    source_document_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("source_documents.id", ondelete="RESTRICT"), nullable=False)
+    source_filename: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    created_by: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, server_default=sa.text('NOW()'))
+
+    targets: Mapped[list["ParserEvalTarget"]] = relationship(
+        back_populates="case", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        sa.Index('ix_parser_eval_cases_project_id', 'project_id'),
+    )
+
+
+class ParserEvalTarget(Base):
+    """One asserted dimension + its ground-truth payload for a case."""
+    __tablename__ = "parser_eval_targets"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    case_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("parser_eval_cases.id", ondelete="CASCADE"), nullable=False)
+    dimension: Mapped[ParserEvalDimension] = mapped_column(
+        Enum(ParserEvalDimension, name='parser_eval_dimension', create_type=False), nullable=False)
+    expected: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+    case: Mapped["ParserEvalCase"] = relationship(back_populates="targets")
+
+    __table_args__ = (
+        sa.UniqueConstraint('case_id', 'dimension', name='uq_parser_eval_targets_case_dim'),
+        sa.Index('ix_parser_eval_targets_case_id', 'case_id'),
+    )
+
+
+class ParserEvalRun(Base):
+    """One execution over selected cases × parsers."""
+    __tablename__ = "parser_eval_runs"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    parsers: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default='[]')
+    case_ids: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default='[]')  # UUID strings
+    status: Mapped[ParserEvalRunStatus] = mapped_column(
+        Enum(ParserEvalRunStatus, name='parser_eval_run_status', create_type=False),
+        nullable=False, default=ParserEvalRunStatus.pending, server_default='pending')
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, server_default=sa.text('NOW()'))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, onupdate=datetime.utcnow,
+                                                 server_default=sa.text('NOW()'))
+
+    results: Mapped[list["ParserEvalResult"]] = relationship(
+        back_populates="run", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        sa.Index('ix_parser_eval_runs_project_id', 'project_id'),
+    )
+
+
+class ParserEvalResult(Base):
+    """One score cell: (run, case, parser, dimension) -> score + details + cost/latency."""
+    __tablename__ = "parser_eval_results"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    run_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("parser_eval_runs.id", ondelete="CASCADE"), nullable=False)
+    case_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("parser_eval_cases.id", ondelete="CASCADE"), nullable=False)
+    parser: Mapped[str] = mapped_column(String(64), nullable=False)
+    dimension: Mapped[ParserEvalDimension] = mapped_column(
+        Enum(ParserEvalDimension, name='parser_eval_dimension', create_type=False), nullable=False)
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    cost: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, server_default=sa.text('NOW()'))
+
+    run: Mapped["ParserEvalRun"] = relationship(back_populates="results")
+
+    __table_args__ = (
+        sa.UniqueConstraint('run_id', 'case_id', 'parser', 'dimension',
+                            name='uq_parser_eval_results_run_case_parser_dim'),
+        sa.Index('ix_parser_eval_results_run_id', 'run_id'),
+    )

--- a/backend/app/repositories/parser_eval_repository.py
+++ b/backend/app/repositories/parser_eval_repository.py
@@ -1,0 +1,103 @@
+"""Repository for parser evaluation data access."""
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.parser_eval import (
+    ParserEvalCase, ParserEvalTarget, ParserEvalRun, ParserEvalResult,
+    ParserEvalDimension, ParserEvalRunStatus,
+)
+
+
+class ParserEvalRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    # --- cases / targets ---
+    async def create_case(self, project_id: UUID, name: str, doc_type: str | None,
+                          source_document_id: UUID, source_filename: str | None,
+                          user_id: UUID) -> ParserEvalCase:
+        case = ParserEvalCase(project_id=project_id, name=name, doc_type=doc_type,
+                              source_document_id=source_document_id,
+                              source_filename=source_filename, created_by=user_id)
+        self.session.add(case)
+        await self.session.commit()
+        await self.session.refresh(case)
+        return case
+
+    async def add_target(self, case_id: UUID, dimension: ParserEvalDimension,
+                         expected: dict) -> ParserEvalTarget:
+        target = ParserEvalTarget(case_id=case_id, dimension=dimension, expected=expected)
+        self.session.add(target)
+        await self.session.commit()
+        await self.session.refresh(target)
+        return target
+
+    async def get_case(self, case_id: UUID) -> ParserEvalCase | None:
+        res = await self.session.execute(
+            select(ParserEvalCase).options(selectinload(ParserEvalCase.targets))
+            .where(ParserEvalCase.id == case_id))
+        return res.scalar_one_or_none()
+
+    async def list_cases(self, project_id: UUID) -> list[ParserEvalCase]:
+        res = await self.session.execute(
+            select(ParserEvalCase).options(selectinload(ParserEvalCase.targets))
+            .where(ParserEvalCase.project_id == project_id)
+            .order_by(ParserEvalCase.created_at.desc()))
+        return list(res.scalars().all())
+
+    # --- runs / results ---
+    async def create_run(self, project_id: UUID, name: str, parsers: list[str],
+                         case_ids: list[str], user_id: UUID) -> ParserEvalRun:
+        run = ParserEvalRun(project_id=project_id, name=name, parsers=parsers,
+                            case_ids=case_ids, created_by=user_id)
+        self.session.add(run)
+        await self.session.commit()
+        await self.session.refresh(run)
+        return run
+
+    async def get_run(self, run_id: UUID) -> ParserEvalRun | None:
+        res = await self.session.execute(
+            select(ParserEvalRun).where(ParserEvalRun.id == run_id))
+        return res.scalar_one_or_none()
+
+    async def list_runs(self, project_id: UUID) -> list[ParserEvalRun]:
+        res = await self.session.execute(
+            select(ParserEvalRun).where(ParserEvalRun.project_id == project_id)
+            .order_by(ParserEvalRun.created_at.desc()))
+        return list(res.scalars().all())
+
+    async def set_run_status(self, run_id: UUID, status: ParserEvalRunStatus,
+                             error_message: str | None = None) -> None:
+        run = await self.get_run(run_id)
+        if run is None:
+            return
+        run.status = status
+        if error_message is not None:
+            run.error_message = error_message
+        await self.session.commit()
+
+    async def upsert_result(self, run_id: UUID, case_id: UUID, parser: str,
+                            dimension: ParserEvalDimension, score: float, details: dict,
+                            cost: dict, latency_ms: int | None) -> None:
+        res = await self.session.execute(
+            select(ParserEvalResult).where(
+                ParserEvalResult.run_id == run_id, ParserEvalResult.case_id == case_id,
+                ParserEvalResult.parser == parser, ParserEvalResult.dimension == dimension))
+        existing = res.scalar_one_or_none()
+        if existing is None:
+            self.session.add(ParserEvalResult(
+                run_id=run_id, case_id=case_id, parser=parser, dimension=dimension,
+                score=score, details=details, cost=cost, latency_ms=latency_ms))
+        else:
+            existing.score, existing.details = score, details
+            existing.cost, existing.latency_ms = cost, latency_ms
+        await self.session.commit()
+
+    async def get_results(self, run_id: UUID) -> list[ParserEvalResult]:
+        res = await self.session.execute(
+            select(ParserEvalResult).where(ParserEvalResult.run_id == run_id)
+            .order_by(ParserEvalResult.case_id, ParserEvalResult.parser))
+        return list(res.scalars().all())

--- a/backend/app/routers/parser_eval.py
+++ b/backend/app/routers/parser_eval.py
@@ -1,0 +1,149 @@
+"""Parser Evaluation API router."""
+from uuid import UUID
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_active_user
+from app.dependencies.documents import get_parsing_service, get_storage_service
+from app.models import User
+from app.repositories.parser_eval_repository import ParserEvalRepository
+from app.repositories.project_repository import ProjectRepository
+from app.repositories.source_document_repository import SourceDocumentRepository
+from app.schemas.parser_eval import (
+    CaseCreate, CaseResponse, RunCreate, RunResponse, ResultResponse,
+)
+from app.services.exceptions import NotFoundError
+from app.services.parser_eval.service import ParserEvalService
+
+router = APIRouter(tags=["parser_eval"])
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+def _service(db: AsyncSession) -> ParserEvalService:
+    return ParserEvalService(
+        repo=ParserEvalRepository(db),
+        source_doc_repo=SourceDocumentRepository(db),
+        parsing_service=get_parsing_service(db),
+        storage=get_storage_service(),
+    )
+
+
+def get_service(db: AsyncSession = Depends(get_db)) -> ParserEvalService:
+    return _service(db)
+
+
+def get_project_repo(db: AsyncSession = Depends(get_db)) -> ProjectRepository:
+    return ProjectRepository(db)
+
+
+async def verify_project_access(
+    project_id: UUID,
+    current_user: User,
+    project_repo: ProjectRepository,
+) -> None:
+    project = await project_repo.get_by_id(project_id, current_user.id)
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Project {project_id} not found",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Background task
+# ---------------------------------------------------------------------------
+
+async def execute_run_background(db: AsyncSession, run_id: UUID) -> None:
+    """Background task to execute a parser-eval run.
+
+    Reuses the request-scoped session (mirrors extraction_eval's background task) so
+    that tests overriding `get_db` still hit the test database rather than production.
+    """
+    await _service(db).execute_run(run_id)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.post("/projects/{project_id}/parser-eval/cases", response_model=CaseResponse)
+async def create_case(
+    project_id: UUID,
+    data: CaseCreate,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    try:
+        return await service.create_case(project_id, current_user.id, data)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.get("/projects/{project_id}/parser-eval/cases", response_model=list[CaseResponse])
+async def list_cases(
+    project_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    return await service.list_cases(project_id)
+
+
+@router.post(
+    "/projects/{project_id}/parser-eval/runs",
+    response_model=RunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_run(
+    project_id: UUID,
+    data: RunCreate,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+    db: AsyncSession = Depends(get_db),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    try:
+        run = await service.create_run(project_id, current_user.id, data)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    background_tasks.add_task(execute_run_background, db=db, run_id=run.id)
+    return run
+
+
+@router.get("/projects/{project_id}/parser-eval/runs", response_model=list[RunResponse])
+async def list_runs(
+    project_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    return await service.list_runs(project_id)
+
+
+@router.get(
+    "/projects/{project_id}/parser-eval/runs/{run_id}/results",
+    response_model=list[ResultResponse],
+)
+async def get_results(
+    project_id: UUID,
+    run_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    try:
+        return await service.get_results(run_id)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/schemas/parser_eval.py
+++ b/backend/app/schemas/parser_eval.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from app.cdm.models import ParserKind
 
 
 class TargetInput(BaseModel):
@@ -41,6 +43,17 @@ class RunCreate(BaseModel):
     name: str | None = None
     case_ids: list[UUID]
     parsers: list[str]
+
+    @field_validator("parsers")
+    @classmethod
+    def _validate_parsers(cls, value: list[str]) -> list[str]:
+        valid = {p.value for p in ParserKind}
+        invalid = [p for p in value if p not in valid]
+        if invalid:
+            raise ValueError(
+                f"Invalid parser name(s): {invalid}. Valid parsers: {sorted(valid)}"
+            )
+        return value
 
 
 class RunResponse(BaseModel):

--- a/backend/app/schemas/parser_eval.py
+++ b/backend/app/schemas/parser_eval.py
@@ -1,0 +1,64 @@
+"""Pydantic schemas for the parser-eval API."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class TargetInput(BaseModel):
+    dimension: str
+    expected: dict
+
+    @model_validator(mode="after")
+    def _validate_expected(self):
+        if self.dimension == "text":
+            pages = self.expected.get("pages")
+            if not isinstance(pages, list) or not all(isinstance(p, str) for p in pages):
+                raise ValueError("text target requires expected.pages: list[str]")
+        return self
+
+
+class CaseCreate(BaseModel):
+    name: str
+    doc_type: str | None = None
+    source_document_id: UUID
+    targets: list[TargetInput]
+
+
+class CaseResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: UUID
+    name: str
+    doc_type: str | None
+    source_document_id: UUID
+    source_filename: str | None
+    created_at: datetime
+
+
+class RunCreate(BaseModel):
+    name: str | None = None
+    case_ids: list[UUID]
+    parsers: list[str]
+
+
+class RunResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: UUID
+    name: str
+    status: str
+    parsers: list[str]
+    error_message: str | None = None
+    created_at: datetime
+
+
+class ResultResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    case_id: UUID
+    parser: str
+    dimension: str
+    score: float
+    details: dict | None
+    cost: dict | None
+    latency_ms: int | None

--- a/backend/app/services/parser_eval/capture.py
+++ b/backend/app/services/parser_eval/capture.py
@@ -1,0 +1,51 @@
+"""Capture a ParsedDocument for one parser by reusing ParsingService.
+
+Cost/latency come from the returned ParseRun — no bespoke timing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from typing import Any
+
+from app.cdm.models import ParsedDocument
+from app.services.parsing.errors import ParseFailedError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REPRESENTATION_KIND = "extract_rich"
+
+
+async def capture(
+    parsing_service: Any,
+    storage: Any,
+    *,
+    source_document_id: str,
+    storage_uri: str,
+    filename: str,
+    mime_type: str,
+    parser: str,
+    project_id: Any,
+) -> tuple[ParsedDocument | None, dict, int | None]:
+    data = await storage.get(storage_uri)
+    source = await parsing_service.ensure_source_document(
+        bytes_=data, filename=filename, mime_type=mime_type)
+
+    suffix = os.path.splitext(filename)[1] or ".bin"
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(data)
+            tmp_path = tmp.name
+        run, doc = await parsing_service.parse_and_persist(
+            source=source, file_path=tmp_path,
+            representation_kind=DEFAULT_REPRESENTATION_KIND,
+            config={"parser": parser}, project_id=project_id, force=False)
+        return doc, dict(run.cost or {}), run.duration_ms
+    except ParseFailedError as err:
+        logger.warning("parser-eval capture failed parser=%s: %s", parser, err)
+        return None, {}, None
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)

--- a/backend/app/services/parser_eval/engine.py
+++ b/backend/app/services/parser_eval/engine.py
@@ -1,0 +1,51 @@
+"""Orchestrate one parser-eval run: capture per parser, score each asserted target, persist."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from app.models.parser_eval import ParserEvalRunStatus
+from app.services.parser_eval.capture import capture
+from app.services.parser_eval.scorers import get_scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _default_case_source(case: Any) -> tuple[str, str, str, str]:
+    # Overridden in tests; the service passes a resolver that reads SourceDocument fields.
+    raise NotImplementedError
+
+
+async def run_evaluation(
+    repo: Any,
+    parsing_service: Any,
+    storage: Any,
+    *,
+    run_id: Any,
+    cases: list[Any],
+    parsers: list[str],
+    project_id: Any,
+    _case_source: Callable[[Any], tuple[str, str, str, str]] = _default_case_source,
+) -> None:
+    await repo.set_run_status(run_id, ParserEvalRunStatus.running)
+    try:
+        for case in cases:
+            source_document_id, storage_uri, filename, mime_type = _case_source(case)
+            for parser in parsers:
+                cdm, cost, latency = await capture(
+                    parsing_service, storage,
+                    source_document_id=source_document_id, storage_uri=storage_uri,
+                    filename=filename, mime_type=mime_type, parser=parser,
+                    project_id=project_id)
+                for target in case.targets:            # only asserted dimensions
+                    if cdm is None:
+                        score, details = 0.0, {"capture_failed": True}
+                    else:
+                        score, details = get_scorer(target.dimension.value)(cdm, target.expected)
+                    await repo.upsert_result(run_id, case.id, parser, target.dimension,
+                                             score, details, cost, latency)
+        await repo.set_run_status(run_id, ParserEvalRunStatus.completed)
+    except Exception as err:                            # noqa: BLE001 — record and surface
+        logger.exception("parser-eval run %s failed", run_id)
+        await repo.set_run_status(run_id, ParserEvalRunStatus.failed, error_message=str(err))
+        raise

--- a/backend/app/services/parser_eval/scorers/__init__.py
+++ b/backend/app/services/parser_eval/scorers/__init__.py
@@ -1,0 +1,17 @@
+"""Registry of dimension scorers. Add a dimension = add one entry here (seam #1)."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from app.cdm.models import ParsedDocument
+from app.services.parser_eval.scorers.text import score_text
+
+Scorer = Callable[[ParsedDocument, dict[str, Any]], tuple[float, dict[str, Any]]]
+
+SCORERS: dict[str, Scorer] = {
+    "text": score_text,
+}
+
+
+def get_scorer(dimension: str) -> Scorer:
+    return SCORERS[dimension]

--- a/backend/app/services/parser_eval/scorers/text.py
+++ b/backend/app/services/parser_eval/scorers/text.py
@@ -61,10 +61,14 @@ def score_text(cdm: ParsedDocument, expected: dict[str, Any]) -> tuple[float, di
         page_scores = _score_page(ref, par)
         per_page.append({"page": i, **page_scores})
 
-    # Length-weighted aggregate by reference character count (empty ref pages weight 0,
-    # but an unmatched *parsed* page still contributes hallucination via a min weight of 1).
+    # Length-weighted aggregate by the larger of reference/parsed character count at each
+    # index. This keeps the omission direction unchanged (parsed empty → weight is ref
+    # length) while making the hallucination direction visible (ref empty → weight is
+    # parsed length, so a fabricated extra page carries full weight instead of a floor of 1).
     def _weight(i: int) -> int:
-        return max(len(reference_pages[i]) if i < len(reference_pages) else 0, 1)
+        ref_len = len(reference_pages[i]) if i < len(reference_pages) else 0
+        par_len = len(parsed_pages[i]) if i < len(parsed_pages) else 0
+        return max(ref_len, par_len, 1)
 
     total_w = sum(_weight(i) for i in range(n)) or 1
     similarity = sum(p["similarity"] * _weight(p["page"]) for p in per_page) / total_w

--- a/backend/app/services/parser_eval/scorers/text.py
+++ b/backend/app/services/parser_eval/scorers/text.py
@@ -1,0 +1,81 @@
+"""Text-faithfulness scorer — compares parsed per-page text to a page-segmented reference.
+
+Content-oriented and parser-agnostic: it flattens each page to text and never inspects
+block structure, so parsers that segment blocks differently are scored fairly.
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from typing import Any
+
+from app.cdm.models import ParsedDocument
+
+_WS = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    return _WS.sub(" ", (text or "").strip().lower())
+
+
+def _tokens(text: str) -> list[str]:
+    return _normalize(text).split()
+
+
+def _parsed_page_texts(cdm: ParsedDocument) -> list[str]:
+    """Per-page text via Page.start_char/end_char slices of full_text.
+
+    Falls back to concatenating each page's block text when offsets are absent.
+    """
+    full = cdm.full_text or ""
+    pages: list[str] = []
+    for page in sorted(cdm.pages, key=lambda p: p.index):
+        if full and page.start_char is not None and page.end_char is not None:
+            pages.append(full[page.start_char:page.end_char])
+        else:
+            pages.append(
+                " ".join(b.text for b in cdm.blocks if b.page_index == page.index)
+            )
+    return pages
+
+
+def _score_page(reference: str, parsed: str) -> dict[str, float]:
+    ref_norm, par_norm = _normalize(reference), _normalize(parsed)
+    similarity = difflib.SequenceMatcher(None, ref_norm, par_norm).ratio()
+
+    ref_toks, par_toks = set(_tokens(reference)), set(_tokens(parsed))
+    omission = 0.0 if not ref_toks else len(ref_toks - par_toks) / len(ref_toks)
+    hallucination = 0.0 if not par_toks else len(par_toks - ref_toks) / len(par_toks)
+    return {"similarity": similarity, "omission": omission, "hallucination": hallucination}
+
+
+def score_text(cdm: ParsedDocument, expected: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    reference_pages: list[str] = expected["pages"]
+    parsed_pages = _parsed_page_texts(cdm)
+
+    per_page: list[dict[str, Any]] = []
+    n = max(len(reference_pages), len(parsed_pages))
+    for i in range(n):
+        ref = reference_pages[i] if i < len(reference_pages) else ""
+        par = parsed_pages[i] if i < len(parsed_pages) else ""
+        page_scores = _score_page(ref, par)
+        per_page.append({"page": i, **page_scores})
+
+    # Length-weighted aggregate by reference character count (empty ref pages weight 0,
+    # but an unmatched *parsed* page still contributes hallucination via a min weight of 1).
+    def _weight(i: int) -> int:
+        return max(len(reference_pages[i]) if i < len(reference_pages) else 0, 1)
+
+    total_w = sum(_weight(i) for i in range(n)) or 1
+    similarity = sum(p["similarity"] * _weight(p["page"]) for p in per_page) / total_w
+    omission = sum(p["omission"] * _weight(p["page"]) for p in per_page) / total_w
+    hallucination = sum(p["hallucination"] * _weight(p["page"]) for p in per_page) / total_w
+
+    details = {
+        "per_page": per_page,
+        "omission": omission,
+        "hallucination": hallucination,
+        "page_count_expected": len(reference_pages),
+        "page_count_parsed": len(parsed_pages),
+    }
+    return similarity, details

--- a/backend/app/services/parser_eval/service.py
+++ b/backend/app/services/parser_eval/service.py
@@ -1,0 +1,81 @@
+"""Service orchestrating parser-eval CRUD and run execution."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.models.parser_eval import ParserEvalDimension
+from app.repositories.parser_eval_repository import ParserEvalRepository
+from app.repositories.source_document_repository import SourceDocumentRepository
+from app.schemas.parser_eval import (
+    CaseCreate, CaseResponse, RunCreate, RunResponse, ResultResponse,
+)
+from app.services.exceptions import NotFoundError
+from app.services.parser_eval.engine import run_evaluation
+
+
+class ParserEvalService:
+    def __init__(self, repo: ParserEvalRepository, source_doc_repo: SourceDocumentRepository,
+                 parsing_service, storage):
+        self.repo = repo
+        self.source_doc_repo = source_doc_repo
+        self.parsing_service = parsing_service
+        self.storage = storage
+
+    async def create_case(self, project_id: UUID, user_id: UUID, data: CaseCreate) -> CaseResponse:
+        source = await self.source_doc_repo.get(data.source_document_id)
+        if source is None:
+            raise NotFoundError(f"Source document {data.source_document_id} not found")
+        case = await self.repo.create_case(project_id, data.name, data.doc_type,
+                                           data.source_document_id, source.filename, user_id)
+        for t in data.targets:
+            await self.repo.add_target(case.id, ParserEvalDimension(t.dimension), t.expected)
+        return CaseResponse.model_validate(case)
+
+    async def list_cases(self, project_id: UUID) -> list[CaseResponse]:
+        return [CaseResponse.model_validate(c) for c in await self.repo.list_cases(project_id)]
+
+    async def create_run(self, project_id: UUID, user_id: UUID, data: RunCreate) -> RunResponse:
+        name = data.name or "Parser eval run"
+        run = await self.repo.create_run(
+            project_id, name, data.parsers, [str(cid) for cid in data.case_ids], user_id)
+        return RunResponse.model_validate(run)
+
+    async def execute_run(self, run_id: UUID) -> None:
+        run = await self.repo.get_run(run_id)
+        if run is None:
+            raise NotFoundError(f"Parser eval run {run_id} not found")
+        # Load only the cases selected for this run (persisted in run.case_ids).
+        selected = {str(cid) for cid in (run.case_ids or [])}
+        cases = [c for c in await self.repo.list_cases(run.project_id) if str(c.id) in selected]
+
+        # Resolve each case's source document fields for capture, once.
+        source_cache: dict[UUID, object] = {}
+
+        async def _resolve(case):
+            src = source_cache.get(case.source_document_id)
+            if src is None:
+                src = await self.source_doc_repo.get(case.source_document_id)
+                source_cache[case.source_document_id] = src
+            return (str(case.source_document_id), src.storage_uri, src.filename, src.mime_type)
+
+        # run_evaluation expects a sync resolver; pre-resolve into a dict.
+        resolved = {c.id: await _resolve(c) for c in cases}
+        await run_evaluation(
+            self.repo, self.parsing_service, self.storage,
+            run_id=run_id, cases=cases, parsers=list(run.parsers),
+            project_id=run.project_id, _case_source=lambda c: resolved[c.id])
+
+    async def get_run(self, run_id: UUID) -> RunResponse:
+        run = await self.repo.get_run(run_id)
+        if run is None:
+            raise NotFoundError(f"Parser eval run {run_id} not found")
+        return RunResponse.model_validate(run)
+
+    async def list_runs(self, project_id: UUID) -> list[RunResponse]:
+        return [RunResponse.model_validate(r) for r in await self.repo.list_runs(project_id)]
+
+    async def get_results(self, run_id: UUID) -> list[ResultResponse]:
+        run = await self.repo.get_run(run_id)
+        if run is None:
+            raise NotFoundError(f"Parser eval run {run_id} not found")
+        return [ResultResponse.model_validate(r) for r in await self.repo.get_results(run_id)]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import AsyncGenerator, Generator
+from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
@@ -58,3 +59,34 @@ async def client(test_db: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
 @pytest.fixture(scope="function")
 def sync_client() -> TestClient:
     return TestClient(app)
+
+
+@pytest.fixture(scope="function")
+async def seed_project_user_source(test_db: AsyncSession):
+    """Insert a Project + User + SourceDocument; return (project_id, user_id, source_id)."""
+    from app.models import User
+    from app.models.project import Project
+    from app.models.source_document import SourceDocument
+
+    user = User(
+        id=uuid4(),
+        email=f"{uuid4()}@example.com",
+        full_name="Test User",
+        auth_provider="email",
+        password_hash="hashed",
+    )
+    test_db.add(user)
+    await test_db.commit()
+    await test_db.refresh(user)
+
+    project = Project(id=uuid4(), user_id=user.id, name="Test Project")
+    test_db.add(project)
+    await test_db.commit()
+    await test_db.refresh(project)
+
+    source = SourceDocument(id=uuid4(), sha256="a" * 64, storage_uri="local://a.pdf")
+    test_db.add(source)
+    await test_db.commit()
+    await test_db.refresh(source)
+
+    return project.id, user.id, source.id

--- a/backend/tests/models/test_parser_eval_models.py
+++ b/backend/tests/models/test_parser_eval_models.py
@@ -1,0 +1,21 @@
+from app.models.parser_eval import (
+    ParserEvalCase, ParserEvalTarget, ParserEvalRun, ParserEvalResult,
+    ParserEvalDimension, ParserEvalRunStatus,
+)
+
+
+def test_dimension_and_status_enums():
+    assert ParserEvalDimension.text.value == "text"
+    assert ParserEvalRunStatus.pending.value == "pending"
+
+
+def test_tablenames():
+    assert ParserEvalCase.__tablename__ == "parser_eval_cases"
+    assert ParserEvalTarget.__tablename__ == "parser_eval_targets"
+    assert ParserEvalRun.__tablename__ == "parser_eval_runs"
+    assert ParserEvalResult.__tablename__ == "parser_eval_results"
+
+
+def test_result_unique_constraint_present():
+    names = {c.name for c in ParserEvalResult.__table__.constraints}
+    assert "uq_parser_eval_results_run_case_parser_dim" in names

--- a/backend/tests/repositories/test_parser_eval_repository.py
+++ b/backend/tests/repositories/test_parser_eval_repository.py
@@ -1,0 +1,35 @@
+import pytest
+from app.models.parser_eval import ParserEvalDimension, ParserEvalRunStatus
+from app.repositories.parser_eval_repository import ParserEvalRepository
+
+
+@pytest.mark.asyncio
+async def test_create_case_with_target_and_fetch(test_db, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+    repo = ParserEvalRepository(test_db)
+
+    case = await repo.create_case(project_id, "acme_invoice", "invoice", source_id, "acme.pdf", user_id)
+    await repo.add_target(case.id, ParserEvalDimension.text, {"pages": ["hello"]})
+
+    fetched = await repo.get_case(case.id)
+    assert fetched.name == "acme_invoice"
+    assert len(fetched.targets) == 1
+    assert fetched.targets[0].expected == {"pages": ["hello"]}
+
+
+@pytest.mark.asyncio
+async def test_run_and_result_upsert(test_db, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+    repo = ParserEvalRepository(test_db)
+    run = await repo.create_run(project_id, "run-1", ["docling", "simple"], [], user_id)
+
+    case = await repo.create_case(project_id, "c", None, source_id, None, user_id)
+    await repo.upsert_result(run.id, case.id, "docling", ParserEvalDimension.text, 0.9, {}, {}, 120)
+    await repo.upsert_result(run.id, case.id, "docling", ParserEvalDimension.text, 0.95, {}, {}, 130)  # same key
+
+    results = await repo.get_results(run.id)
+    assert len(results) == 1              # upsert replaced, not duplicated
+    assert results[0].score == 0.95
+
+    await repo.set_run_status(run.id, ParserEvalRunStatus.completed)
+    assert (await repo.get_run(run.id)).status == ParserEvalRunStatus.completed

--- a/backend/tests/routers/test_parser_eval_router.py
+++ b/backend/tests/routers/test_parser_eval_router.py
@@ -1,0 +1,75 @@
+"""Tests for the parser-eval router (project-scoped endpoints)."""
+import pytest
+from httpx import AsyncClient
+
+from app.main import app
+from app.dependencies.auth import get_current_active_user
+
+
+@pytest.mark.asyncio
+async def test_create_case_and_run_flow(client: AsyncClient, seed_project_user_source, monkeypatch):
+    from app.services.parser_eval import engine as engine_mod
+    from app.cdm.models import ParsedDocument, Page
+
+    async def fake_capture(*a, **k):
+        doc = ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                              page_count=1, pages=[Page(index=0, start_char=0, end_char=2)],
+                              blocks=[], full_text="hi")
+        return doc, {"usd": 0.0}, 3
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    project_id, user_id, source_id = seed_project_user_source
+
+    class _FakeUser:
+        id = user_id
+
+    app.dependency_overrides[get_current_active_user] = lambda: _FakeUser()
+    try:
+        r = await client.post(
+            f"/api/v1/projects/{project_id}/parser-eval/cases",
+            json={"name": "c", "source_document_id": str(source_id),
+                  "targets": [{"dimension": "text", "expected": {"pages": ["hi"]}}]})
+        assert r.status_code == 200, r.text
+        case_id = r.json()["id"]
+
+        r = await client.get(f"/api/v1/projects/{project_id}/parser-eval/cases")
+        assert r.status_code == 200
+        assert len(r.json()) == 1
+
+        r = await client.post(
+            f"/api/v1/projects/{project_id}/parser-eval/runs",
+            json={"name": "run", "case_ids": [case_id], "parsers": ["docling"]})
+        assert r.status_code == 202, r.text
+        run_id = r.json()["id"]
+
+        r = await client.get(f"/api/v1/projects/{project_id}/parser-eval/runs")
+        assert r.status_code == 200
+        assert len(r.json()) == 1
+
+        r = await client.get(
+            f"/api/v1/projects/{project_id}/parser-eval/runs/{run_id}/results")
+        assert r.status_code == 200
+        assert len(r.json()) == 1
+        assert r.json()[0]["score"] == 1.0
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+@pytest.mark.asyncio
+async def test_create_case_unknown_project_returns_404(client: AsyncClient, seed_project_user_source):
+    from uuid import uuid4
+
+    _, user_id, source_id = seed_project_user_source
+
+    class _FakeUser:
+        id = user_id
+
+    app.dependency_overrides[get_current_active_user] = lambda: _FakeUser()
+    try:
+        r = await client.post(
+            f"/api/v1/projects/{uuid4()}/parser-eval/cases",
+            json={"name": "c", "source_document_id": str(source_id),
+                  "targets": [{"dimension": "text", "expected": {"pages": ["hi"]}}]})
+        assert r.status_code == 404
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)

--- a/backend/tests/schemas/test_parser_eval_schema.py
+++ b/backend/tests/schemas/test_parser_eval_schema.py
@@ -1,0 +1,15 @@
+import pytest
+from uuid import uuid4
+from pydantic import ValidationError
+from app.schemas.parser_eval import CaseCreate, TargetInput
+
+
+def test_valid_text_target():
+    c = CaseCreate(name="c", doc_type="invoice", source_document_id=uuid4(),
+                   targets=[TargetInput(dimension="text", expected={"pages": ["a", "b"]})])
+    assert c.targets[0].expected["pages"] == ["a", "b"]
+
+
+def test_text_target_requires_pages_list():
+    with pytest.raises(ValidationError):
+        TargetInput(dimension="text", expected={"wrong": 1})

--- a/backend/tests/schemas/test_parser_eval_schema.py
+++ b/backend/tests/schemas/test_parser_eval_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from uuid import uuid4
 from pydantic import ValidationError
-from app.schemas.parser_eval import CaseCreate, TargetInput
+from app.schemas.parser_eval import CaseCreate, RunCreate, TargetInput
 
 
 def test_valid_text_target():
@@ -13,3 +13,13 @@ def test_valid_text_target():
 def test_text_target_requires_pages_list():
     with pytest.raises(ValidationError):
         TargetInput(dimension="text", expected={"wrong": 1})
+
+
+def test_run_create_accepts_valid_parser():
+    run = RunCreate(name="run", case_ids=[uuid4()], parsers=["docling"])
+    assert run.parsers == ["docling"]
+
+
+def test_run_create_rejects_unknown_parser():
+    with pytest.raises(ValidationError):
+        RunCreate(name="run", case_ids=[uuid4()], parsers=["nope"])

--- a/backend/tests/services/parser_eval/test_capture.py
+++ b/backend/tests/services/parser_eval/test_capture.py
@@ -2,6 +2,7 @@ import pytest
 from types import SimpleNamespace
 from app.cdm.models import ParsedDocument
 from app.services.parser_eval.capture import capture
+from app.services.parsing.errors import ParseFailedError
 
 
 class _FakeStorage:
@@ -21,6 +22,14 @@ class _FakeParsing:
         return run, doc
 
 
+class _FakeParsingFails:
+    async def ensure_source_document(self, *, bytes_, filename, mime_type):
+        return SimpleNamespace(id="src-1", sha256="abc", filename=filename,
+                               mime_type=mime_type, byte_size=len(bytes_), storage_uri="u")
+    async def parse_and_persist(self, *, source, file_path, representation_kind, config, project_id, force=False):
+        raise ParseFailedError("boom")
+
+
 @pytest.mark.asyncio
 async def test_capture_returns_cdm_and_metrics():
     cdm, cost, latency = await capture(
@@ -30,3 +39,14 @@ async def test_capture_returns_cdm_and_metrics():
     assert cdm.full_text == "hi"
     assert latency == 42
     assert cost == {"usd": 0.0}
+
+
+@pytest.mark.asyncio
+async def test_capture_returns_none_on_parse_failure():
+    cdm, cost, latency = await capture(
+        _FakeParsingFails(), _FakeStorage(),
+        source_document_id="src-1", storage_uri="u", filename="a.pdf",
+        mime_type="application/pdf", parser="docling", project_id="p1")
+    assert cdm is None
+    assert cost == {}
+    assert latency is None

--- a/backend/tests/services/parser_eval/test_capture.py
+++ b/backend/tests/services/parser_eval/test_capture.py
@@ -1,0 +1,32 @@
+import pytest
+from types import SimpleNamespace
+from app.cdm.models import ParsedDocument
+from app.services.parser_eval.capture import capture
+
+
+class _FakeStorage:
+    async def get(self, path): return b"%PDF-1.4 fake"
+    async def save(self, content, rel): return rel
+
+
+class _FakeParsing:
+    async def ensure_source_document(self, *, bytes_, filename, mime_type):
+        return SimpleNamespace(id="src-1", sha256="abc", filename=filename,
+                               mime_type=mime_type, byte_size=len(bytes_), storage_uri="u")
+    async def parse_and_persist(self, *, source, file_path, representation_kind, config, project_id, force=False):
+        run = SimpleNamespace(cost={"usd": 0.0}, duration_ms=42,
+                              input_tokens=None, output_tokens=None)
+        doc = ParsedDocument(id="d", source_document_id="src-1", parse_run_id="r",
+                             page_count=1, pages=[], blocks=[], full_text="hi")
+        return run, doc
+
+
+@pytest.mark.asyncio
+async def test_capture_returns_cdm_and_metrics():
+    cdm, cost, latency = await capture(
+        _FakeParsing(), _FakeStorage(),
+        source_document_id="src-1", storage_uri="u", filename="a.pdf",
+        mime_type="application/pdf", parser="docling", project_id="p1")
+    assert cdm.full_text == "hi"
+    assert latency == 42
+    assert cost == {"usd": 0.0}

--- a/backend/tests/services/parser_eval/test_engine.py
+++ b/backend/tests/services/parser_eval/test_engine.py
@@ -1,0 +1,52 @@
+import pytest
+from types import SimpleNamespace
+from app.cdm.models import ParsedDocument, Page
+from app.models.parser_eval import ParserEvalDimension, ParserEvalRunStatus
+from app.services.parser_eval import engine as engine_mod
+
+
+class _RepoSpy:
+    def __init__(self): self.results = []; self.status = None
+    async def upsert_result(self, run_id, case_id, parser, dimension, score, details, cost, latency_ms):
+        self.results.append((parser, dimension, score))
+    async def set_run_status(self, run_id, status, error_message=None):
+        self.status = status
+
+
+def _case():
+    target = SimpleNamespace(dimension=ParserEvalDimension.text, expected={"pages": ["hi"]})
+    return SimpleNamespace(id="c1", targets=[target])
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_scores_each_parser(monkeypatch):
+    async def fake_capture(*args, **kwargs):
+        doc = ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                             page_count=1, pages=[Page(index=0, start_char=0, end_char=2)],
+                             blocks=[], full_text="hi")
+        return doc, {"usd": 0.0}, 10
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    repo = _RepoSpy()
+    await engine_mod.run_evaluation(
+        repo, parsing_service=None, storage=None, run_id="run1",
+        cases=[_case()], parsers=["docling", "simple"], project_id="p1",
+        _case_source=lambda c: ("src", "uri", "a.pdf", "application/pdf"))
+    assert repo.status == ParserEvalRunStatus.completed
+    assert {r[0] for r in repo.results} == {"docling", "simple"}
+    assert all(r[2] == 1.0 for r in repo.results)   # "hi" == "hi"
+
+
+@pytest.mark.asyncio
+async def test_capture_failure_records_zero(monkeypatch):
+    async def fake_capture(*args, **kwargs):
+        return None, {}, None
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    repo = _RepoSpy()
+    await engine_mod.run_evaluation(
+        repo, parsing_service=None, storage=None, run_id="run1",
+        cases=[_case()], parsers=["docling"], project_id="p1",
+        _case_source=lambda c: ("src", "uri", "a.pdf", "application/pdf"))
+    assert repo.results == [("docling", ParserEvalDimension.text, 0.0)]
+    assert repo.status == ParserEvalRunStatus.completed

--- a/backend/tests/services/parser_eval/test_registry.py
+++ b/backend/tests/services/parser_eval/test_registry.py
@@ -1,0 +1,12 @@
+import pytest
+from app.services.parser_eval.scorers import get_scorer
+from app.services.parser_eval.scorers.text import score_text
+
+
+def test_text_scorer_registered():
+    assert get_scorer("text") is score_text
+
+
+def test_unknown_dimension_raises():
+    with pytest.raises(KeyError):
+        get_scorer("does_not_exist")

--- a/backend/tests/services/parser_eval/test_service.py
+++ b/backend/tests/services/parser_eval/test_service.py
@@ -1,0 +1,38 @@
+import pytest
+from app.cdm.models import ParsedDocument, Page
+from app.repositories.parser_eval_repository import ParserEvalRepository
+from app.repositories.source_document_repository import SourceDocumentRepository
+from app.schemas.parser_eval import CaseCreate, TargetInput, RunCreate
+from app.services.parser_eval import engine as engine_mod
+from app.services.parser_eval.service import ParserEvalService
+
+
+def _build_service(db):
+    """Wire the real repos with fake parsing_service/storage (capture is monkeypatched)."""
+    repo = ParserEvalRepository(db)
+    source_doc_repo = SourceDocumentRepository(db)
+    return ParserEvalService(repo, source_doc_repo, parsing_service=object(), storage=object())
+
+
+@pytest.mark.asyncio
+async def test_create_case_then_run_produces_results(test_db, seed_project_user_source, monkeypatch):
+    project_id, user_id, source_id = seed_project_user_source
+
+    async def fake_capture(*a, **k):
+        doc = ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                             page_count=1, pages=[Page(index=0, start_char=0, end_char=2)],
+                             blocks=[], full_text="hi")
+        return doc, {"usd": 0.0}, 5
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    service = _build_service(test_db)
+    case = await service.create_case(project_id, user_id, CaseCreate(
+        name="c", source_document_id=source_id,
+        targets=[TargetInput(dimension="text", expected={"pages": ["hi"]})]))
+    run = await service.create_run(project_id, user_id, RunCreate(
+        name="r1", case_ids=[case.id], parsers=["docling"]))
+    await service.execute_run(run.id)
+
+    results = await service.get_results(run.id)
+    assert len(results) == 1
+    assert results[0].score == 1.0

--- a/backend/tests/services/parser_eval/test_text_scorer.py
+++ b/backend/tests/services/parser_eval/test_text_scorer.py
@@ -47,3 +47,13 @@ def test_normalization_ignores_whitespace_and_case():
     doc = _doc("Hello    WORLD", [(0, 14)])
     score, _ = score_text(doc, {"pages": ["hello world"]})
     assert score == 1.0
+
+
+def test_fabricated_extra_page_penalized_as_hallucination():
+    # reference has 1 page, parse produced 2 → the extra page is fully fabricated and
+    # must carry full weight in the aggregate, not a floor weight of 1.
+    full_text = "hello world" + " some entirely fabricated extra page content here"
+    doc = _doc(full_text, [(0, 11), (11, len(full_text))])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert details["hallucination"] > 0.3
+    assert score < 1.0

--- a/backend/tests/services/parser_eval/test_text_scorer.py
+++ b/backend/tests/services/parser_eval/test_text_scorer.py
@@ -1,0 +1,49 @@
+from app.cdm.models import ParsedDocument, Page
+from app.services.parser_eval.scorers.text import score_text
+
+
+def _doc(full_text: str, pages: list[tuple[int, int]]) -> ParsedDocument:
+    """Build a minimal ParsedDocument with page char-offsets into full_text."""
+    return ParsedDocument(
+        id="d1", source_document_id="s1", parse_run_id="r1",
+        page_count=len(pages),
+        pages=[Page(index=i, start_char=s, end_char=e) for i, (s, e) in enumerate(pages)],
+        blocks=[], full_text=full_text,
+    )
+
+
+def test_perfect_match_scores_one():
+    doc = _doc("hello world", [(0, 11)])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert score == 1.0
+    assert details["omission"] == 0.0
+    assert details["hallucination"] == 0.0
+
+
+def test_omission_detected():
+    # reference has two words, parse dropped one
+    doc = _doc("hello", [(0, 5)])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert score < 1.0
+    assert details["omission"] > 0.0
+
+
+def test_hallucination_detected():
+    doc = _doc("hello world extra", [(0, 17)])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert details["hallucination"] > 0.0
+
+
+def test_page_count_mismatch_penalized():
+    # reference has 2 pages, parse produced 1 → missing page fully omitted
+    doc = _doc("page one text", [(0, 13)])
+    score, details = score_text(doc, {"pages": ["page one text", "page two text"]})
+    assert details["page_count_expected"] == 2
+    assert details["page_count_parsed"] == 1
+    assert score < 1.0
+
+
+def test_normalization_ignores_whitespace_and_case():
+    doc = _doc("Hello    WORLD", [(0, 14)])
+    score, _ = score_text(doc, {"pages": ["hello world"]})
+    assert score == 1.0

--- a/docs/superpowers/plans/2026-07-03-parser-eval-backend.md
+++ b/docs/superpowers/plans/2026-07-03-parser-eval-backend.md
@@ -31,6 +31,20 @@
 
 ---
 
+## Known deviation from the product vision (build as specified; do NOT "fix" here)
+
+`ParserEvalCase` is a deliberate pragmatic stand-in: it re-wraps `project_id + source_document_id`
+(plus `name`/`doc_type`/`source_filename`) in a parallel table. The product vision treats `Document`
+and `ParsedDocument` as first-class primitives ("Document" = the source_document that belongs to this
+project), and eval/ground-truth should ultimately bind to those rather than a parallel case entity;
+raw-text `text` ground truth is a convenience, not canonical; `source_filename` is redundant
+denormalization of `SourceDocument.filename`. **Build the model exactly as specified for the first
+slice** — collapsing `ParserEvalCase` onto `Document`/`ParsedDocument` is a separate future refactor
+(see the design spec's "Vision alignment & known deviations"), gated on the Index→`ParsedDocument`
+refactor. Do not attempt it in this plan.
+
+---
+
 ## File Structure
 
 - Create `app/models/parser_eval.py` — `ParserEvalCase`, `ParserEvalTarget`, `ParserEvalRun`, `ParserEvalResult`, `ParserEvalDimension`, `ParserEvalRunStatus`.

--- a/docs/superpowers/plans/2026-07-03-parser-eval-backend.md
+++ b/docs/superpowers/plans/2026-07-03-parser-eval-backend.md
@@ -1,0 +1,1472 @@
+# Parser Evaluation — Backend (Plan 1 of 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the backend for the parser-evaluation feature's first slice — a project-scoped API that stores benchmark cases with per-dimension ground truth, runs a set of parsers over each case, scores the `text` dimension, and persists comparable per-parser results.
+
+**Architecture:** Mirrors the existing `extraction_eval` feature: `models → repository → service (+ engine + scorers) → router`, all async. The scoring engine reuses `ParsingService.parse_and_persist` to produce a `ParsedDocument` per parser (getting cost/latency from the returned `ParseRun` for free). Scorers are pure functions behind a registry keyed by dimension; only `text` is implemented in this slice.
+
+**Tech Stack:** Python 3.12, FastAPI (async), SQLAlchemy 2.0 (`Mapped`/`mapped_column`), Alembic, Pydantic v2, Postgres (ParadeDB), pytest. Text similarity uses stdlib `difflib` (no new dependency).
+
+## Global Constraints
+
+- Data flow is strictly `router → service → repository → database`; services raise exceptions, routers translate to HTTP. (Copied from CLAUDE.md.)
+- All DB operations are async with type hints.
+- Result rows are unique on `(run_id, case_id, parser, dimension)` — this is the mental-model result key.
+- The user never authors a `ParsedDocument`. Ground truth is a per-dimension JSON payload; `text` = `{ "pages": [str] }`.
+- A scorer runs for a case only if a target for that dimension exists (asserted-or-not; no false-zeros).
+- New models MUST be exported from `app/models/__init__.py` (so Alembic autogenerate and relationships resolve).
+- Enum columns follow the existing pattern: `Enum(<PyEnum>, name='<snake>', create_type=False)` with the type created explicitly in the migration.
+- Reuse `app.services.exceptions.NotFoundError` for missing entities; the router maps it to 404.
+- Tests run with: `cd backend && uv run python -m pytest -o "addopts=" <path> -v`.
+
+**Reference files to imitate (read before starting):**
+- Models: `app/models/extraction_eval.py`
+- Repository: `app/repositories/extraction_eval_repository.py`
+- Service: `app/services/extraction_eval/service.py`
+- Router + DI: `app/routers/extraction_eval.py`
+- Parsing entry point: `app/services/parsing/parsing_service.py` (`ensure_source_document`, `parse_and_persist`)
+- Parsing DI: `app/dependencies/documents.py` (`get_parsing_service`)
+- CDM types: `app/cdm/models.py` (`ParsedDocument`, `Page`, `ParserKind`)
+
+---
+
+## File Structure
+
+- Create `app/models/parser_eval.py` — `ParserEvalCase`, `ParserEvalTarget`, `ParserEvalRun`, `ParserEvalResult`, `ParserEvalDimension`, `ParserEvalRunStatus`.
+- Modify `app/models/__init__.py` — export the new models.
+- Create `alembic/versions/<rev>_add_parser_eval_tables.py` — enum types + 4 tables.
+- Create `app/services/parser_eval/__init__.py`
+- Create `app/services/parser_eval/scorers/__init__.py` — registry.
+- Create `app/services/parser_eval/scorers/text.py` — text-faithfulness scorer.
+- Create `app/services/parser_eval/capture.py` — wraps `ParsingService`.
+- Create `app/services/parser_eval/engine.py` — orchestrates a run.
+- Create `app/services/parser_eval/service.py` — CRUD + `execute_run`.
+- Create `app/repositories/parser_eval_repository.py`
+- Create `app/schemas/parser_eval.py`
+- Create `app/routers/parser_eval.py`
+- Modify `app/main.py` — include the router.
+- Create tests under `tests/services/parser_eval/`, `tests/repositories/`, `tests/routers/`.
+
+---
+
+## Task 1: Text-faithfulness scorer (pure function)
+
+Start here — it's the novel logic, has zero infra dependencies, and is fully unit-testable.
+
+**Files:**
+- Create: `app/services/parser_eval/__init__.py` (empty)
+- Create: `app/services/parser_eval/scorers/__init__.py` (empty for now)
+- Create: `app/services/parser_eval/scorers/text.py`
+- Test: `tests/services/parser_eval/__init__.py` (empty), `tests/services/parser_eval/test_text_scorer.py`
+
+**Interfaces:**
+- Produces: `score_text(cdm: ParsedDocument, expected: dict) -> tuple[float, dict]` where `expected == {"pages": [str, ...]}`. Returns `(similarity_score_0_1, details_dict)`. `details` keys: `per_page: list[{page, similarity, omission, hallucination}]`, `omission`, `hallucination`, `page_count_expected`, `page_count_parsed`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/services/parser_eval/test_text_scorer.py
+from app.cdm.models import ParsedDocument, Page
+from app.services.parser_eval.scorers.text import score_text
+
+
+def _doc(full_text: str, pages: list[tuple[int, int]]) -> ParsedDocument:
+    """Build a minimal ParsedDocument with page char-offsets into full_text."""
+    return ParsedDocument(
+        id="d1", source_document_id="s1", parse_run_id="r1",
+        page_count=len(pages),
+        pages=[Page(index=i, start_char=s, end_char=e) for i, (s, e) in enumerate(pages)],
+        blocks=[], full_text=full_text,
+    )
+
+
+def test_perfect_match_scores_one():
+    doc = _doc("hello world", [(0, 11)])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert score == 1.0
+    assert details["omission"] == 0.0
+    assert details["hallucination"] == 0.0
+
+
+def test_omission_detected():
+    # reference has two words, parse dropped one
+    doc = _doc("hello", [(0, 5)])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert score < 1.0
+    assert details["omission"] > 0.0
+
+
+def test_hallucination_detected():
+    doc = _doc("hello world extra", [(0, 17)])
+    score, details = score_text(doc, {"pages": ["hello world"]})
+    assert details["hallucination"] > 0.0
+
+
+def test_page_count_mismatch_penalized():
+    # reference has 2 pages, parse produced 1 → missing page fully omitted
+    doc = _doc("page one text", [(0, 13)])
+    score, details = score_text(doc, {"pages": ["page one text", "page two text"]})
+    assert details["page_count_expected"] == 2
+    assert details["page_count_parsed"] == 1
+    assert score < 1.0
+
+
+def test_normalization_ignores_whitespace_and_case():
+    doc = _doc("Hello    WORLD", [(0, 14)])
+    score, _ = score_text(doc, {"pages": ["hello world"]})
+    assert score == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_text_scorer.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.services.parser_eval.scorers.text`.
+
+- [ ] **Step 3: Implement the scorer**
+
+```python
+# app/services/parser_eval/scorers/text.py
+"""Text-faithfulness scorer — compares parsed per-page text to a page-segmented reference.
+
+Content-oriented and parser-agnostic: it flattens each page to text and never inspects
+block structure, so parsers that segment blocks differently are scored fairly.
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from typing import Any
+
+from app.cdm.models import ParsedDocument
+
+_WS = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    return _WS.sub(" ", (text or "").strip().lower())
+
+
+def _tokens(text: str) -> list[str]:
+    return _normalize(text).split()
+
+
+def _parsed_page_texts(cdm: ParsedDocument) -> list[str]:
+    """Per-page text via Page.start_char/end_char slices of full_text.
+
+    Falls back to concatenating each page's block text when offsets are absent.
+    """
+    full = cdm.full_text or ""
+    pages: list[str] = []
+    for page in sorted(cdm.pages, key=lambda p: p.index):
+        if full and page.start_char is not None and page.end_char is not None:
+            pages.append(full[page.start_char:page.end_char])
+        else:
+            pages.append(
+                " ".join(b.text for b in cdm.blocks if b.page_index == page.index)
+            )
+    return pages
+
+
+def _score_page(reference: str, parsed: str) -> dict[str, float]:
+    ref_norm, par_norm = _normalize(reference), _normalize(parsed)
+    similarity = difflib.SequenceMatcher(None, ref_norm, par_norm).ratio()
+
+    ref_toks, par_toks = set(_tokens(reference)), set(_tokens(parsed))
+    omission = 0.0 if not ref_toks else len(ref_toks - par_toks) / len(ref_toks)
+    hallucination = 0.0 if not par_toks else len(par_toks - ref_toks) / len(par_toks)
+    return {"similarity": similarity, "omission": omission, "hallucination": hallucination}
+
+
+def score_text(cdm: ParsedDocument, expected: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    reference_pages: list[str] = expected["pages"]
+    parsed_pages = _parsed_page_texts(cdm)
+
+    per_page: list[dict[str, Any]] = []
+    n = max(len(reference_pages), len(parsed_pages))
+    for i in range(n):
+        ref = reference_pages[i] if i < len(reference_pages) else ""
+        par = parsed_pages[i] if i < len(parsed_pages) else ""
+        page_scores = _score_page(ref, par)
+        per_page.append({"page": i, **page_scores})
+
+    # Length-weighted aggregate by reference character count (empty ref pages weight 0,
+    # but an unmatched *parsed* page still contributes hallucination via a min weight of 1).
+    def _weight(i: int) -> int:
+        return max(len(reference_pages[i]) if i < len(reference_pages) else 0, 1)
+
+    total_w = sum(_weight(i) for i in range(n)) or 1
+    similarity = sum(p["similarity"] * _weight(p["page"]) for p in per_page) / total_w
+    omission = sum(p["omission"] * _weight(p["page"]) for p in per_page) / total_w
+    hallucination = sum(p["hallucination"] * _weight(p["page"]) for p in per_page) / total_w
+
+    details = {
+        "per_page": per_page,
+        "omission": omission,
+        "hallucination": hallucination,
+        "page_count_expected": len(reference_pages),
+        "page_count_parsed": len(parsed_pages),
+    }
+    return similarity, details
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_text_scorer.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parser_eval backend/tests/services/parser_eval
+git commit -m "feat(parser-eval): text-faithfulness scorer"
+```
+
+---
+
+## Task 2: Scorer registry
+
+**Files:**
+- Modify: `app/services/parser_eval/scorers/__init__.py`
+- Test: `tests/services/parser_eval/test_registry.py`
+
+**Interfaces:**
+- Consumes: `score_text` from Task 1.
+- Produces: `SCORERS: dict[str, Scorer]` and `get_scorer(dimension: str) -> Scorer`. `Scorer` is `Callable[[ParsedDocument, dict], tuple[float, dict]]`. Unknown dimension raises `KeyError`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/parser_eval/test_registry.py
+import pytest
+from app.services.parser_eval.scorers import get_scorer
+from app.services.parser_eval.scorers.text import score_text
+
+
+def test_text_scorer_registered():
+    assert get_scorer("text") is score_text
+
+
+def test_unknown_dimension_raises():
+    with pytest.raises(KeyError):
+        get_scorer("does_not_exist")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_registry.py -v`
+Expected: FAIL — `ImportError: cannot import name 'get_scorer'`.
+
+- [ ] **Step 3: Implement the registry**
+
+```python
+# app/services/parser_eval/scorers/__init__.py
+"""Registry of dimension scorers. Add a dimension = add one entry here (seam #1)."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from app.cdm.models import ParsedDocument
+from app.services.parser_eval.scorers.text import score_text
+
+Scorer = Callable[[ParsedDocument, dict[str, Any]], tuple[float, dict[str, Any]]]
+
+SCORERS: dict[str, Scorer] = {
+    "text": score_text,
+}
+
+
+def get_scorer(dimension: str) -> Scorer:
+    return SCORERS[dimension]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_registry.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parser_eval/scorers/__init__.py backend/tests/services/parser_eval/test_registry.py
+git commit -m "feat(parser-eval): scorer registry"
+```
+
+---
+
+## Task 3: Data model + migration
+
+**Files:**
+- Create: `app/models/parser_eval.py`
+- Modify: `app/models/__init__.py` (add exports)
+- Create: `alembic/versions/<rev>_add_parser_eval_tables.py`
+- Test: `tests/models/test_parser_eval_models.py`
+
+**Interfaces:**
+- Produces (imported by later tasks):
+  - `ParserEvalDimension(str, enum.Enum)` with member `text = "text"`.
+  - `ParserEvalRunStatus(str, enum.Enum)`: `pending, running, completed, failed`.
+  - `ParserEvalCase(id, project_id, name, doc_type, source_document_id, source_filename, created_by, created_at)` with `targets` relationship.
+  - `ParserEvalTarget(id, case_id, dimension, expected: dict)`.
+  - `ParserEvalRun(id, project_id, name, parsers: list[str], case_ids: list[str], status, error_message, created_by, created_at, updated_at)` with `results` relationship.
+  - `ParserEvalResult(id, run_id, case_id, parser, dimension, score, details: dict, cost: dict, latency_ms, created_at)`; unique `(run_id, case_id, parser, dimension)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/models/test_parser_eval_models.py
+from app.models.parser_eval import (
+    ParserEvalCase, ParserEvalTarget, ParserEvalRun, ParserEvalResult,
+    ParserEvalDimension, ParserEvalRunStatus,
+)
+
+
+def test_dimension_and_status_enums():
+    assert ParserEvalDimension.text.value == "text"
+    assert ParserEvalRunStatus.pending.value == "pending"
+
+
+def test_tablenames():
+    assert ParserEvalCase.__tablename__ == "parser_eval_cases"
+    assert ParserEvalTarget.__tablename__ == "parser_eval_targets"
+    assert ParserEvalRun.__tablename__ == "parser_eval_runs"
+    assert ParserEvalResult.__tablename__ == "parser_eval_results"
+
+
+def test_result_unique_constraint_present():
+    names = {c.name for c in ParserEvalResult.__table__.constraints}
+    assert "uq_parser_eval_results_run_case_parser_dim" in names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/models/test_parser_eval_models.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.models.parser_eval`.
+
+- [ ] **Step 3: Implement the models**
+
+```python
+# app/models/parser_eval.py
+"""Models for parser evaluation — scoring parser CDM output against per-dimension ground truth."""
+from datetime import datetime
+from uuid import UUID, uuid4
+import enum
+
+import sqlalchemy as sa
+from sqlalchemy import DateTime, Enum, Float, ForeignKey, Integer, String, Text, JSON
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class ParserEvalDimension(str, enum.Enum):
+    text = "text"          # first slice; table/reading_order/roles added later (seam #1)
+
+
+class ParserEvalRunStatus(str, enum.Enum):
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+
+
+class ParserEvalCase(Base):
+    """A benchmark document plus its per-dimension ground-truth targets."""
+    __tablename__ = "parser_eval_cases"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    doc_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    source_document_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("source_documents.id", ondelete="RESTRICT"), nullable=False)
+    source_filename: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    created_by: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, server_default=sa.text('NOW()'))
+
+    targets: Mapped[list["ParserEvalTarget"]] = relationship(
+        back_populates="case", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        sa.Index('ix_parser_eval_cases_project_id', 'project_id'),
+    )
+
+
+class ParserEvalTarget(Base):
+    """One asserted dimension + its ground-truth payload for a case."""
+    __tablename__ = "parser_eval_targets"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    case_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("parser_eval_cases.id", ondelete="CASCADE"), nullable=False)
+    dimension: Mapped[ParserEvalDimension] = mapped_column(
+        Enum(ParserEvalDimension, name='parser_eval_dimension', create_type=False), nullable=False)
+    expected: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+    case: Mapped["ParserEvalCase"] = relationship(back_populates="targets")
+
+    __table_args__ = (
+        sa.UniqueConstraint('case_id', 'dimension', name='uq_parser_eval_targets_case_dim'),
+        sa.Index('ix_parser_eval_targets_case_id', 'case_id'),
+    )
+
+
+class ParserEvalRun(Base):
+    """One execution over selected cases × parsers."""
+    __tablename__ = "parser_eval_runs"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    parsers: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default='[]')
+    case_ids: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default='[]')  # UUID strings
+    status: Mapped[ParserEvalRunStatus] = mapped_column(
+        Enum(ParserEvalRunStatus, name='parser_eval_run_status', create_type=False),
+        nullable=False, default=ParserEvalRunStatus.pending, server_default='pending')
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, server_default=sa.text('NOW()'))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, onupdate=datetime.utcnow,
+                                                 server_default=sa.text('NOW()'))
+
+    results: Mapped[list["ParserEvalResult"]] = relationship(
+        back_populates="run", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        sa.Index('ix_parser_eval_runs_project_id', 'project_id'),
+    )
+
+
+class ParserEvalResult(Base):
+    """One score cell: (run, case, parser, dimension) -> score + details + cost/latency."""
+    __tablename__ = "parser_eval_results"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4,
+                                     server_default=sa.text('gen_random_uuid()'))
+    run_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("parser_eval_runs.id", ondelete="CASCADE"), nullable=False)
+    case_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("parser_eval_cases.id", ondelete="CASCADE"), nullable=False)
+    parser: Mapped[str] = mapped_column(String(64), nullable=False)
+    dimension: Mapped[ParserEvalDimension] = mapped_column(
+        Enum(ParserEvalDimension, name='parser_eval_dimension', create_type=False), nullable=False)
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    cost: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False,
+                                                 default=datetime.utcnow, server_default=sa.text('NOW()'))
+
+    run: Mapped["ParserEvalRun"] = relationship(back_populates="results")
+
+    __table_args__ = (
+        sa.UniqueConstraint('run_id', 'case_id', 'parser', 'dimension',
+                            name='uq_parser_eval_results_run_case_parser_dim'),
+        sa.Index('ix_parser_eval_results_run_id', 'run_id'),
+    )
+```
+
+- [ ] **Step 4: Export the models**
+
+Add to `app/models/__init__.py` (follow the existing import + `__all__` style already used for `extraction_eval`):
+
+```python
+from app.models.parser_eval import (
+    ParserEvalCase, ParserEvalTarget, ParserEvalRun, ParserEvalResult,
+    ParserEvalDimension, ParserEvalRunStatus,
+)
+```
+Add those six names to `__all__` if the file defines one.
+
+- [ ] **Step 5: Run model test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/models/test_parser_eval_models.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Generate the migration**
+
+Run: `cd backend && alembic revision --autogenerate -m "add parser eval tables"`
+Then open the generated file and verify/adjust:
+- The two enum types (`parser_eval_dimension`, `parser_eval_run_status`) are created before the tables that use them. If autogenerate omitted them (common with `create_type=False`), add explicit creation at the top of `upgrade()` and drop at the bottom of `downgrade()`:
+
+```python
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    dim = sa.Enum('text', name='parser_eval_dimension')
+    status = sa.Enum('pending', 'running', 'completed', 'failed', name='parser_eval_run_status')
+    dim.create(op.get_bind(), checkfirst=True)
+    status.create(op.get_bind(), checkfirst=True)
+    # ... op.create_table(...) for the 4 tables (autogenerated) ...
+
+def downgrade():
+    # ... op.drop_table(...) in reverse FK order (results, targets, runs, cases) ...
+    sa.Enum(name='parser_eval_run_status').drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name='parser_eval_dimension').drop(op.get_bind(), checkfirst=True)
+```
+
+- [ ] **Step 7: Apply and verify the migration**
+
+Run: `cd backend && alembic upgrade head`
+Expected: no error; tables created. Sanity check round-trip:
+Run: `cd backend && alembic downgrade -1 && alembic upgrade head`
+Expected: both succeed (down/up are symmetric).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/models/parser_eval.py backend/app/models/__init__.py backend/alembic/versions backend/tests/models/test_parser_eval_models.py
+git commit -m "feat(parser-eval): data model + migration"
+```
+
+---
+
+## Task 4: Repository
+
+**Files:**
+- Create: `app/repositories/parser_eval_repository.py`
+- Test: `tests/repositories/test_parser_eval_repository.py`
+
+**Interfaces:**
+- Consumes: models from Task 3.
+- Produces `ParserEvalRepository(session)` with:
+  - `create_case(project_id, name, doc_type, source_document_id, source_filename, user_id) -> ParserEvalCase`
+  - `add_target(case_id, dimension, expected) -> ParserEvalTarget`
+  - `get_case(case_id) -> ParserEvalCase | None` (targets eager-loaded)
+  - `list_cases(project_id) -> list[ParserEvalCase]`
+  - `create_run(project_id, name, parsers, case_ids, user_id) -> ParserEvalRun`
+  - `get_run(run_id) -> ParserEvalRun | None`
+  - `list_runs(project_id) -> list[ParserEvalRun]`
+  - `set_run_status(run_id, status, error_message=None) -> None`
+  - `upsert_result(run_id, case_id, parser, dimension, score, details, cost, latency_ms) -> None`
+  - `get_results(run_id) -> list[ParserEvalResult]`
+
+- [ ] **Step 1: Write the failing test** (uses the async DB session fixture used by other repo tests — imitate `tests/repositories/test_classification_run_repository.py` for fixture names)
+
+```python
+# tests/repositories/test_parser_eval_repository.py
+import pytest
+from app.models.parser_eval import ParserEvalDimension, ParserEvalRunStatus
+from app.repositories.parser_eval_repository import ParserEvalRepository
+
+
+@pytest.mark.asyncio
+async def test_create_case_with_target_and_fetch(db_session, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+    repo = ParserEvalRepository(db_session)
+
+    case = await repo.create_case(project_id, "acme_invoice", "invoice", source_id, "acme.pdf", user_id)
+    await repo.add_target(case.id, ParserEvalDimension.text, {"pages": ["hello"]})
+
+    fetched = await repo.get_case(case.id)
+    assert fetched.name == "acme_invoice"
+    assert len(fetched.targets) == 1
+    assert fetched.targets[0].expected == {"pages": ["hello"]}
+
+
+@pytest.mark.asyncio
+async def test_run_and_result_upsert(db_session, seed_project_user_source):
+    project_id, user_id, _ = seed_project_user_source
+    repo = ParserEvalRepository(db_session)
+    run = await repo.create_run(project_id, "run-1", ["docling", "simple"], [], user_id)
+
+    case = await repo.create_case(project_id, "c", None, _seed_source_of(seed_project_user_source), None, user_id)
+    await repo.upsert_result(run.id, case.id, "docling", ParserEvalDimension.text, 0.9, {}, {}, 120)
+    await repo.upsert_result(run.id, case.id, "docling", ParserEvalDimension.text, 0.95, {}, {}, 130)  # same key
+
+    results = await repo.get_results(run.id)
+    assert len(results) == 1              # upsert replaced, not duplicated
+    assert results[0].score == 0.95
+
+    await repo.set_run_status(run.id, ParserEvalRunStatus.completed)
+    assert (await repo.get_run(run.id)).status == ParserEvalRunStatus.completed
+```
+
+> Note for implementer: `seed_project_user_source` is a fixture you add to `tests/conftest.py` (or the nearest package conftest) that inserts a `Project`, `User`, and `SourceDocument` and returns their ids. Follow the existing seeding helpers in `tests/conftest.py`. `_seed_source_of` is illustrative — reuse the same `source_id` from the fixture; simplify the second test to reuse `source_id` if a helper isn't warranted.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/repositories/test_parser_eval_repository.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.repositories.parser_eval_repository`.
+
+- [ ] **Step 3: Implement the repository** (mirror `extraction_eval_repository.py`)
+
+```python
+# app/repositories/parser_eval_repository.py
+"""Repository for parser evaluation data access."""
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.parser_eval import (
+    ParserEvalCase, ParserEvalTarget, ParserEvalRun, ParserEvalResult,
+    ParserEvalDimension, ParserEvalRunStatus,
+)
+
+
+class ParserEvalRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    # --- cases / targets ---
+    async def create_case(self, project_id: UUID, name: str, doc_type: str | None,
+                          source_document_id: UUID, source_filename: str | None,
+                          user_id: UUID) -> ParserEvalCase:
+        case = ParserEvalCase(project_id=project_id, name=name, doc_type=doc_type,
+                              source_document_id=source_document_id,
+                              source_filename=source_filename, created_by=user_id)
+        self.session.add(case)
+        await self.session.commit()
+        await self.session.refresh(case)
+        return case
+
+    async def add_target(self, case_id: UUID, dimension: ParserEvalDimension,
+                         expected: dict) -> ParserEvalTarget:
+        target = ParserEvalTarget(case_id=case_id, dimension=dimension, expected=expected)
+        self.session.add(target)
+        await self.session.commit()
+        await self.session.refresh(target)
+        return target
+
+    async def get_case(self, case_id: UUID) -> ParserEvalCase | None:
+        res = await self.session.execute(
+            select(ParserEvalCase).options(selectinload(ParserEvalCase.targets))
+            .where(ParserEvalCase.id == case_id))
+        return res.scalar_one_or_none()
+
+    async def list_cases(self, project_id: UUID) -> list[ParserEvalCase]:
+        res = await self.session.execute(
+            select(ParserEvalCase).options(selectinload(ParserEvalCase.targets))
+            .where(ParserEvalCase.project_id == project_id)
+            .order_by(ParserEvalCase.created_at.desc()))
+        return list(res.scalars().all())
+
+    # --- runs / results ---
+    async def create_run(self, project_id: UUID, name: str, parsers: list[str],
+                         case_ids: list[str], user_id: UUID) -> ParserEvalRun:
+        run = ParserEvalRun(project_id=project_id, name=name, parsers=parsers,
+                            case_ids=case_ids, created_by=user_id)
+        self.session.add(run)
+        await self.session.commit()
+        await self.session.refresh(run)
+        return run
+
+    async def get_run(self, run_id: UUID) -> ParserEvalRun | None:
+        res = await self.session.execute(
+            select(ParserEvalRun).where(ParserEvalRun.id == run_id))
+        return res.scalar_one_or_none()
+
+    async def list_runs(self, project_id: UUID) -> list[ParserEvalRun]:
+        res = await self.session.execute(
+            select(ParserEvalRun).where(ParserEvalRun.project_id == project_id)
+            .order_by(ParserEvalRun.created_at.desc()))
+        return list(res.scalars().all())
+
+    async def set_run_status(self, run_id: UUID, status: ParserEvalRunStatus,
+                             error_message: str | None = None) -> None:
+        run = await self.get_run(run_id)
+        if run is None:
+            return
+        run.status = status
+        if error_message is not None:
+            run.error_message = error_message
+        await self.session.commit()
+
+    async def upsert_result(self, run_id: UUID, case_id: UUID, parser: str,
+                            dimension: ParserEvalDimension, score: float, details: dict,
+                            cost: dict, latency_ms: int | None) -> None:
+        res = await self.session.execute(
+            select(ParserEvalResult).where(
+                ParserEvalResult.run_id == run_id, ParserEvalResult.case_id == case_id,
+                ParserEvalResult.parser == parser, ParserEvalResult.dimension == dimension))
+        existing = res.scalar_one_or_none()
+        if existing is None:
+            self.session.add(ParserEvalResult(
+                run_id=run_id, case_id=case_id, parser=parser, dimension=dimension,
+                score=score, details=details, cost=cost, latency_ms=latency_ms))
+        else:
+            existing.score, existing.details = score, details
+            existing.cost, existing.latency_ms = cost, latency_ms
+        await self.session.commit()
+
+    async def get_results(self, run_id: UUID) -> list[ParserEvalResult]:
+        res = await self.session.execute(
+            select(ParserEvalResult).where(ParserEvalResult.run_id == run_id)
+            .order_by(ParserEvalResult.case_id, ParserEvalResult.parser))
+        return list(res.scalars().all())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/repositories/test_parser_eval_repository.py -v`
+Expected: PASS (adjust the `seed_project_user_source` fixture until green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/repositories/parser_eval_repository.py backend/tests/repositories/test_parser_eval_repository.py backend/tests/conftest.py
+git commit -m "feat(parser-eval): repository"
+```
+
+---
+
+## Task 5: Capture (wraps ParsingService)
+
+**Files:**
+- Create: `app/services/parser_eval/capture.py`
+- Test: `tests/services/parser_eval/test_capture.py`
+
+**Interfaces:**
+- Consumes: `ParsingService` (`ensure_source_document`, `parse_and_persist`), `app.ports.storage.StorageService`, `ParserKind`.
+- Produces: `async capture(parsing_service, storage, *, source_document_id, storage_uri, filename, mime_type, parser, project_id) -> tuple[ParsedDocument | None, dict, int | None]` returning `(cdm, cost_dict, latency_ms)`. On parse failure returns `(None, {}, None)`.
+
+Design note: `parse_and_persist` needs a local `file_path`. We fetch bytes via `storage.get(storage_uri)`, write them to a temp file, and pass that path. We call `ensure_source_document` to obtain the CDM `SourceDocument` the parser expects.
+
+- [ ] **Step 1: Write the failing test** (unit test with fakes — no real parsers)
+
+```python
+# tests/services/parser_eval/test_capture.py
+import pytest
+from types import SimpleNamespace
+from app.cdm.models import ParsedDocument
+from app.services.parser_eval.capture import capture
+
+
+class _FakeStorage:
+    async def get(self, path): return b"%PDF-1.4 fake"
+    async def save(self, content, rel): return rel
+
+
+class _FakeParsing:
+    async def ensure_source_document(self, *, bytes_, filename, mime_type):
+        return SimpleNamespace(id="src-1", sha256="abc", filename=filename,
+                               mime_type=mime_type, byte_size=len(bytes_), storage_uri="u")
+    async def parse_and_persist(self, *, source, file_path, representation_kind, config, project_id, force=False):
+        run = SimpleNamespace(cost={"usd": 0.0}, duration_ms=42,
+                              input_tokens=None, output_tokens=None)
+        doc = ParsedDocument(id="d", source_document_id="src-1", parse_run_id="r",
+                             page_count=1, pages=[], blocks=[], full_text="hi")
+        return run, doc
+
+
+@pytest.mark.asyncio
+async def test_capture_returns_cdm_and_metrics():
+    cdm, cost, latency = await capture(
+        _FakeParsing(), _FakeStorage(),
+        source_document_id="src-1", storage_uri="u", filename="a.pdf",
+        mime_type="application/pdf", parser="docling", project_id="p1")
+    assert cdm.full_text == "hi"
+    assert latency == 42
+    assert cost == {"usd": 0.0}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_capture.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement capture**
+
+```python
+# app/services/parser_eval/capture.py
+"""Capture a ParsedDocument for one parser by reusing ParsingService.
+
+Cost/latency come from the returned ParseRun — no bespoke timing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from typing import Any
+
+from app.cdm.models import ParsedDocument
+from app.services.parsing.errors import ParseFailedError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REPRESENTATION_KIND = "extract_rich"
+
+
+async def capture(
+    parsing_service: Any,
+    storage: Any,
+    *,
+    source_document_id: str,
+    storage_uri: str,
+    filename: str,
+    mime_type: str,
+    parser: str,
+    project_id: Any,
+) -> tuple[ParsedDocument | None, dict, int | None]:
+    data = await storage.get(storage_uri)
+    source = await parsing_service.ensure_source_document(
+        bytes_=data, filename=filename, mime_type=mime_type)
+
+    suffix = os.path.splitext(filename)[1] or ".bin"
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(data)
+            tmp_path = tmp.name
+        run, doc = await parsing_service.parse_and_persist(
+            source=source, file_path=tmp_path,
+            representation_kind=DEFAULT_REPRESENTATION_KIND,
+            config={"parser": parser}, project_id=project_id, force=False)
+        return doc, dict(run.cost or {}), run.duration_ms
+    except ParseFailedError as err:
+        logger.warning("parser-eval capture failed parser=%s: %s", parser, err)
+        return None, {}, None
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_capture.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parser_eval/capture.py backend/tests/services/parser_eval/test_capture.py
+git commit -m "feat(parser-eval): capture via ParsingService"
+```
+
+---
+
+## Task 6: Engine (orchestrate a run)
+
+**Files:**
+- Create: `app/services/parser_eval/engine.py`
+- Test: `tests/services/parser_eval/test_engine.py`
+
+**Interfaces:**
+- Consumes: `capture` (Task 5), `get_scorer` (Task 2), `ParserEvalRepository` (Task 4).
+- Produces: `async run_evaluation(repo, parsing_service, storage, *, run_id, cases, parsers, project_id) -> None`. `cases` is a list of `ParserEvalCase` (with `.targets`). For each `(case, parser)` it captures once, then scores each asserted target and upserts a result. A parser that fails capture records a `score=0.0` result with `details={"capture_failed": True}` for each of the case's targets (so failure is visible, not missing). Sets run status running→completed, or failed on unexpected error.
+
+- [ ] **Step 1: Write the failing test** (fakes for capture via monkeypatch and an in-memory repo spy)
+
+```python
+# tests/services/parser_eval/test_engine.py
+import pytest
+from types import SimpleNamespace
+from app.cdm.models import ParsedDocument
+from app.models.parser_eval import ParserEvalDimension, ParserEvalRunStatus
+from app.services.parser_eval import engine as engine_mod
+
+
+class _RepoSpy:
+    def __init__(self): self.results = []; self.status = None
+    async def upsert_result(self, run_id, case_id, parser, dimension, score, details, cost, latency_ms):
+        self.results.append((parser, dimension, score))
+    async def set_run_status(self, run_id, status, error_message=None):
+        self.status = status
+
+
+def _case():
+    target = SimpleNamespace(dimension=ParserEvalDimension.text, expected={"pages": ["hi"]})
+    return SimpleNamespace(id="c1", targets=[target])
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_scores_each_parser(monkeypatch):
+    async def fake_capture(*args, **kwargs):
+        doc = ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                             page_count=1, pages=[], blocks=[], full_text="hi")
+        return doc, {"usd": 0.0}, 10
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    repo = _RepoSpy()
+    await engine_mod.run_evaluation(
+        repo, parsing_service=None, storage=None, run_id="run1",
+        cases=[_case()], parsers=["docling", "simple"], project_id="p1",
+        _case_source=lambda c: ("src", "uri", "a.pdf", "application/pdf"))
+    assert repo.status == ParserEvalRunStatus.completed
+    assert {r[0] for r in repo.results} == {"docling", "simple"}
+    assert all(r[2] == 1.0 for r in repo.results)   # "hi" == "hi"
+
+
+@pytest.mark.asyncio
+async def test_capture_failure_records_zero(monkeypatch):
+    async def fake_capture(*args, **kwargs):
+        return None, {}, None
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    repo = _RepoSpy()
+    await engine_mod.run_evaluation(
+        repo, parsing_service=None, storage=None, run_id="run1",
+        cases=[_case()], parsers=["docling"], project_id="p1",
+        _case_source=lambda c: ("src", "uri", "a.pdf", "application/pdf"))
+    assert repo.results == [("docling", ParserEvalDimension.text, 0.0)]
+    assert repo.status == ParserEvalRunStatus.completed
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_engine.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the engine**
+
+```python
+# app/services/parser_eval/engine.py
+"""Orchestrate one parser-eval run: capture per parser, score each asserted target, persist."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from app.models.parser_eval import ParserEvalRunStatus
+from app.services.parser_eval.capture import capture
+from app.services.parser_eval.scorers import get_scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _default_case_source(case: Any) -> tuple[str, str, str, str]:
+    # Overridden in tests; the service passes a resolver that reads SourceDocument fields.
+    raise NotImplementedError
+
+
+async def run_evaluation(
+    repo: Any,
+    parsing_service: Any,
+    storage: Any,
+    *,
+    run_id: Any,
+    cases: list[Any],
+    parsers: list[str],
+    project_id: Any,
+    _case_source: Callable[[Any], tuple[str, str, str, str]] = _default_case_source,
+) -> None:
+    await repo.set_run_status(run_id, ParserEvalRunStatus.running)
+    try:
+        for case in cases:
+            source_document_id, storage_uri, filename, mime_type = _case_source(case)
+            for parser in parsers:
+                cdm, cost, latency = await capture(
+                    parsing_service, storage,
+                    source_document_id=source_document_id, storage_uri=storage_uri,
+                    filename=filename, mime_type=mime_type, parser=parser,
+                    project_id=project_id)
+                for target in case.targets:            # only asserted dimensions
+                    if cdm is None:
+                        score, details = 0.0, {"capture_failed": True}
+                    else:
+                        score, details = get_scorer(target.dimension.value)(cdm, target.expected)
+                    await repo.upsert_result(run_id, case.id, parser, target.dimension,
+                                             score, details, cost, latency)
+        await repo.set_run_status(run_id, ParserEvalRunStatus.completed)
+    except Exception as err:                            # noqa: BLE001 — record and surface
+        logger.exception("parser-eval run %s failed", run_id)
+        await repo.set_run_status(run_id, ParserEvalRunStatus.failed, error_message=str(err))
+        raise
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_engine.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parser_eval/engine.py backend/tests/services/parser_eval/test_engine.py
+git commit -m "feat(parser-eval): run orchestration engine"
+```
+
+---
+
+## Task 7: Schemas
+
+**Files:**
+- Create: `app/schemas/parser_eval.py`
+- Test: `tests/schemas/test_parser_eval_schema.py`
+
+**Interfaces:**
+- Produces Pydantic v2 models: `TargetInput{dimension: str, expected: dict}`, `CaseCreate{name, doc_type: str|None, source_document_id: UUID, targets: list[TargetInput]}`, `CaseResponse`, `RunCreate{name: str|None, case_ids: list[UUID], parsers: list[str]}`, `RunResponse{id, name, status, parsers, created_at}`, `ResultResponse{case_id, parser, dimension, score, details, cost, latency_ms}`. Validate `text` targets have `expected["pages"]: list[str]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/schemas/test_parser_eval_schema.py
+import pytest
+from uuid import uuid4
+from pydantic import ValidationError
+from app.schemas.parser_eval import CaseCreate, TargetInput
+
+
+def test_valid_text_target():
+    c = CaseCreate(name="c", doc_type="invoice", source_document_id=uuid4(),
+                   targets=[TargetInput(dimension="text", expected={"pages": ["a", "b"]})])
+    assert c.targets[0].expected["pages"] == ["a", "b"]
+
+
+def test_text_target_requires_pages_list():
+    with pytest.raises(ValidationError):
+        TargetInput(dimension="text", expected={"wrong": 1})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/schemas/test_parser_eval_schema.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement schemas**
+
+```python
+# app/schemas/parser_eval.py
+"""Pydantic schemas for the parser-eval API."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class TargetInput(BaseModel):
+    dimension: str
+    expected: dict
+
+    @model_validator(mode="after")
+    def _validate_expected(self):
+        if self.dimension == "text":
+            pages = self.expected.get("pages")
+            if not isinstance(pages, list) or not all(isinstance(p, str) for p in pages):
+                raise ValueError("text target requires expected.pages: list[str]")
+        return self
+
+
+class CaseCreate(BaseModel):
+    name: str
+    doc_type: str | None = None
+    source_document_id: UUID
+    targets: list[TargetInput]
+
+
+class CaseResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: UUID
+    name: str
+    doc_type: str | None
+    source_document_id: UUID
+    source_filename: str | None
+    created_at: datetime
+
+
+class RunCreate(BaseModel):
+    name: str | None = None
+    case_ids: list[UUID]
+    parsers: list[str]
+
+
+class RunResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: UUID
+    name: str
+    status: str
+    parsers: list[str]
+    error_message: str | None = None
+    created_at: datetime
+
+
+class ResultResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    case_id: UUID
+    parser: str
+    dimension: str
+    score: float
+    details: dict | None
+    cost: dict | None
+    latency_ms: int | None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/schemas/test_parser_eval_schema.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/schemas/parser_eval.py backend/tests/schemas/test_parser_eval_schema.py
+git commit -m "feat(parser-eval): API schemas"
+```
+
+---
+
+## Task 8: Service (CRUD + execute_run)
+
+**Files:**
+- Create: `app/services/parser_eval/service.py`
+- Test: `tests/services/parser_eval/test_service.py`
+
+**Interfaces:**
+- Consumes: `ParserEvalRepository`, `SourceDocumentRepository` (to resolve a case's source `storage_uri`/`filename`/`mime_type`), `ParsingService`, `StorageService`, `run_evaluation`.
+- Produces `ParserEvalService(repo, source_doc_repo, parsing_service, storage)` with:
+  - `create_case(project_id, user_id, data: CaseCreate) -> CaseResponse` (persists case + targets; copies `source_filename` from the source document)
+  - `list_cases(project_id) -> list[CaseResponse]`
+  - `create_run(project_id, user_id, data: RunCreate) -> RunResponse`
+  - `execute_run(run_id) -> None` (loads run's cases, builds the `_case_source` resolver from `SourceDocument`, calls `run_evaluation`)
+  - `get_run / list_runs / get_results` passthroughs, raising `NotFoundError` when missing.
+
+- [ ] **Step 1: Write the failing test** (service-level, DB-backed; monkeypatch `engine.capture` so no real parser runs)
+
+```python
+# tests/services/parser_eval/test_service.py
+import pytest
+from app.cdm.models import ParsedDocument
+from app.schemas.parser_eval import CaseCreate, TargetInput, RunCreate
+from app.services.parser_eval import engine as engine_mod
+from app.services.parser_eval.service import ParserEvalService
+# ... construct service from db_session + real repos + fake parsing/storage (see capture test fakes)
+
+
+@pytest.mark.asyncio
+async def test_create_case_then_run_produces_results(db_session, seed_project_user_source, monkeypatch):
+    project_id, user_id, source_id = seed_project_user_source
+
+    async def fake_capture(*a, **k):
+        doc = ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                             page_count=1, pages=[], blocks=[], full_text="hi")
+        return doc, {"usd": 0.0}, 5
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    service = _build_service(db_session)   # helper wiring real repos + fakes
+    case = await service.create_case(project_id, user_id, CaseCreate(
+        name="c", source_document_id=source_id,
+        targets=[TargetInput(dimension="text", expected={"pages": ["hi"]})]))
+    run = await service.create_run(project_id, user_id, RunCreate(
+        name="r1", case_ids=[case.id], parsers=["docling"]))
+    await service.execute_run(run.id)
+
+    results = await service.get_results(run.id)
+    assert len(results) == 1
+    assert results[0].score == 1.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_service.py -v`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the service**
+
+```python
+# app/services/parser_eval/service.py
+"""Service orchestrating parser-eval CRUD and run execution."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.models.parser_eval import ParserEvalDimension
+from app.repositories.parser_eval_repository import ParserEvalRepository
+from app.repositories.source_document_repository import SourceDocumentRepository
+from app.schemas.parser_eval import (
+    CaseCreate, CaseResponse, RunCreate, RunResponse, ResultResponse,
+)
+from app.services.exceptions import NotFoundError
+from app.services.parser_eval.engine import run_evaluation
+
+
+class ParserEvalService:
+    def __init__(self, repo: ParserEvalRepository, source_doc_repo: SourceDocumentRepository,
+                 parsing_service, storage):
+        self.repo = repo
+        self.source_doc_repo = source_doc_repo
+        self.parsing_service = parsing_service
+        self.storage = storage
+
+    async def create_case(self, project_id: UUID, user_id: UUID, data: CaseCreate) -> CaseResponse:
+        source = await self.source_doc_repo.get(data.source_document_id)
+        if source is None:
+            raise NotFoundError(f"Source document {data.source_document_id} not found")
+        case = await self.repo.create_case(project_id, data.name, data.doc_type,
+                                           data.source_document_id, source.filename, user_id)
+        for t in data.targets:
+            await self.repo.add_target(case.id, ParserEvalDimension(t.dimension), t.expected)
+        return CaseResponse.model_validate(case)
+
+    async def list_cases(self, project_id: UUID) -> list[CaseResponse]:
+        return [CaseResponse.model_validate(c) for c in await self.repo.list_cases(project_id)]
+
+    async def create_run(self, project_id: UUID, user_id: UUID, data: RunCreate) -> RunResponse:
+        name = data.name or "Parser eval run"
+        run = await self.repo.create_run(
+            project_id, name, data.parsers, [str(cid) for cid in data.case_ids], user_id)
+        return RunResponse.model_validate(run)
+
+    async def execute_run(self, run_id: UUID) -> None:
+        run = await self.repo.get_run(run_id)
+        if run is None:
+            raise NotFoundError(f"Parser eval run {run_id} not found")
+        # Load only the cases selected for this run (persisted in run.case_ids).
+        selected = {str(cid) for cid in (run.case_ids or [])}
+        cases = [c for c in await self.repo.list_cases(run.project_id) if str(c.id) in selected]
+
+        # Resolve each case's source document fields for capture, once.
+        source_cache: dict[UUID, object] = {}
+
+        async def _resolve(case):
+            src = source_cache.get(case.source_document_id)
+            if src is None:
+                src = await self.source_doc_repo.get(case.source_document_id)
+                source_cache[case.source_document_id] = src
+            return (str(case.source_document_id), src.storage_uri, src.filename, src.mime_type)
+
+        # run_evaluation expects a sync resolver; pre-resolve into a dict.
+        resolved = {c.id: await _resolve(c) for c in cases}
+        await run_evaluation(
+            self.repo, self.parsing_service, self.storage,
+            run_id=run_id, cases=cases, parsers=list(run.parsers),
+            project_id=run.project_id, _case_source=lambda c: resolved[c.id])
+
+    async def get_run(self, run_id: UUID) -> RunResponse:
+        run = await self.repo.get_run(run_id)
+        if run is None:
+            raise NotFoundError(f"Parser eval run {run_id} not found")
+        return RunResponse.model_validate(run)
+
+    async def list_runs(self, project_id: UUID) -> list[RunResponse]:
+        return [RunResponse.model_validate(r) for r in await self.repo.list_runs(project_id)]
+
+    async def get_results(self, run_id: UUID) -> list[ResultResponse]:
+        run = await self.repo.get_run(run_id)
+        if run is None:
+            raise NotFoundError(f"Parser eval run {run_id} not found")
+        return [ResultResponse.model_validate(r) for r in await self.repo.get_results(run_id)]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_service.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parser_eval/service.py backend/tests/services/parser_eval/test_service.py
+git commit -m "feat(parser-eval): service (CRUD + execute_run)"
+```
+
+---
+
+## Task 9: Router + registration
+
+**Files:**
+- Create: `app/routers/parser_eval.py`
+- Modify: `app/main.py` (include router)
+- Test: `tests/routers/test_parser_eval_router.py`
+
+**Interfaces:**
+- Consumes: `ParserEvalService`, schemas, `get_current_active_user`, `get_db`, `get_parsing_service`, `get_storage_service`, `ProjectRepository` for access checks.
+- Produces routes (project-scoped, mirroring `extraction_eval.py`):
+  - `POST /api/projects/{project_id}/parser-eval/cases` → `CaseResponse`
+  - `GET  /api/projects/{project_id}/parser-eval/cases` → `list[CaseResponse]`
+  - `POST /api/projects/{project_id}/parser-eval/runs` (BackgroundTasks → `execute_run`) → `RunResponse` (202)
+  - `GET  /api/projects/{project_id}/parser-eval/runs` → `list[RunResponse]`
+  - `GET  /api/projects/{project_id}/parser-eval/runs/{run_id}/results` → `list[ResultResponse]`
+
+- [ ] **Step 1: Write the failing test** (imitate `tests/routers/test_extraction_router.py` client + auth fixtures)
+
+```python
+# tests/routers/test_parser_eval_router.py
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_case_and_run_flow(async_client, auth_headers, seed_project_source, monkeypatch):
+    from app.services.parser_eval import engine as engine_mod
+    from app.cdm.models import ParsedDocument
+
+    async def fake_capture(*a, **k):
+        return ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                              page_count=1, pages=[], blocks=[], full_text="hi"), {"usd": 0}, 3
+    monkeypatch.setattr(engine_mod, "capture", fake_capture)
+
+    project_id, source_id = seed_project_source
+    r = await async_client.post(
+        f"/api/projects/{project_id}/parser-eval/cases", headers=auth_headers,
+        json={"name": "c", "source_document_id": str(source_id),
+              "targets": [{"dimension": "text", "expected": {"pages": ["hi"]}}]})
+    assert r.status_code == 200
+    case_id = r.json()["id"]
+
+    r = await async_client.post(
+        f"/api/projects/{project_id}/parser-eval/runs", headers=auth_headers,
+        json={"name": "run", "case_ids": [case_id], "parsers": ["docling"]})
+    assert r.status_code in (200, 202)
+    run_id = r.json()["id"]
+
+    r = await async_client.get(
+        f"/api/projects/{project_id}/parser-eval/runs/{run_id}/results", headers=auth_headers)
+    assert r.status_code == 200
+```
+
+> Note: with `BackgroundTasks`, the run executes after the response in the test client. If results aren't ready synchronously, either call `service.execute_run` inline in the test or assert on run status instead. Mirror whatever pattern `test_extraction_router.py` uses for background eval runs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/routers/test_parser_eval_router.py -v`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Implement the router**
+
+```python
+# app/routers/parser_eval.py
+"""Parser Evaluation API router."""
+from uuid import UUID
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies.auth import get_current_active_user
+from app.dependencies.documents import get_parsing_service, get_storage_service
+from app.models import User
+from app.repositories.parser_eval_repository import ParserEvalRepository
+from app.repositories.project_repository import ProjectRepository
+from app.repositories.source_document_repository import SourceDocumentRepository
+from app.schemas.parser_eval import (
+    CaseCreate, CaseResponse, RunCreate, RunResponse, ResultResponse,
+)
+from app.services.exceptions import NotFoundError
+from app.services.parser_eval.service import ParserEvalService
+
+router = APIRouter(tags=["parser_eval"])
+
+
+def _service(db: AsyncSession) -> ParserEvalService:
+    return ParserEvalService(
+        repo=ParserEvalRepository(db),
+        source_doc_repo=SourceDocumentRepository(db),
+        parsing_service=get_parsing_service(db),
+        storage=get_storage_service(),
+    )
+
+
+def get_service(db: AsyncSession = Depends(get_db)) -> ParserEvalService:
+    return _service(db)
+
+
+async def _verify_project(project_id: UUID, user: User, db: AsyncSession) -> None:
+    project = await ProjectRepository(db).get_by_id(project_id, user.id)
+    if not project:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Project {project_id} not found")
+
+
+async def _execute_run_bg(db_maker, run_id: UUID) -> None:
+    async with db_maker() as db:               # fresh session for the background task
+        await _service(db).execute_run(run_id)
+
+
+@router.post("/projects/{project_id}/parser-eval/cases", response_model=CaseResponse)
+async def create_case(project_id: UUID, body: CaseCreate,
+                      user: User = Depends(get_current_active_user),
+                      db: AsyncSession = Depends(get_db)):
+    await _verify_project(project_id, user, db)
+    try:
+        return await get_service(db).create_case(project_id, user.id, body)
+    except NotFoundError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+
+
+@router.get("/projects/{project_id}/parser-eval/cases", response_model=list[CaseResponse])
+async def list_cases(project_id: UUID, user: User = Depends(get_current_active_user),
+                     db: AsyncSession = Depends(get_db)):
+    await _verify_project(project_id, user, db)
+    return await get_service(db).list_cases(project_id)
+
+
+@router.post("/projects/{project_id}/parser-eval/runs", response_model=RunResponse,
+             status_code=status.HTTP_202_ACCEPTED)
+async def create_run(project_id: UUID, body: RunCreate, background: BackgroundTasks,
+                     user: User = Depends(get_current_active_user),
+                     db: AsyncSession = Depends(get_db)):
+    await _verify_project(project_id, user, db)
+    run = await get_service(db).create_run(project_id, user.id, body)
+    from app.database import async_session_maker      # background task uses its own session
+    background.add_task(_execute_run_bg, async_session_maker, run.id)
+    return run
+
+
+@router.get("/projects/{project_id}/parser-eval/runs", response_model=list[RunResponse])
+async def list_runs(project_id: UUID, user: User = Depends(get_current_active_user),
+                    db: AsyncSession = Depends(get_db)):
+    await _verify_project(project_id, user, db)
+    return await get_service(db).list_runs(project_id)
+
+
+@router.get("/projects/{project_id}/parser-eval/runs/{run_id}/results",
+            response_model=list[ResultResponse])
+async def get_results(project_id: UUID, run_id: UUID,
+                      user: User = Depends(get_current_active_user),
+                      db: AsyncSession = Depends(get_db)):
+    await _verify_project(project_id, user, db)
+    try:
+        return await get_service(db).get_results(run_id)
+    except NotFoundError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+```
+
+> Confirm the exact background-session helper name (`async_session_maker`) and the router prefix used by peers in `app/main.py` (extraction_eval is included with a prefix like `/api`). Match that prefix so paths become `/api/projects/{id}/parser-eval/...`.
+
+- [ ] **Step 4: Register the router in `app/main.py`**
+
+Mirror the existing `extraction_eval` include line, e.g.:
+```python
+from app.routers import parser_eval
+app.include_router(parser_eval.router, prefix="/api")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/routers/test_parser_eval_router.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/routers/parser_eval.py backend/app/main.py backend/tests/routers/test_parser_eval_router.py
+git commit -m "feat(parser-eval): API router + registration"
+```
+
+---
+
+## Task 10: Full-suite regression check
+
+- [ ] **Step 1: Run the whole backend suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts="`
+Expected: no new failures introduced by this feature. Fix any import/registration fallout (e.g. `app/models/__init__.py` export, migration head).
+
+- [ ] **Step 2: Commit any fixes**
+
+```bash
+git add -A && git commit -m "test(parser-eval): green full backend suite"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+- **Spec coverage:** data model (Task 3) ✔; per-dimension asserted truth + result key `(run,case,parser,dimension)` (Tasks 3–4, unique constraint) ✔; capture reuses `ParsingService`, cost/latency from `ParseRun` (Task 5) ✔; text scorer page-segmented with omission/hallucination (Task 1) ✔; scorer registry seam (Task 2) ✔; project-scoped API mirroring `extraction_eval` (Task 9) ✔.
+- **Deferred to Plan 2 (frontend):** case/truth authoring UI, run trigger, comparison table (`ComparisonTable`/`ScorePill`). Backend endpoints here are the contract that plan consumes.
+- **Run→case selection:** persisted via a `case_ids` JSON column on `ParserEvalRun` (Task 3), filtered in `execute_run` (Task 8) — no "run all project cases" trap.
+- **Confirm-at-implementation (environment specifics, not logic gaps):** the background DB session-maker symbol (`async_session_maker`) and the router prefix peers use in `app/main.py`; the `seed_project_user_source` test fixture wiring. Each is a name to match against the existing codebase, shown with its expected shape.
+- **Not in this slice (seams):** table/reading-order/roles scorers, profiles/weighting/selection, caching/capture-score split, baselines/regression, LLM-judge. All additive via the registry (Task 2) and dimension-typed `expected` payloads.

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -29,14 +29,22 @@ table structure for a document, pick `pdfplumber` — it is CPU-only, fast, and 
 - Start **as simple as possible**; grow abstractions only when a second concrete case demands them.
 - Leave clean seams so extension is additive, not a rewrite.
 
-## Non-Goals (for v0)
+## Non-Goals (for the first slice)
+
+The feature's destination is DB-backed and frontend-surfaced (see "Relationship to existing code").
+These are deferred out of the *first* slice, not out of the feature:
 
 - No CI integration, no regression gating. (Named as a seam; deferred.)
 - No extrinsic / end-task evaluation (retrieval or answer quality). **Intrinsic first** — score the
   CDM directly against ground truth. Extrinsic is a future layer.
-- No profile/weighting engine, no automatic "winner" selection. v0 prints raw per-dimension scores.
-- No caching layer / capture-score split. v0 runs parsing and scoring inline.
-- No UI. Output is a printed table + a JSON/JSONL artifact.
+- No profile/weighting engine, no automatic "winner" selection. First slice reports raw
+  per-dimension scores.
+- No caching layer / capture-score split. First slice runs parsing and scoring inline.
+- Implementing a `pdfplumber` adapter — pdfplumber belongs to the existing `custom_pipeline`.
+
+**Frontend note:** the feature *is* surfaced in the app UI; whether the UI lands in the first slice
+or the second is the lead Open Question below. The "printed table + `results.json`" form is the
+minimal developer-facing output of the scoring core, which the UI later reads — not the end state.
 
 ## Mental model
 
@@ -52,10 +60,16 @@ Result:                score in [0,1] for (case, parser, target), plus cost + la
   structure, reading order, role/structure accuracy, spatial (bbox). Different documents stress
   different dimensions; a parser is never one number.
 - A **scorer** is a small, independently testable unit: `score(cdm, expected) -> (float, details)`.
-- **Ground truth is per-dimension**, not per-document. A case carries `expected` only for the
-  dimensions it tests. A table-stress doc ships a gold table; a prose doc ships clean text. Ground
-  truth cost scales with *what you test*, not with document complexity — this is what makes the
-  corpus sustainable.
+- **One document, many scorers — but ground truth stays per-dimension.** A document is a *container*:
+  it may attach several dimension scorers (that is the intended UX). But each dimension carries its
+  **own** `expected` artifact and is **explicitly asserted or not** for that document. There is no
+  single shared ground-truth object that all scorers read — that path causes all-or-nothing
+  authoring, silent false-zeros when a dimension's truth is absent, schema-migration ripple, and
+  segmentation bias. See "Ground truth model" below.
+- **Ground truth cost scales with what you test**, not with document complexity. A table-stress doc
+  ships a gold table; a prose doc ships clean text; neither is forced to label the other's dimension.
+- **The result key is `(doc, parser, dimension)`** — a flat row, from day one. Many scorers per doc
+  produces a vector of these rows, which is also how baselines and regression are keyed.
 
 ## v0 design — the minimal loop
 
@@ -74,16 +88,34 @@ backend/app/services/parser_eval/benchmark/
       p2.html             #   gold table            (table dimension)
 ```
 
-`case.yaml`:
+`case.yaml` — a doc may attach multiple targets; each names its own dimension + `expected`, and a
+dimension is asserted **only** if it appears here:
 
 ```yaml
 name: acme_invoice
 doc_type: invoice
-parsers: [pdfplumber, docling, llamaparse]   # omit/[] = all registered parsers
+parsers: [docling, llamaparse, custom_pipeline]   # omit/[] = all registered parsers
 targets:
   - dimension: text
     expected: truth/text.txt
+  - dimension: table
+    expected: truth/p2.html         # table is asserted; reading_order/roles are NOT for this doc
 ```
+
+### Ground truth model (why it's per-dimension, not one shared object)
+
+A document containing multiple targets is the intended shape, but each target owns its ground truth:
+
+- **Per-dimension `expected`.** The `text` target reads `truth/text.txt`; the `table` target reads
+  `truth/p2.html`. No scorer reads a shared "expected document."
+- **Asserted-or-not is explicit.** A scorer runs for a doc **only if that dimension is a target**. A
+  missing dimension means "not evaluated here" — never a silent score of 0. This prevents
+  false-zeros and keeps authoring incremental (add a target when you're ready to label it).
+- **Prefer content-oriented truth.** Clean text, gold-table HTML — truth that does *not* assume a
+  block structure. Structural `expected_blocks`/`expected_page` is reserved for dimensions that are
+  inherently positional (reading order, role labels), and even then scorers align by **content, not
+  block id** — because parsers legitimately segment blocks differently, and a fixed `expected_blocks`
+  would unfairly penalize a parser whose segmentation differs but is correct.
 
 ### The run
 
@@ -102,9 +134,9 @@ Printed output shape:
 
 ```
 acme_invoice · text
-  pdfplumber   0.98   (cpu,   120ms,  $0)
-  docling      0.97   (cpu,   890ms,  $0)
-  llamaparse   0.99   (cloud, 3.2s,   $0.010)
+  docling          0.97   (cpu,   890ms,  $0)
+  custom_pipeline  0.95   (cpu,   140ms,  $0)
+  llamaparse       0.99   (cloud, 3.2s,   $0.010)
 ```
 
 ### First scorer: **text faithfulness** (chosen for v0)
@@ -149,9 +181,10 @@ forces them.
 2. **Dimension-typed truth loader.** `expected` for `text` is a string, for `table` is HTML, for
    `reading_order` a list. Seam: a per-dimension `load_truth` keyed by dimension, so no single "gold
    format" is ever forced across dimensions.
-3. **Parser = adapter + config.** The `pdfplumber_config` idea. Seam: an evaluator identity of
-   `(adapter, config)` so the *same* adapter under different configs is a distinct comparable row.
-   v0 uses default config and identifies parsers by `ParserKind`.
+3. **Parser = adapter + config.** E.g. the `custom_pipeline` adapter run under different tool configs
+   (pdfplumber-based or otherwise). Seam: an evaluator identity of `(adapter, config)` so the *same*
+   adapter under different configs is a distinct comparable row. v0 uses default config and
+   identifies parsers by `ParserKind`.
 4. **Capture/score split.** v0 runs `adapt()` inline. Seam: a `CachedRun {cdm, cost, latency}`
    boundary persisted to disk, so scoring decouples from expensive parsing once cloud cost/latency
    make re-parsing-per-metric-tweak wasteful. Aligns with existing raw-payload persistence.
@@ -170,34 +203,35 @@ forces them.
    small hand-labeled anchor set so its error rate is known before it is trusted. Never the backbone.
 9. **Extrinsic layer.** Intrinsic scores are primary. Seam: a future evaluator that feeds a parse
    through chunk → retrieve → answer and scores end-task quality, reusing existing answer-evals work.
-10. **DB-backed feature graduation.** v0 is a file-based harness under `app/services/parser_eval/`.
-    Seam: promote to the same shape as the other evals — `parser_eval` models/repository/router,
-    ground truth stored like golden sets, results persisted per run, and a `frontend/.../evaluation`
-    view — so parser-eval runs can be triggered and browsed from the UI. Pursued only when that need
-    is real; the v0 package boundary is chosen to make this additive.
+10. **DB-backed + frontend surface (the destination, not optional).** Unlike the other seams, this
+    is a committed goal, sequenced as a later slice: `parser_eval` models/repository/router, ground
+    truth persisted (golden-set style), results stored per run, and a `frontend/.../evaluation` view
+    to trigger and browse runs. The v0 core (scoring loop + data model) is shaped so these layers
+    wrap it additively. The only open question is *which slice* introduces the UI (see Open
+    Questions), not *whether*.
 
-## Relationship to existing eval code
+## Relationship to existing code
 
-The two existing evals are DB-backed, full-stack features, and both live under `app/services/`:
+**This is a new, first-class, frontend-surfaced feature — not an extension of anything that exists.**
 
-- **Answer / retrieval eval** — `app/services/eval_service.py` + `eval_run` models/repository/router
-  + golden sets + `frontend/src/components/evaluation/`.
-- **Extraction eval** — the `app/services/extraction_eval/` package (`engine.py`, `service.py`,
-  `field_matchers.py`, `line_item_matcher.py`) + models/repository/router.
+- The `tests/cdm/eval/` invariant/snapshot/cost artifacts are **early test scaffolding from the
+  parse feature's first iterations**. They are *not* the foundation for this work and are not being
+  extended, refactored, or depended on. Parser eval is greenfield.
+- Its **peers** are the other two evals, and it is modeled after them as a sibling feature under
+  `app/services/`:
+  - **Answer / retrieval eval** — `app/services/eval_service.py` + `eval_run`
+    models/repository/router + golden sets + `frontend/src/components/evaluation/`.
+  - **Extraction eval** — `app/services/extraction_eval/` package + models/repository/router + UI.
+- **Parser eval lives at `app/services/parser_eval/`**, mirroring `app/services/extraction_eval/`,
+  and — like both peers — is **DB-backed and surfaced in the app frontend**. The end state is a
+  feature a user runs and browses in the UI, not a developer-only script.
 
-**Parser eval is co-located with them: `app/services/parser_eval/`, mirroring
-`app/services/extraction_eval/`.** This is the requested consistency point — parser eval sits beside
-the other evals, not under `app/cdm/`.
-
-One deliberate difference for v0: the existing evals persist ground truth and results in the
-database. Parser eval **starts as a lightweight, file-based harness** (benchmark corpus + truth
-artifacts on disk, results to `results.json`) per the "start simple" goal. Graduating to the
-DB-backed shape (models, repository, router, frontend) is **seam #10 below**, matching how the other
-evals are built — pursued only when the app needs to trigger and browse parser-eval runs from the UI.
-
-This harness also complements the existing `tests/cdm/eval/` invariant + snapshot + cost tests
-(structural + change + cost layers), which stay as-is; parser eval adds the missing
-**quality-vs-ground-truth** and **cross-parser comparison** layers.
+**Phasing "start simple" against "it's a real feature":** the destination is the full DB-backed,
+frontend-surfaced feature. We still build it in thin slices, starting with the smallest correct
+core (the scoring loop + data model) and adding the router/UI in a following slice, rather than
+front-loading a large surface. Exactly where the frontend enters is settled in the implementation
+plan (see Open Questions). The v0 module boundaries above are chosen so the DB/router/UI layers wrap
+the core additively.
 
 ## Success criteria for v0
 
@@ -208,8 +242,14 @@ This harness also complements the existing `tests/cdm/eval/` invariant + snapsho
 
 ## Open questions (resolve in planning)
 
+- **Which slice introduces the frontend.** Options: (a) backend scoring core + data model first,
+  UI in the immediately-following slice; or (b) a thin end-to-end vertical slice (one scorer wired
+  through DB + a minimal UI view) from the start. Determines whether early ground truth is authored
+  as files or through the UI.
 - Exact edit-distance vs. token-F1 choice and normalization rules for the text scorer.
 - Where cost/latency come from per adapter (job metadata exists for LlamaParse; local parsers need a
   timer and `$0`).
-- Whether `pdfplumber` is added as a new `ParserKind` + adapter now, or the corpus starts with
-  existing adapters and pdfplumber lands with the table scorer.
+
+_Out of scope for this feature (noted to prevent scope creep): implementing a `pdfplumber` adapter.
+pdfplumber is a tool inside the existing `custom_pipeline` and was only ever an illustrative example;
+the corpus compares whatever adapters already exist._

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -42,9 +42,9 @@ These are deferred out of the *first* slice, not out of the feature:
 - No caching layer / capture-score split. First slice runs parsing and scoring inline.
 - Implementing a `pdfplumber` adapter — pdfplumber belongs to the existing `custom_pipeline`.
 
-**Frontend note:** the feature *is* surfaced in the app UI; whether the UI lands in the first slice
-or the second is the lead Open Question below. The "printed table + `results.json`" form is the
-minimal developer-facing output of the scoring core, which the UI later reads — not the end state.
+**Frontend note:** the UI *is* in the first slice — a minimal view to author a case + one truth
+dimension, run, and read the comparison table. It is intentionally thin (one scorer, no profiles, no
+history browsing); richness follows through seam #10.
 
 ## Mental model
 
@@ -71,45 +71,40 @@ Result:                score in [0,1] for (case, parser, target), plus cost + la
 - **The result key is `(doc, parser, dimension)`** — a flat row, from day one. Many scorers per doc
   produces a vector of these rows, which is also how baselines and regression are keyed.
 
-## v0 design — the minimal loop
+## First slice — thin vertical slice (end-to-end)
 
-### Corpus layout
+The first slice is **one scorer wired all the way through**: DB-backed data model → scoring service
+→ router → a minimal frontend view. It proves the full stack early. The user flow it delivers:
 
-A tiny anchor set of ~5 hand-picked stress documents (e.g. one prose, one table-heavy, one
-multi-column, one scanned, one form). Grow by adding real failures, not synthetic breadth.
+> Create a case (upload a source document) → attach **one** dimension's ground truth (the `text`
+> reference) in the UI → pick parsers → run → see a persisted per-parser score table.
 
-```
-backend/app/services/parser_eval/benchmark/
-  <case_name>/
-    source.<ext>          # the document
-    case.yaml             # manifest: targets + which parsers apply
-    truth/                # dimension-typed ground-truth artifacts
-      text.txt            #   clean reference text  (text dimension)
-      p2.html             #   gold table            (table dimension)
-```
+Deliberately one scorer (`text`), one dimension of ground truth authored via UI, no profiles, no
+caching. Everything else grows through the seams.
 
-`case.yaml` — a doc may attach multiple targets; each names its own dimension + `expected`, and a
-dimension is asserted **only** if it appears here:
+### Data model (lean, mirrors `eval_run` / `extraction_eval`)
 
-```yaml
-name: acme_invoice
-doc_type: invoice
-parsers: [docling, llamaparse, custom_pipeline]   # omit/[] = all registered parsers
-targets:
-  - dimension: text
-    expected: truth/text.txt
-  - dimension: table
-    expected: truth/p2.html         # table is asserted; reading_order/roles are NOT for this doc
-```
+Ground truth and results live in the **database**, not files. Sketch (finalized in the plan):
+
+| Entity | Purpose | Key fields |
+|---|---|---|
+| `ParserEvalCase` | a benchmark document | `id`, `name`, `doc_type`, source document ref, `created_at` |
+| `ParserEvalTarget` | one asserted dimension + its truth for a case | `case_id`, `dimension`, `expected` (payload; for `text` = reference string) |
+| `ParserEvalRun` | one execution over case(s) × parsers | `id`, `status`, selected parsers, `created_at` |
+| `ParserEvalResult` | one score cell | `run_id`, `case_id`, `parser`, `dimension`, `score`, `details` (json), `cost`, `latency_ms` — **unique on `(run_id, case_id, parser, dimension)`** |
+
+A **target existing is what "asserts" a dimension** — the result key `(run, case, parser, dimension)`
+is the flat row the mental model calls for. Aim for a tiny anchor set (~5 stress docs: prose,
+table-heavy, multi-column, scanned, form); grow by adding real failures, not synthetic breadth.
 
 ### Ground truth model (why it's per-dimension, not one shared object)
 
-A document containing multiple targets is the intended shape, but each target owns its ground truth:
+A case with multiple targets is the intended shape, but each target owns its ground truth:
 
-- **Per-dimension `expected`.** The `text` target reads `truth/text.txt`; the `table` target reads
-  `truth/p2.html`. No scorer reads a shared "expected document."
-- **Asserted-or-not is explicit.** A scorer runs for a doc **only if that dimension is a target**. A
-  missing dimension means "not evaluated here" — never a silent score of 0. This prevents
+- **Per-dimension `expected`.** The `text` target stores a reference string; a future `table` target
+  stores gold-table HTML. No scorer reads a shared "expected document."
+- **Asserted-or-not is explicit.** A scorer runs for a case **only if a target for that dimension
+  exists**. A missing dimension means "not evaluated here" — never a silent score of 0. This prevents
   false-zeros and keeps authoring incremental (add a target when you're ready to label it).
 - **Prefer content-oriented truth.** Clean text, gold-table HTML — truth that does *not* assume a
   block structure. Structural `expected_blocks`/`expected_page` is reserved for dimensions that are
@@ -117,20 +112,20 @@ A document containing multiple targets is the intended shape, but each target ow
   block id** — because parsers legitimately segment blocks differently, and a fixed `expected_blocks`
   would unfairly penalize a parser whose segmentation differs but is correct.
 
-### The run
+### The scoring service (backend core)
 
 ```
-for case in load_cases(benchmark_dir):
-    for parser in applicable_parsers(case):
-        run = capture(parser, case.doc)          # -> { cdm, cost, latency }
-        for target in case.targets:
-            expected = load_truth(target)         # dimension-typed loader
-            score, details = SCORERS[target.dimension](run.cdm, expected)
-            results.append(Result(case, parser, target, score, run.cost, run.latency, details))
-report(results)                                   # printed table + results.json
+run = create_run(case_ids, parsers)              # persisted, status=running
+for case in cases(run):
+    for parser in applicable_parsers(case, run):
+        cdm, cost, latency = capture(parser, case.source)     # adapter.adapt(...), timed
+        for target in case.targets:                            # only asserted dimensions
+            score, details = SCORERS[target.dimension](cdm, target.expected)
+            save_result(run, case, parser, target.dimension, score, details, cost, latency)
+finish_run(run)                                   # status=complete
 ```
 
-Printed output shape:
+What the UI shows (a comparison table keyed by parser, one row group per case × dimension):
 
 ```
 acme_invoice · text
@@ -139,14 +134,18 @@ acme_invoice · text
   llamaparse       0.99   (cloud, 3.2s,   $0.010)
 ```
 
-### First scorer: **text faithfulness** (chosen for v0)
+Reuse existing evaluation UI primitives where they fit (`ComparisonTable`, `ScorePill`,
+`MetricCard`) rather than building new ones.
 
-Rationale for picking text over table first: clean reference text is the **cheapest ground truth
-to author**, so it proves the entire loop (corpus → capture → scorer → report) end-to-end with the
-least up-front labeling, before we take on the harder table metric. Table structure is scorer #2,
-added purely through the scorer-registry seam — no harness change.
+### The one scorer: **text faithfulness** (chosen for the first slice)
 
-- **Ground truth:** `truth/text.txt` — the known-correct readable text of the document.
+Rationale for text over table first: a clean reference string is the **cheapest ground truth to
+author** (paste/type it in the UI), so it proves the full vertical (upload → author truth → run →
+persisted score) with the least labeling before we take on the harder table metric. Table structure
+is scorer #2, added purely through the scorer-registry seam — no service change.
+
+- **Ground truth:** the known-correct readable text of the document, authored in the UI, stored on
+  the `text` target.
 - **Input from CDM:** `cdm.full_text` (fall back to concatenated block text if absent).
 - **Metric:** normalize both sides (whitespace, casing per config), then report three numbers,
   combined into the `[0,1]` score:
@@ -154,47 +153,51 @@ added purely through the scorer-registry seam — no harness change.
   - **omission rate** — fraction of reference content missing from the parse.
   - **hallucination rate** — fraction of parsed content absent from the reference.
   Omission and hallucination are called out separately because they are the two failure modes that
-  actually hurt downstream RAG; a single blended similarity can hide them. v0 score =
-  `similarity`; omission/hallucination travel in `details` and are printed as sub-columns.
+  actually hurt downstream RAG; a single blended similarity can hide them. Slice-1 score =
+  `similarity`; omission/hallucination travel in `details` and surface as sub-columns.
 
-### Components (v0)
+### Components (first slice) — full-stack, mirroring `extraction_eval`
 
-| Component | v0 form | File (proposed) |
+| Layer | Responsibility | File (proposed) |
 |---|---|---|
-| Case loader | parse `case.yaml`, resolve truth paths | `app/services/parser_eval/cases.py` |
-| Capture | call `adapter.adapt(...)`, time it, read cost from `parser_extras`/job metadata | `app/services/parser_eval/capture.py` |
-| Scorer registry | hardcoded `dict[str, Scorer]` | `app/services/parser_eval/scorers/__init__.py` |
+| Models | `ParserEvalCase/Target/Run/Result` | `app/models/parser_eval.py` |
+| Repository | persistence + result upsert keyed `(run, case, parser, dimension)` | `app/repositories/parser_eval_repository.py` |
+| Scorer registry | `dict[dimension → scorer]`, one entry (`text`) | `app/services/parser_eval/scorers/__init__.py` |
 | Text scorer | the faithfulness metric above | `app/services/parser_eval/scorers/text.py` |
-| Reporter | printed table + `results.json` | `app/services/parser_eval/report.py` |
-| Entry point | `python -m app.services.parser_eval.run [--benchmark DIR]` | `app/services/parser_eval/run.py` |
+| Capture | `adapter.adapt(...)`, timed, cost from `parser_extras`/job metadata | `app/services/parser_eval/capture.py` |
+| Engine/service | orchestrate run → capture → score → persist | `app/services/parser_eval/engine.py`, `service.py` |
+| Router | create case/target, trigger run, fetch results | `app/routers/parser_eval.py` |
+| Schemas | request/response DTOs | `app/schemas/parser_eval.py` |
+| Frontend | author case+truth, run, view comparison | `frontend/src/components/evaluation/parser/…` |
 
-(Directory names are proposals; final layout settled in the implementation plan. The point is that
-capture, scoring, and reporting are separate modules from day one, even while wired inline.)
+(Names are proposals; final layout settled in the plan. The point: capture, scoring, and persistence
+are separate modules from day one, so seams wrap them additively.)
 
-## Extension seams (scaffolding — deliberately NOT built in v0)
+## Extension seams (scaffolding — deliberately NOT built in the first slice)
 
-Each seam is written so v0 leaves a clean joint. None are implemented until a second concrete case
-forces them.
+Each seam is written so the first slice leaves a clean joint. None are implemented until a concrete
+case forces them. (The DB + a minimal frontend view are *in* the first slice — see Components — so
+seam #10 is only about the *richer* surface that follows.)
 
-1. **Scorer registry.** v0 is a literal `dict[dimension → scorer]`. Seam: a `register("table", fn)`
-   interface so new dimensions are additive files, never edits to the run loop.
+1. **Scorer registry.** First slice is a literal `dict[dimension → scorer]` with one entry. Seam: a
+   `register("table", fn)` interface so new dimensions are additive files, never edits to the engine.
 2. **Dimension-typed truth loader.** `expected` for `text` is a string, for `table` is HTML, for
    `reading_order` a list. Seam: a per-dimension `load_truth` keyed by dimension, so no single "gold
    format" is ever forced across dimensions.
 3. **Parser = adapter + config.** E.g. the `custom_pipeline` adapter run under different tool configs
    (pdfplumber-based or otherwise). Seam: an evaluator identity of `(adapter, config)` so the *same*
-   adapter under different configs is a distinct comparable row. v0 uses default config and
+   adapter under different configs is a distinct comparable row. First slice uses default config and
    identifies parsers by `ParserKind`.
-4. **Capture/score split.** v0 runs `adapt()` inline. Seam: a `CachedRun {cdm, cost, latency}`
-   boundary persisted to disk, so scoring decouples from expensive parsing once cloud cost/latency
+4. **Capture/score split.** First slice runs `adapt()` inline. Seam: a `CachedRun {cdm, cost, latency}`
+   boundary persisted, so scoring decouples from expensive parsing once cloud cost/latency
    make re-parsing-per-metric-tweak wasteful. Aligns with existing raw-payload persistence.
-5. **Profiles & selection.** v0 prints raw per-dimension scores. Seam: a `Profile { weights, floors,
+5. **Profiles & selection.** First slice reports raw per-dimension scores. Seam: a `Profile { weights, floors,
    tie_tolerance }` applied *at report time* (so one scoring pass serves many projects) that
    produces a weighted total, marks who clears the floor, and applies the cheapest/fastest-wins
    tie-break — directly implementing the pdfplumber-vs-docling decision. Kicks in at >1 dimension.
    Profiles may later map to real app Projects; not now.
 6. **Baseline / regression.** Seam: freeze a scorecard as committed baseline (mirroring the existing
-   `UPDATE_SNAPSHOTS` pattern) and fail when a parser drops >Δ below its own baseline. No CI in v0.
+   `UPDATE_SNAPSHOTS` pattern) and fail when a parser drops >Δ below its own baseline. No CI initially.
 7. **Truth bootstrapping.** Authoring `expected` from scratch is the main cost. Seam: generate a
    draft `expected` from a trusted parser run, then hand-correct — record-then-correct, like
    snapshots.
@@ -203,12 +206,10 @@ forces them.
    small hand-labeled anchor set so its error rate is known before it is trusted. Never the backbone.
 9. **Extrinsic layer.** Intrinsic scores are primary. Seam: a future evaluator that feeds a parse
    through chunk → retrieve → answer and scores end-task quality, reusing existing answer-evals work.
-10. **DB-backed + frontend surface (the destination, not optional).** Unlike the other seams, this
-    is a committed goal, sequenced as a later slice: `parser_eval` models/repository/router, ground
-    truth persisted (golden-set style), results stored per run, and a `frontend/.../evaluation` view
-    to trigger and browse runs. The v0 core (scoring loop + data model) is shaped so these layers
-    wrap it additively. The only open question is *which slice* introduces the UI (see Open
-    Questions), not *whether*.
+10. **Richer frontend + operational surface.** The *minimal* DB + UI (author a case, one truth
+    dimension, run, view a comparison table) is in the first slice. This seam is the surface that
+    follows: run history browsing, multi-case corpus management, a golden-set-style truth library,
+    profile/floor configuration UI, and a regression/baseline dashboard. Built as those needs land.
 
 ## Relationship to existing code
 
@@ -227,25 +228,23 @@ forces them.
   feature a user runs and browses in the UI, not a developer-only script.
 
 **Phasing "start simple" against "it's a real feature":** the destination is the full DB-backed,
-frontend-surfaced feature. We still build it in thin slices, starting with the smallest correct
-core (the scoring loop + data model) and adding the router/UI in a following slice, rather than
-front-loading a large surface. Exactly where the frontend enters is settled in the implementation
-plan (see Open Questions). The v0 module boundaries above are chosen so the DB/router/UI layers wrap
-the core additively.
+frontend-surfaced feature. The **first slice is a thin end-to-end vertical** — one scorer (`text`)
+wired through models → repository → engine → router → a minimal UI view — proving the whole stack
+before breadth. Additional dimensions, profiles, caching, and the richer surface follow through the
+seams. Truth is authored **in the UI** from the first slice (no file corpus).
 
-## Success criteria for v0
+## Success criteria for the first slice
 
-- Running the entry point over the anchor corpus prints a per-case, per-parser table of text
-  faithfulness scores with cost + latency, and writes `results.json`.
-- Adding the table scorer later requires only: a new scorer file + registry line + a `truth/*.html`
-  artifact and a `case.yaml` target — no change to the run loop, reporter, or case loader.
+- In the app UI: create a case (upload a document), author the `text` ground truth, select ≥2
+  parsers, run, and see a persisted per-parser score table with cost + latency.
+- Scores, cost, and latency persist as `ParserEvalResult` rows keyed `(run, case, parser, dimension)`
+  and reload after refresh.
+- A case with no `text` target simply isn't scored on `text` — no false-zero. (Asserted-or-not works.)
+- Adding the table scorer later requires only: a new scorer file + one registry line + a `table`
+  target type — no change to the engine, router, or result model.
 
 ## Open questions (resolve in planning)
 
-- **Which slice introduces the frontend.** Options: (a) backend scoring core + data model first,
-  UI in the immediately-following slice; or (b) a thin end-to-end vertical slice (one scorer wired
-  through DB + a minimal UI view) from the start. Determines whether early ground truth is authored
-  as files or through the UI.
 - Exact edit-distance vs. token-F1 choice and normalization rules for the text scorer.
 - Where cost/latency come from per adapter (job metadata exists for LlamaParse; local parsers need a
   timer and `$0`).

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -293,6 +293,31 @@ seams. Truth is authored **in the UI** from the first slice (no file corpus).
 - Adding the table scorer later requires only: a new scorer file + one registry line + a `table`
   target type — no change to the engine, router, or result model.
 
+## Vision alignment & known deviations (revisit before hardening)
+
+The product's larger purpose is to **evaluate the options available at each stage of a RAG pipeline** —
+hand-rolled/custom pipelines vs. providers (LlamaParse) vs. OSS (docling) — using the CDM
+(`ParsedDocument`) as the common *projection* of each tool's output that makes them comparable. Parser
+eval is the first stage. The first slice takes deliberate shortcuts that are **not** the target shape:
+
+1. **`ParserEvalCase` is a stand-in, not the target entity.** It re-wraps `project_id +
+   source_document_id` (plus `name`/`doc_type`/`source_filename`) in a parallel table. In the product
+   vision, `Document` and `ParsedDocument` are the first-class, load-bearing primitives — and
+   "Document" means *the source_document that belongs to this project*. Eval + ground truth should
+   ultimately bind to that first-class project-scoped `Document`/`ParsedDocument` primitive rather than
+   a parallel case table. (The `documents` table's chunk/index/folder weight is **vestigial** — an
+   artifact of Index being the first pipeline component built; Index has since been refactored onto
+   `ParsedDocument` and those references are slated for cleanup. Do not treat that baggage as the
+   definition of `Document`.) **Plan:** collapse `ParserEvalCase` onto `Document`/`ParsedDocument` once
+   that primitive settles from the Index refactor.
+2. **Raw-text ground truth is a convenience, not canonical.** For `text`, ground truth is authored and
+   scored as raw text (`{"pages": [str]}`) rather than against `ParsedDocument.Page.Block.text`, to
+   feel out the parser flow first. The canonical form follows the primitives later.
+3. **`source_filename` on `ParserEvalCase` is redundant** — a denormalization of
+   `SourceDocument.filename`; derive via join when the entity is reworked (or drop it).
+
+These are intentional stepping stones for the first slice; revisit before the feature is hardened.
+
 ## Open questions (resolve in planning)
 
 - Exact edit-distance vs. token-F1 choice and normalization rules for the text scorer.

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -151,12 +151,23 @@ additive via the scorer registry (seam #1) and dimension-typed loader (seam #2).
 run = create_run(case_ids, parsers)              # persisted, status=running
 for case in cases(run):
     for parser in applicable_parsers(case, run):
-        cdm, cost, latency = capture(parser, case.source)     # adapter.adapt(...), timed
+        # capture reuses ParsingService.parse_and_persist — NOT adapter.adapt directly.
+        # The runners do file→raw→adapt, and the returned ParseRun already carries
+        # duration_ms + cost + tokens (our cost/latency signal) and same-config reuse.
+        parse_run, cdm = capture(parser, case.source, project_id)
+        cost, latency = parse_run.cost, parse_run.duration_ms
         for target in case.targets:                            # only asserted dimensions
             score, details = SCORERS[target.dimension](cdm, target.expected)
             save_result(run, case, parser, target.dimension, score, details, cost, latency)
 finish_run(run)                                   # status=complete
 ```
+
+> **Capture reuses existing infrastructure.** `capture(parser, source, project_id)` calls
+> `ParsingService.ensure_source_document(...)` then `parse_and_persist(config={"parser": kind}, …)`,
+> which returns `(ParseRunCDM, ParsedDocumentCDM)`. Cost/latency come from the `ParseRun`
+> (`duration_ms`, `cost`, `input_tokens`, `output_tokens`) — no bespoke timing/metrics needed. Local
+> parsers (docling, custom_pipeline, simple) need no cloud client; cloud parsers reuse the existing
+> per-parser clients from `get_parsing_service`.
 
 What the UI shows (a comparison table keyed by parser, one row group per case × dimension):
 
@@ -203,7 +214,7 @@ is scorer #2, added purely through the scorer-registry seam — no service chang
 | Repository | persistence + result upsert keyed `(run, case, parser, dimension)` | `app/repositories/parser_eval_repository.py` |
 | Scorer registry | `dict[dimension → scorer]`, one entry (`text`) | `app/services/parser_eval/scorers/__init__.py` |
 | Text scorer | the faithfulness metric above | `app/services/parser_eval/scorers/text.py` |
-| Capture | `adapter.adapt(...)`, timed, cost from `parser_extras`/job metadata | `app/services/parser_eval/capture.py` |
+| Capture | wraps `ParsingService.parse_and_persist` per parser; cost/latency from `ParseRun` | `app/services/parser_eval/capture.py` |
 | Engine/service | orchestrate run → capture → score → persist | `app/services/parser_eval/engine.py`, `service.py` |
 | Router | create case/target, trigger run, fetch results | `app/routers/parser_eval.py` |
 | Schemas | request/response DTOs | `app/schemas/parser_eval.py` |

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -89,7 +89,7 @@ Ground truth and results live in the **database**, not files. Sketch (finalized 
 | Entity | Purpose | Key fields |
 |---|---|---|
 | `ParserEvalCase` | a benchmark document | `id`, `name`, `doc_type`, source document ref, `created_at` |
-| `ParserEvalTarget` | one asserted dimension + its truth for a case | `case_id`, `dimension`, `expected` (payload; for `text` = reference string) |
+| `ParserEvalTarget` | one asserted dimension + its truth for a case | `case_id`, `dimension`, `expected` (dimension-typed JSON payload; for `text` = `{ pages: [str] }`) |
 | `ParserEvalRun` | one execution over case(s) × parsers | `id`, `status`, selected parsers, `created_at` |
 | `ParserEvalResult` | one score cell | `run_id`, `case_id`, `parser`, `dimension`, `score`, `details` (json), `cost`, `latency_ms` — **unique on `(run_id, case_id, parser, dimension)`** |
 
@@ -101,8 +101,8 @@ table-heavy, multi-column, scanned, form); grow by adding real failures, not syn
 
 A case with multiple targets is the intended shape, but each target owns its ground truth:
 
-- **Per-dimension `expected`.** The `text` target stores a reference string; a future `table` target
-  stores gold-table HTML. No scorer reads a shared "expected document."
+- **Per-dimension `expected`.** The `text` target stores page-segmented reference text; a future
+  `table` target stores gold-table HTML. No scorer reads a shared "expected document."
 - **Asserted-or-not is explicit.** A scorer runs for a case **only if a target for that dimension
   exists**. A missing dimension means "not evaluated here" — never a silent score of 0. This prevents
   false-zeros and keeps authoring incremental (add a target when you're ready to label it).
@@ -111,6 +111,39 @@ A case with multiple targets is the intended shape, but each target owns its gro
   inherently positional (reading order, role labels), and even then scorers align by **content, not
   block id** — because parsers legitimately segment blocks differently, and a fixed `expected_blocks`
   would unfairly penalize a parser whose segmentation differs but is correct.
+
+### Ground truth formats per dimension
+
+**The user never authors a `ParsedDocument`.** No block ids, `parent_id`, `reading_order` integers,
+`bbox`, or page `block_ids` — those are per-parser artifacts and authoring them would bake in one
+parser's segmentation. Instead `expected` is the **minimal parser-agnostic projection** of a single
+dimension, and every scorer locates what to compare by **matching text content, not index/id**
+(content-anchored alignment) — this is what lets one `expected` fairly score parsers that segment
+differently.
+
+CDM vocabulary is reused *selectively*:
+- **Value vocabulary reused** where it is intrinsic and parser-agnostic: `BlockRole` names, the
+  `Table`/`Cell` shape, and `page` (a PDF's page N is physically page N for every parser).
+- **Structural/identity vocabulary never authored**: block ids, `parent_id`, `reading_order`, `bbox`.
+
+`ParserEvalTarget.expected` is a **JSON payload whose shape is discriminated by `dimension`** (this
+is seam #2). Each dimension also gets its own authoring widget:
+
+| Dimension | User enters | `expected` payload | CDM vocab | Scorer compares vs | Authoring widget |
+|---|---|---|---|---|---|
+| **text** | correct readable text, per page | `{ pages: [str] }` | `page` only | per-page slices of `cdm.full_text` (via `Page.start_char/end_char`) | per-page textareas, pre-fillable from a trusted parser |
+| **table** | correct table as HTML `<table>` | `{ locator: {page}, html: str }` | `Table`/`Cell` | matching `Block.table`, aligned by page+content | HTML paste + rendered preview |
+| **reading_order** | ordered short anchor snippets | `{ anchors: [str] }` | none | positions of anchors located in the parser's block sequence | drag-to-order snippet list |
+| **roles** | `snippet → role` assertions | `{ assertions: [{snippet, role, depth?}] }` | `BlockRole` | role of the block whose text matches each snippet | snippet + role dropdown |
+| **spatial** (deferred) | gold boxes per region | `{ regions: [{bbox, label}] }` | `BBox` | region boxes, IoU after content match | box-drawing tool |
+
+**OCR is a *condition*, not a dimension.** A scanned document is evaluated on the same dimensions
+(chiefly `text`, sometimes `table`); the `expected` format is unchanged. The case is **tagged**
+`scanned`/`ocr` so results can be *sliced* ("text faithfulness on scanned docs") — that is where OCR
+surfaces, as a filter over the same scores, not a new truth format.
+
+First slice implements the **`text` payload + per-page textarea authoring only**; every other row is
+additive via the scorer registry (seam #1) and dimension-typed loader (seam #2).
 
 ### The scoring service (backend core)
 
@@ -144,17 +177,23 @@ author** (paste/type it in the UI), so it proves the full vertical (upload → a
 persisted score) with the least labeling before we take on the harder table metric. Table structure
 is scorer #2, added purely through the scorer-registry seam — no service change.
 
-- **Ground truth:** the known-correct readable text of the document, authored in the UI, stored on
-  the `text` target.
-- **Input from CDM:** `cdm.full_text` (fall back to concatenated block text if absent).
-- **Metric:** normalize both sides (whitespace, casing per config), then report three numbers,
-  combined into the `[0,1]` score:
+- **Ground truth:** `{ pages: [str] }` — the known-correct readable text **per page**, authored in
+  the UI (one textarea per page), pre-fillable from a trusted parser's per-page text then corrected.
+- **Input from CDM:** per-page text via `Page.start_char/end_char` slices of `cdm.full_text` (fall
+  back to concatenated per-page block text if offsets absent).
+- **Metric:** compare **page-aligned** — score each page's parsed text vs. its reference, then
+  aggregate to a document score (mean, or content-length-weighted). Per page, normalize both sides
+  (whitespace, casing per config) and compute three numbers:
   - **similarity** — normalized edit-distance similarity (or token-level F1) of parsed vs. reference.
   - **omission rate** — fraction of reference content missing from the parse.
   - **hallucination rate** — fraction of parsed content absent from the reference.
   Omission and hallucination are called out separately because they are the two failure modes that
   actually hurt downstream RAG; a single blended similarity can hide them. Slice-1 score =
-  `similarity`; omission/hallucination travel in `details` and surface as sub-columns.
+  `similarity`; per-page scores + omission/hallucination travel in `details` (enabling per-page
+  attribution) and surface as sub-columns.
+- **Page-count mismatch:** if a parser yields a different page count than the reference, unmatched
+  reference pages count as fully omitted and unmatched parser pages as fully hallucinated — the
+  mismatch is penalized, not silently ignored.
 
 ### Components (first slice) — full-stack, mirroring `extraction_eval`
 

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -65,7 +65,7 @@ A tiny anchor set of ~5 hand-picked stress documents (e.g. one prose, one table-
 multi-column, one scanned, one form). Grow by adding real failures, not synthetic breadth.
 
 ```
-backend/app/cdm/eval/benchmark/
+backend/app/services/parser_eval/benchmark/
   <case_name>/
     source.<ext>          # the document
     case.yaml             # manifest: targets + which parsers apply
@@ -129,12 +129,12 @@ added purely through the scorer-registry seam — no harness change.
 
 | Component | v0 form | File (proposed) |
 |---|---|---|
-| Case loader | parse `case.yaml`, resolve truth paths | `app/cdm/eval/harness/cases.py` |
-| Capture | call `adapter.adapt(...)`, time it, read cost from `parser_extras`/job metadata | `app/cdm/eval/harness/capture.py` |
-| Scorer registry | hardcoded `dict[str, Scorer]` | `app/cdm/eval/harness/scorers/__init__.py` |
-| Text scorer | the faithfulness metric above | `app/cdm/eval/harness/scorers/text.py` |
-| Reporter | printed table + `results.json` | `app/cdm/eval/harness/report.py` |
-| Entry point | `python -m app.cdm.eval.harness.run [--benchmark DIR]` | `app/cdm/eval/harness/run.py` |
+| Case loader | parse `case.yaml`, resolve truth paths | `app/services/parser_eval/cases.py` |
+| Capture | call `adapter.adapt(...)`, time it, read cost from `parser_extras`/job metadata | `app/services/parser_eval/capture.py` |
+| Scorer registry | hardcoded `dict[str, Scorer]` | `app/services/parser_eval/scorers/__init__.py` |
+| Text scorer | the faithfulness metric above | `app/services/parser_eval/scorers/text.py` |
+| Reporter | printed table + `results.json` | `app/services/parser_eval/report.py` |
+| Entry point | `python -m app.services.parser_eval.run [--benchmark DIR]` | `app/services/parser_eval/run.py` |
 
 (Directory names are proposals; final layout settled in the implementation plan. The point is that
 capture, scoring, and reporting are separate modules from day one, even while wired inline.)
@@ -170,14 +170,34 @@ forces them.
    small hand-labeled anchor set so its error rate is known before it is trusted. Never the backbone.
 9. **Extrinsic layer.** Intrinsic scores are primary. Seam: a future evaluator that feeds a parse
    through chunk → retrieve → answer and scores end-task quality, reusing existing answer-evals work.
+10. **DB-backed feature graduation.** v0 is a file-based harness under `app/services/parser_eval/`.
+    Seam: promote to the same shape as the other evals — `parser_eval` models/repository/router,
+    ground truth stored like golden sets, results persisted per run, and a `frontend/.../evaluation`
+    view — so parser-eval runs can be triggered and browsed from the UI. Pursued only when that need
+    is real; the v0 package boundary is chosen to make this additive.
 
 ## Relationship to existing eval code
 
-- Keeps `tests/cdm/eval/` invariant + snapshot + cost tests as-is (structural + change + cost
-  layers). This harness adds the missing **quality-vs-ground-truth** and **cross-parser comparison**
-  layers.
-- Lives under `app/cdm/eval/` (library, reusable) rather than test-only, because capture is a
-  deliberate script that may spend money, and the scorers are reusable logic.
+The two existing evals are DB-backed, full-stack features, and both live under `app/services/`:
+
+- **Answer / retrieval eval** — `app/services/eval_service.py` + `eval_run` models/repository/router
+  + golden sets + `frontend/src/components/evaluation/`.
+- **Extraction eval** — the `app/services/extraction_eval/` package (`engine.py`, `service.py`,
+  `field_matchers.py`, `line_item_matcher.py`) + models/repository/router.
+
+**Parser eval is co-located with them: `app/services/parser_eval/`, mirroring
+`app/services/extraction_eval/`.** This is the requested consistency point — parser eval sits beside
+the other evals, not under `app/cdm/`.
+
+One deliberate difference for v0: the existing evals persist ground truth and results in the
+database. Parser eval **starts as a lightweight, file-based harness** (benchmark corpus + truth
+artifacts on disk, results to `results.json`) per the "start simple" goal. Graduating to the
+DB-backed shape (models, repository, router, frontend) is **seam #10 below**, matching how the other
+evals are built — pursued only when the app needs to trigger and browse parser-eval runs from the UI.
+
+This harness also complements the existing `tests/cdm/eval/` invariant + snapshot + cost tests
+(structural + change + cost layers), which stay as-is; parser eval adds the missing
+**quality-vs-ground-truth** and **cross-parser comparison** layers.
 
 ## Success criteria for v0
 

--- a/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
+++ b/docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md
@@ -1,0 +1,195 @@
+# Parser Evaluation Harness — Design
+
+**Date:** 2026-07-03
+**Status:** Draft for review
+**Author:** brainstorming session (asanyaga)
+
+## Problem
+
+We have multiple CDM parser adapters — `simple`, `docling`, `llamaparse`, `landing_ai`,
+`custom_pipeline` (and want to add e.g. `pdfplumber`). Each turns a source document into a
+`ParsedDocument` (CDM). Today we can tell whether an adapter's output is *structurally legal*
+(`test_invariants`), whether it *changed* (`test_snapshot`), and what it *cost* (`metrics.jsonl`).
+
+We cannot answer the question that actually drives tool choice:
+
+> "How **good** is this parser on this document, and which parser should I pick?"
+
+We want to establish **"good enough" baselines** and **compare tools across dimensions**
+(accuracy, speed, cost). Motivating example: if `pdfplumber` and `docling` both score ~0.95 on
+table structure for a document, pick `pdfplumber` — it is CPU-only, fast, and free.
+
+## Goals
+
+- Score a parser's CDM output against ground truth on a named **quality dimension**, producing a
+  number in `[0, 1]`.
+- Compare multiple parsers on the **same** document + dimension, alongside cost and latency.
+- Support **different priorities per use case** — one project cares about precise tables, another
+  about content faithfulness — without re-running parsers.
+- Start **as simple as possible**; grow abstractions only when a second concrete case demands them.
+- Leave clean seams so extension is additive, not a rewrite.
+
+## Non-Goals (for v0)
+
+- No CI integration, no regression gating. (Named as a seam; deferred.)
+- No extrinsic / end-task evaluation (retrieval or answer quality). **Intrinsic first** — score the
+  CDM directly against ground truth. Extrinsic is a future layer.
+- No profile/weighting engine, no automatic "winner" selection. v0 prints raw per-dimension scores.
+- No caching layer / capture-score split. v0 runs parsing and scoring inline.
+- No UI. Output is a printed table + a JSON/JSONL artifact.
+
+## Mental model
+
+Two tuples describe the entire system:
+
+```
+Case (ground truth):   { doc, target: dimension, expected }
+Evaluator:             { parser (+ config), scorer }
+Result:                score in [0,1] for (case, parser, target), plus cost + latency
+```
+
+- A **dimension** is one independently-failing aspect of parse quality: text faithfulness, table
+  structure, reading order, role/structure accuracy, spatial (bbox). Different documents stress
+  different dimensions; a parser is never one number.
+- A **scorer** is a small, independently testable unit: `score(cdm, expected) -> (float, details)`.
+- **Ground truth is per-dimension**, not per-document. A case carries `expected` only for the
+  dimensions it tests. A table-stress doc ships a gold table; a prose doc ships clean text. Ground
+  truth cost scales with *what you test*, not with document complexity — this is what makes the
+  corpus sustainable.
+
+## v0 design — the minimal loop
+
+### Corpus layout
+
+A tiny anchor set of ~5 hand-picked stress documents (e.g. one prose, one table-heavy, one
+multi-column, one scanned, one form). Grow by adding real failures, not synthetic breadth.
+
+```
+backend/app/cdm/eval/benchmark/
+  <case_name>/
+    source.<ext>          # the document
+    case.yaml             # manifest: targets + which parsers apply
+    truth/                # dimension-typed ground-truth artifacts
+      text.txt            #   clean reference text  (text dimension)
+      p2.html             #   gold table            (table dimension)
+```
+
+`case.yaml`:
+
+```yaml
+name: acme_invoice
+doc_type: invoice
+parsers: [pdfplumber, docling, llamaparse]   # omit/[] = all registered parsers
+targets:
+  - dimension: text
+    expected: truth/text.txt
+```
+
+### The run
+
+```
+for case in load_cases(benchmark_dir):
+    for parser in applicable_parsers(case):
+        run = capture(parser, case.doc)          # -> { cdm, cost, latency }
+        for target in case.targets:
+            expected = load_truth(target)         # dimension-typed loader
+            score, details = SCORERS[target.dimension](run.cdm, expected)
+            results.append(Result(case, parser, target, score, run.cost, run.latency, details))
+report(results)                                   # printed table + results.json
+```
+
+Printed output shape:
+
+```
+acme_invoice · text
+  pdfplumber   0.98   (cpu,   120ms,  $0)
+  docling      0.97   (cpu,   890ms,  $0)
+  llamaparse   0.99   (cloud, 3.2s,   $0.010)
+```
+
+### First scorer: **text faithfulness** (chosen for v0)
+
+Rationale for picking text over table first: clean reference text is the **cheapest ground truth
+to author**, so it proves the entire loop (corpus → capture → scorer → report) end-to-end with the
+least up-front labeling, before we take on the harder table metric. Table structure is scorer #2,
+added purely through the scorer-registry seam — no harness change.
+
+- **Ground truth:** `truth/text.txt` — the known-correct readable text of the document.
+- **Input from CDM:** `cdm.full_text` (fall back to concatenated block text if absent).
+- **Metric:** normalize both sides (whitespace, casing per config), then report three numbers,
+  combined into the `[0,1]` score:
+  - **similarity** — normalized edit-distance similarity (or token-level F1) of parsed vs. reference.
+  - **omission rate** — fraction of reference content missing from the parse.
+  - **hallucination rate** — fraction of parsed content absent from the reference.
+  Omission and hallucination are called out separately because they are the two failure modes that
+  actually hurt downstream RAG; a single blended similarity can hide them. v0 score =
+  `similarity`; omission/hallucination travel in `details` and are printed as sub-columns.
+
+### Components (v0)
+
+| Component | v0 form | File (proposed) |
+|---|---|---|
+| Case loader | parse `case.yaml`, resolve truth paths | `app/cdm/eval/harness/cases.py` |
+| Capture | call `adapter.adapt(...)`, time it, read cost from `parser_extras`/job metadata | `app/cdm/eval/harness/capture.py` |
+| Scorer registry | hardcoded `dict[str, Scorer]` | `app/cdm/eval/harness/scorers/__init__.py` |
+| Text scorer | the faithfulness metric above | `app/cdm/eval/harness/scorers/text.py` |
+| Reporter | printed table + `results.json` | `app/cdm/eval/harness/report.py` |
+| Entry point | `python -m app.cdm.eval.harness.run [--benchmark DIR]` | `app/cdm/eval/harness/run.py` |
+
+(Directory names are proposals; final layout settled in the implementation plan. The point is that
+capture, scoring, and reporting are separate modules from day one, even while wired inline.)
+
+## Extension seams (scaffolding — deliberately NOT built in v0)
+
+Each seam is written so v0 leaves a clean joint. None are implemented until a second concrete case
+forces them.
+
+1. **Scorer registry.** v0 is a literal `dict[dimension → scorer]`. Seam: a `register("table", fn)`
+   interface so new dimensions are additive files, never edits to the run loop.
+2. **Dimension-typed truth loader.** `expected` for `text` is a string, for `table` is HTML, for
+   `reading_order` a list. Seam: a per-dimension `load_truth` keyed by dimension, so no single "gold
+   format" is ever forced across dimensions.
+3. **Parser = adapter + config.** The `pdfplumber_config` idea. Seam: an evaluator identity of
+   `(adapter, config)` so the *same* adapter under different configs is a distinct comparable row.
+   v0 uses default config and identifies parsers by `ParserKind`.
+4. **Capture/score split.** v0 runs `adapt()` inline. Seam: a `CachedRun {cdm, cost, latency}`
+   boundary persisted to disk, so scoring decouples from expensive parsing once cloud cost/latency
+   make re-parsing-per-metric-tweak wasteful. Aligns with existing raw-payload persistence.
+5. **Profiles & selection.** v0 prints raw per-dimension scores. Seam: a `Profile { weights, floors,
+   tie_tolerance }` applied *at report time* (so one scoring pass serves many projects) that
+   produces a weighted total, marks who clears the floor, and applies the cheapest/fastest-wins
+   tie-break — directly implementing the pdfplumber-vs-docling decision. Kicks in at >1 dimension.
+   Profiles may later map to real app Projects; not now.
+6. **Baseline / regression.** Seam: freeze a scorecard as committed baseline (mirroring the existing
+   `UPDATE_SNAPSHOTS` pattern) and fail when a parser drops >Δ below its own baseline. No CI in v0.
+7. **Truth bootstrapping.** Authoring `expected` from scratch is the main cost. Seam: generate a
+   draft `expected` from a trusted parser run, then hand-correct — record-then-correct, like
+   snapshots.
+8. **LLM-as-judge scorer.** For dimensions with no cheap objective ground truth (e.g. figure
+   captions). Seam: it is just another scorer behind the registry, but must be validated against a
+   small hand-labeled anchor set so its error rate is known before it is trusted. Never the backbone.
+9. **Extrinsic layer.** Intrinsic scores are primary. Seam: a future evaluator that feeds a parse
+   through chunk → retrieve → answer and scores end-task quality, reusing existing answer-evals work.
+
+## Relationship to existing eval code
+
+- Keeps `tests/cdm/eval/` invariant + snapshot + cost tests as-is (structural + change + cost
+  layers). This harness adds the missing **quality-vs-ground-truth** and **cross-parser comparison**
+  layers.
+- Lives under `app/cdm/eval/` (library, reusable) rather than test-only, because capture is a
+  deliberate script that may spend money, and the scorers are reusable logic.
+
+## Success criteria for v0
+
+- Running the entry point over the anchor corpus prints a per-case, per-parser table of text
+  faithfulness scores with cost + latency, and writes `results.json`.
+- Adding the table scorer later requires only: a new scorer file + registry line + a `truth/*.html`
+  artifact and a `case.yaml` target — no change to the run loop, reporter, or case loader.
+
+## Open questions (resolve in planning)
+
+- Exact edit-distance vs. token-F1 choice and normalization rules for the text scorer.
+- Where cost/latency come from per adapter (job metadata exists for LlamaParse; local parsers need a
+  timer and `$0`).
+- Whether `pdfplumber` is added as a new `ParserKind` + adapter now, or the corpus starts with
+  existing adapters and pdfplumber lands with the table scorer.


### PR DESCRIPTION
Implements the backend for the parser-evaluation feature (Plan 1 of 2). Project-scoped API to store benchmark documents with per-dimension ground truth, run a set of parsers over each, score text-faithfulness, and persist comparable per-parser results (score + cost + latency). Modeled on the existing `extraction_eval` feature; tests run on SQLite in-memory.

Closes #141.

## What's included
- **Models + migration** — `ParserEvalCase / Target / Run / Result` (+ enums); results unique on `(run_id, case_id, parser, dimension)`.
- **Scorers** — a registry (the additive seam for future dimensions) + a page-segmented **text-faithfulness** scorer (similarity + omission + hallucination; parser-agnostic, no block-structure dependence).
- **Capture** — wraps `ParsingService.parse_and_persist`; cost/latency come from the `ParseRun`.
- **Engine** — runs each selected case × parser, scores each *asserted* target, persists results; a capture failure records a visible `score=0` (not a missing row).
- **Service + Router** — CRUD + background `execute_run` (runs only the run's selected `case_ids`); project-scoped endpoints under `/api/v1/projects/{project_id}/parser-eval/...`; run parsers validated against `ParserKind` (422 on unknown).

## Design docs
- Spec: `docs/superpowers/specs/2026-07-03-parser-evaluation-harness-design.md`
- Plan: `docs/superpowers/plans/2026-07-03-parser-eval-backend.md`

## Process
Built task-by-task via subagent-driven development: each task implemented TDD, task-reviewed (spec + quality), then a final whole-branch review (all binding invariants verified end-to-end). One review fix applied (parser validation → 422).

## Verification
- All 24 parser-eval tests pass (models, scorers, registry, capture success + failure paths, repository, service, router). Full backend suite green (1 pre-existing unrelated flake in `test_experiment_repository`).

## ⚠️ Required before deploy
- **Apply the migration to Postgres.** It could not be applied/round-trip-verified locally (local DB volume password mismatch). It runs automatically on backend container startup per the Docker flow, but please confirm `alembic upgrade head` (and a `downgrade -1 && upgrade head` round-trip) against a real Postgres — the two `create_type=False` enum DDLs are only exercised there, not by SQLite tests.

## Follow-ups (non-blocking)
- Frontend (Plan 2): authoring UI (case + per-page `text` ground truth) + comparison table.
- Minor: drop unused `source_document_id` param in `capture()`; `upsert_result` TOCTOU (scoped out for slice 1); `score_text` double-normalize (DRY); `datetime.utcnow` deprecation (repo-wide, matches existing models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
