### PR TITLE
Parser eval — back-to-runs action + evaluation nav order

### DIFF
--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -41,9 +41,9 @@ export const navigationItems: readonly NavItem[] = [
     icon: BarChart3,
     activeColor: 'border-l-amber-500',
     children: [
+      { label: 'Parsing', href: '/evaluation/parser' },
       { label: 'Retrieval', href: '/evaluation/retrieval' },
       { label: 'Extraction', href: '/evaluation/extraction' },
-      { label: 'Parsing', href: '/evaluation/parser' },
     ],
   },
   { label: 'Settings', href: '/settings', icon: Settings, activeColor: 'border-l-gray-400' },

--- a/frontend/src/pages/ParserEvalRunDetailPage.tsx
+++ b/frontend/src/pages/ParserEvalRunDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
 import { useProject } from '@/contexts/ProjectContext'
 import { EvalStatusBadge } from '@/components/evaluation/EvalStatusBadge'
 import { ParserComparisonTable } from '@/components/parser-eval/ParserComparisonTable'
@@ -23,11 +24,21 @@ export default function ParserEvalRunDetailPage(): JSX.Element {
     return labels
   }, [cases, sourceDocuments])
 
+  const backToRuns = (
+    <Link
+      to="/evaluation/parser?tab=runs"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" /> Back to runs
+    </Link>
+  )
+
   if (isLoading && !run) return <p className="text-muted-foreground">Loading…</p>
-  if (!run) return <p className="text-muted-foreground">Run not found.</p>
+  if (!run) return <div className="space-y-4">{backToRuns}<p className="text-muted-foreground">Run not found.</p></div>
 
   return (
     <div className="space-y-6">
+      {backToRuns}
       <div className="flex items-center gap-3">
         <h1 className="text-2xl font-bold">{run.name}</h1>
         <EvalStatusBadge status={run.status} />

--- a/frontend/src/pages/ParserEvaluationPage.tsx
+++ b/frontend/src/pages/ParserEvaluationPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useProject } from '@/contexts/ProjectContext'
 import { cn } from '@/lib/utils'
 import { ParserEvalCasesTab } from '@/components/parser-eval/ParserEvalCasesTab'
@@ -8,7 +9,10 @@ type Tab = 'cases' | 'runs'
 
 export default function ParserEvaluationPage(): JSX.Element {
   const { currentProject } = useProject()
-  const [activeTab, setActiveTab] = useState<Tab>('cases')
+  const [searchParams] = useSearchParams()
+  const [activeTab, setActiveTab] = useState<Tab>(
+    searchParams.get('tab') === 'runs' ? 'runs' : 'cases'
+  )
 
   if (!currentProject) {
     return (


### PR DESCRIPTION
Two small parser-eval UI tweaks.

- **Back-to-runs action:** the run-detail (eval results) page gets a "← Back to runs" link. The parser-eval page's Runs tab is now addressable via `/evaluation/parser?tab=runs` (initial tab read from the query param), so the link lands on Runs rather than the default Cases tab.
- **Evaluation nav order:** reordered to **Parsing, Retrieval, Extraction**.

Verified: `npx tsc --noEmit`, `eslint`, `npm run build`, and `ParserEvaluationPage.test.tsx` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
