### PR TITLE
Parser Eval Slice 2: table grid editor

### DIFF
--- a/backend/app/repositories/parser_eval_repository.py
+++ b/backend/app/repositories/parser_eval_repository.py
@@ -66,6 +66,16 @@ class ParserEvalRepository:
         await self.session.refresh(case)
         return case
 
+    async def replace_case_expected(self, case_id: UUID, expected: dict) -> ParserEvalCase | None:
+        case = await self.get_case(case_id)
+        if case is None:
+            return None
+        case.expected = expected
+        case.review_status = ParserEvalReviewStatus.draft
+        await self.session.commit()
+        await self.session.refresh(case)
+        return case
+
     async def delete_case(self, case_id: UUID) -> bool:
         case = await self.get_case(case_id)
         if case is None:

--- a/backend/app/routers/parser_eval.py
+++ b/backend/app/routers/parser_eval.py
@@ -12,8 +12,8 @@ from app.repositories.parser_eval_repository import ParserEvalRepository
 from app.repositories.project_repository import ProjectRepository
 from app.repositories.source_document_repository import SourceDocumentRepository
 from app.schemas.parser_eval import (
-    BootstrapTableRequest, CaseCreate, CaseDetailResponse, CaseResponse, CaseReviewUpdate,
-    DatasetCreate, DatasetResponse, RunCreate, RunResponse, ResultResponse,
+    BootstrapTableRequest, CaseCreate, CaseDetailResponse, CaseExpectedUpdate, CaseResponse,
+    CaseReviewUpdate, DatasetCreate, DatasetResponse, RunCreate, RunResponse, ResultResponse,
 )
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 from app.services.parser_eval.service import ParserEvalService
@@ -149,6 +149,25 @@ async def update_case_review(
         return await service.set_case_review(case_id, data.review_status)
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.put("/projects/{project_id}/parser-eval/cases/{case_id}",
+            response_model=CaseDetailResponse)
+async def replace_case_tables(
+    project_id: UUID,
+    case_id: UUID,
+    data: CaseExpectedUpdate,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    try:
+        return await service.replace_case_tables(case_id, data)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete("/projects/{project_id}/parser-eval/cases/{case_id}",

--- a/backend/app/schemas/parser_eval.py
+++ b/backend/app/schemas/parser_eval.py
@@ -89,6 +89,29 @@ class CaseReviewUpdate(BaseModel):
         return value
 
 
+_MAX_TABLES = 50
+
+
+class CaseExpectedUpdate(BaseModel):
+    tables: list[dict]
+
+    model_config = _CAMEL
+
+    @field_validator("tables")
+    @classmethod
+    def _validate_tables(cls, value: list[dict]) -> list[dict]:
+        if not value:
+            raise ValueError("at least one table is required")
+        if len(value) > _MAX_TABLES:
+            raise ValueError(f"at most {_MAX_TABLES} tables allowed")
+        for t in value:
+            if not isinstance(t.get("html"), str) or not t["html"].strip():
+                raise ValueError("each table requires a non-empty 'html' string")
+            if not isinstance(t.get("page"), int):
+                raise ValueError("each table requires an integer 'page'")
+        return value
+
+
 class DatasetCreate(BaseModel):
     name: str
     description: str | None = None

--- a/backend/app/services/parser_eval/service.py
+++ b/backend/app/services/parser_eval/service.py
@@ -9,13 +9,13 @@ from app.models.parser_eval import (
 from app.repositories.parser_eval_repository import ParserEvalRepository
 from app.repositories.source_document_repository import SourceDocumentRepository
 from app.schemas.parser_eval import (
-    BootstrapTableRequest, CaseCreate, CaseDetailResponse, CaseResponse,
+    BootstrapTableRequest, CaseCreate, CaseDetailResponse, CaseExpectedUpdate, CaseResponse,
     DatasetCreate, DatasetResponse, RunCreate, RunResponse, ResultResponse,
 )
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 from app.services.parser_eval.capture import capture
 from app.services.parser_eval.engine import run_evaluation
-from app.services.parser_eval.table_html import extract_cdm_tables
+from app.services.parser_eval.table_html import extract_cdm_tables, sanitize_table_html
 
 
 class ParserEvalService:
@@ -80,6 +80,29 @@ class ParserEvalService:
         if case is None:
             raise NotFoundError(f"Parser eval case {case_id} not found")
         return CaseDetailResponse.model_validate(case)
+
+    _MAX_CELLS_PER_TABLE = 2000
+
+    async def replace_case_tables(self, case_id: UUID,
+                                  data: CaseExpectedUpdate) -> CaseDetailResponse:
+        case = await self.repo.get_case(case_id)
+        if case is None:
+            raise NotFoundError(f"Parser eval case {case_id} not found")
+        if case.dimension != ParserEvalDimension.table:
+            raise ValidationError("Only table cases support table replacement")
+
+        clean_tables = []
+        for t in data.tables:
+            html = sanitize_table_html(t["html"])
+            cell_count = html.lower().count("<td") + html.lower().count("<th")
+            if "<table" not in html.lower() or cell_count == 0:
+                raise ValidationError("each table must contain at least one cell")
+            if cell_count > self._MAX_CELLS_PER_TABLE:
+                raise ValidationError(f"table exceeds {self._MAX_CELLS_PER_TABLE} cells")
+            clean_tables.append({"page": t["page"], "html": html})
+
+        updated = await self.repo.replace_case_expected(case_id, {"tables": clean_tables})
+        return CaseDetailResponse.model_validate(updated)
 
     async def delete_case(self, case_id: UUID) -> None:
         if not await self.repo.delete_case(case_id):

--- a/backend/app/services/parser_eval/table_html.py
+++ b/backend/app/services/parser_eval/table_html.py
@@ -7,7 +7,26 @@ from __future__ import annotations
 
 from html import escape
 
+import nh3
+
 from app.cdm.models import BlockRole, ParsedDocument, Table
+
+_ALLOWED_TAGS = {"table", "thead", "tbody", "tr", "td", "th"}
+_ALLOWED_ATTRS = {"td": {"colspan", "rowspan"}, "th": {"colspan", "rowspan", "scope"}}
+
+
+def sanitize_table_html(html: str) -> str:
+    """Strip everything outside the table-structure allowlist; keep text content.
+
+    Ground-truth HTML is authored by a trusted human but is rendered via
+    dangerouslySetInnerHTML and scored, so it is sanitized at the write boundary.
+    """
+    return nh3.clean(
+        html or "",
+        tags=_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRS,
+        strip_comments=True,
+    )
 
 
 def table_to_html(table: Table) -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "camelot-py>=2.0.0",
     "tabulate>=0.10.0",
     "apted>=1.0.3",
+    "nh3>=0.3.6",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/repositories/test_parser_eval_repository.py
+++ b/backend/tests/repositories/test_parser_eval_repository.py
@@ -1,8 +1,27 @@
 import pytest
+from uuid import uuid4
 from app.models.parser_eval import (
     ParserEvalDimension, ParserEvalReviewStatus, ParserEvalRunStatus,
 )
 from app.repositories.parser_eval_repository import ParserEvalRepository
+
+
+@pytest.mark.asyncio
+async def test_replace_case_expected_resets_to_draft(test_db, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+    repo = ParserEvalRepository(test_db)
+    case = await repo.create_case(
+        project_id, source_id, ParserEvalDimension.table,
+        {"tables": [{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}]}, user_id,
+        review_status=ParserEvalReviewStatus.verified)
+
+    new_expected = {"tables": [{"page": 2, "html": "<table><tr><td>b</td></tr></table>"}]}
+    updated = await repo.replace_case_expected(case.id, new_expected)
+
+    assert updated is not None
+    assert updated.expected == new_expected
+    assert updated.review_status == ParserEvalReviewStatus.draft
+    assert await repo.replace_case_expected(uuid4(), new_expected) is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_parser_eval_router.py
+++ b/backend/tests/routers/test_parser_eval_router.py
@@ -80,6 +80,58 @@ async def test_dataset_run_snapshot_flow(client: AsyncClient, seed_project_user_
 
 
 @pytest.mark.asyncio
+async def test_put_case_replaces_tables_and_resets_draft(client: AsyncClient, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+
+    class _FakeUser:
+        id = user_id
+
+    app.dependency_overrides[get_current_active_user] = lambda: _FakeUser()
+    try:
+        r = await client.post(
+            f"/api/v1/projects/{project_id}/parser-eval/cases",
+            json={"source_document_id": str(source_id), "dimension": "table",
+                  "expected": {"tables": [{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}]},
+                  "reviewStatus": "verified"})
+        assert r.status_code == 200, r.text
+        case_id = r.json()["id"]
+
+        r = await client.put(
+            f"/api/v1/projects/{project_id}/parser-eval/cases/{case_id}",
+            json={"tables": [{"page": 2,
+                              "html": '<table><tr><td onclick="x">b</td></tr></table>'}]})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["reviewStatus"] == "draft"
+        assert body["expected"]["tables"][0]["page"] == 2
+        assert "onclick" not in body["expected"]["tables"][0]["html"].lower()
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+@pytest.mark.asyncio
+async def test_put_case_rejects_text_dimension(client: AsyncClient, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+
+    class _FakeUser:
+        id = user_id
+
+    app.dependency_overrides[get_current_active_user] = lambda: _FakeUser()
+    try:
+        r = await client.post(
+            f"/api/v1/projects/{project_id}/parser-eval/cases",
+            json={"source_document_id": str(source_id), "dimension": "text",
+                  "expected": {"pages": ["hi"]}})
+        case_id = r.json()["id"]
+        r = await client.put(
+            f"/api/v1/projects/{project_id}/parser-eval/cases/{case_id}",
+            json={"tables": [{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}]})
+        assert r.status_code == 400, r.text
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+@pytest.mark.asyncio
 async def test_create_run_unknown_adapter_returns_422(client: AsyncClient, seed_project_user_source):
     project_id, user_id, source_id = seed_project_user_source
 

--- a/backend/tests/schemas/test_parser_eval_schema.py
+++ b/backend/tests/schemas/test_parser_eval_schema.py
@@ -1,7 +1,22 @@
 import pytest
 from uuid import uuid4
 from pydantic import ValidationError
-from app.schemas.parser_eval import CaseCreate, RunCreate, VariantInput
+from app.schemas.parser_eval import CaseCreate, CaseExpectedUpdate, RunCreate, VariantInput
+
+
+def test_case_expected_update_accepts_tables():
+    m = CaseExpectedUpdate(tables=[{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}])
+    assert m.tables[0]["html"].startswith("<table")
+
+
+def test_case_expected_update_rejects_empty():
+    with pytest.raises(ValidationError):
+        CaseExpectedUpdate(tables=[])
+
+
+def test_case_expected_update_rejects_missing_html():
+    with pytest.raises(ValidationError):
+        CaseExpectedUpdate(tables=[{"page": 1}])
 
 
 def test_case_create_requires_dimension_and_expected():

--- a/backend/tests/services/parser_eval/test_table_html.py
+++ b/backend/tests/services/parser_eval/test_table_html.py
@@ -1,5 +1,7 @@
 from app.cdm.models import Block, BlockRole, Cell, Page, ParsedDocument, Table
-from app.services.parser_eval.table_html import extract_cdm_tables, table_to_html
+from app.services.parser_eval.table_html import (
+    extract_cdm_tables, sanitize_table_html, table_to_html,
+)
 
 
 def test_table_to_html_prefers_existing_html():
@@ -39,3 +41,26 @@ def test_extract_cdm_tables_orders_by_page_then_reading_order():
                          page_count=2, pages=[Page(index=0), Page(index=1)], blocks=blocks)
     result = extract_cdm_tables(cdm)
     assert result == [(0, "<table>p0</table>"), (1, "<table>p1</table>")]
+
+
+def test_sanitize_strips_script_and_handlers_keeps_text():
+    dirty = '<table><tr><td onclick="x()">Hi<script>alert(1)</script></td></tr></table>'
+    clean = sanitize_table_html(dirty)
+    assert "script" not in clean.lower()
+    assert "onclick" not in clean.lower()
+    assert "Hi" in clean
+
+
+def test_sanitize_keeps_table_tags_and_span_attrs():
+    html = ('<table><tr><th colspan="2" scope="col">H</th></tr>'
+            '<tr><td rowspan="2">a</td><td>b</td></tr></table>')
+    clean = sanitize_table_html(html)
+    assert "<th" in clean and 'colspan="2"' in clean and 'scope="col"' in clean
+    assert 'rowspan="2"' in clean
+
+
+def test_sanitize_drops_non_table_wrapper_tags():
+    clean = sanitize_table_html('<div style="x"><table><tr><td>c</td></tr></table></div>')
+    assert "<div" not in clean
+    assert "style" not in clean
+    assert "<td>c</td>" in clean

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2329,6 +2329,40 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1b/ef84624f14954d270f74060a19fc550dd4f06656399447569afb584d8c06/nh3-0.3.6.tar.gz", hash = "sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7", size = 24684, upload-time = "2026-06-22T00:47:02.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/3e/6506aa4f23dc7b7993a2d0a45dca3ce864ec48380adfe15a173e643c63e8/nh3-0.3.6-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2411e8c3cee81a1ddd62c2a5d50585c28aa5566d373ad1db92536b95ddb24ef2", size = 1421679, upload-time = "2026-06-22T00:46:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e1/e96e7864a7a53bd6b6fab7e9632467382a2a2c1f3fed951918ad131542fb/nh3-0.3.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e196fa70c2ff2eb4de7d3df3108f8f358c1d69dff20d45b11f20a5aa227ffb6d", size = 792570, upload-time = "2026-06-22T00:46:22.179Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/5b6108bedaef2b2637fed04c87bdbcb5967b9961758b41f0e466ef22a022/nh3-0.3.6-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:34d2b0d934156b87ee114f599a3ba9b8b9e17b5d79652ba3a13fa50903de965e", size = 842243, upload-time = "2026-06-22T00:46:23.801Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4a/526f199626bfcb496bc01a268051b44737962005553b158e985ed7e64865/nh3-0.3.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2f14b7ae1fca99c4a66c981aac3974e7fbc1ca30a12673d223ae1df76680917", size = 1001468, upload-time = "2026-06-22T00:46:25.481Z" },
+    { url = "https://files.pythonhosted.org/packages/49/09/0d8e3101636d9ad88cdefb2914e764cb8e876ebdbb4286bfc251277d9c67/nh3-0.3.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:889932a97fb4abb6f95fef1914c0d269ebfb60011e67121c1163059b9449dbb4", size = 1082933, upload-time = "2026-06-22T00:46:27.15Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a1/ea83abe738a3fbaa203dfdb836ca7cbab0e7e9609faaee4fe1d4652599c0/nh3-0.3.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:edb2b4a1a27523e6cc7c417f8d21ce3d005243548b93e56b762b66b0c7f589f9", size = 1043120, upload-time = "2026-06-22T00:46:28.89Z" },
+    { url = "https://files.pythonhosted.org/packages/66/69/0654482b8635012fbae67826bd6c381abb05d841ac7388b9b4666300fdad/nh3-0.3.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43bc1ed3fa0716295fabee29ba42b2667e4a51d140b0a68e092170a765474fa6", size = 1023824, upload-time = "2026-06-22T00:46:30.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/1f7285ffadc8307c4dbeb08d21b920536d5117785056d1079e998c4dfa44/nh3-0.3.6-cp314-cp314t-win32.whl", hash = "sha256:597a8e843bea00b2eb5520658dc24a9bb032e7fc9e7c2c0c4cd29420220c9796", size = 599253, upload-time = "2026-06-22T00:46:32.072Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/5542f3c45da4c00290d9d67a65e996702e23e613c4b627de3e09cb9fe357/nh3-0.3.6-cp314-cp314t-win_amd64.whl", hash = "sha256:4713502748f564fee0633b37b3403783ce0a3af3a3d148ad91025a5bdadb7bc6", size = 612553, upload-time = "2026-06-22T00:46:33.53Z" },
+    { url = "https://files.pythonhosted.org/packages/66/35/26bd47e6af5915a628281dccdac354ddf4e32f7397047894270acd8c9870/nh3-0.3.6-cp314-cp314t-win_arm64.whl", hash = "sha256:69bbb92865a693d909db3a700d3c01537533844d0948c1e9323561ce06ecda41", size = 595151, upload-time = "2026-06-22T00:46:34.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ab/a7653bce9a3b204be6a6931767a9e23595807bb84790ce6685e4d7e5bd08/nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25", size = 1443564, upload-time = "2026-06-22T00:46:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/41/21/e1084ab18eb589506335c7c7576f2d4643e9a0c0e33983ef0e549a256b96/nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69", size = 838002, upload-time = "2026-06-22T00:46:38.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/94/f48d08e6f72a406300fa11d8acd929fea1a80d4bf750fa292cb10785f126/nh3-0.3.6-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e", size = 823045, upload-time = "2026-06-22T00:46:39.495Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/431615ba1d1d3eb63cde0f974f2114edf863a8a3f6049a12fed23fc241d3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae", size = 1093171, upload-time = "2026-06-22T00:46:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/24/a0d80182a18919665fefd19c1c06f1d1df1c9a6455d0252de40c034a0bc3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d", size = 1049217, upload-time = "2026-06-22T00:46:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/13/6f1e302ca674ac74362e150848ad56a1be5145391204f74facdb8e94df12/nh3-0.3.6-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf", size = 917372, upload-time = "2026-06-22T00:46:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e", size = 806699, upload-time = "2026-06-22T00:46:45.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bfaa00046e58603507dcfc266c4778e3ab7adf68a5dedd73b6274b8d9314/nh3-0.3.6-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec", size = 835165, upload-time = "2026-06-22T00:46:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/fb2c38845efb703a9173bffdfc745fc64d2b0e55cfc73a3647d2f028250c/nh3-0.3.6-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0", size = 858282, upload-time = "2026-06-22T00:46:49.276Z" },
+    { url = "https://files.pythonhosted.org/packages/68/17/06e72a18ee9b572914447338237ca7eb164c0df901f141bc10d1282247a2/nh3-0.3.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78", size = 1014328, upload-time = "2026-06-22T00:46:51.026Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/3966c61455668c08853bf5e33b4bed93c421f3194ce4de896dc248d6f6ce/nh3-0.3.6-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438", size = 1098207, upload-time = "2026-06-22T00:46:52.674Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d3/479cb4ae440424825735d60525b53e3c77fd60fd6e6afc0e984f00eb0178/nh3-0.3.6-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56", size = 1056961, upload-time = "2026-06-22T00:46:54.335Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0c/6cdb5ee1e127be50dc8391e54bddc1f64e87bf4bfad0c55633320e2e02db/nh3-0.3.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f", size = 1033829, upload-time = "2026-06-22T00:46:56.258Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/55/9de666ad975d6ccd77d799ea0add55ee2347aa81286ce21b2a97c070746b/nh3-0.3.6-cp38-abi3-win32.whl", hash = "sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da", size = 609081, upload-time = "2026-06-22T00:46:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10", size = 624461, upload-time = "2026-06-22T00:46:59.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e5/7cafee2f0413ca4cb0ef3bd111e94d408a48810008b283ad8aee00dd1809/nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21", size = 603060, upload-time = "2026-06-22T00:47:00.596Z" },
+]
+
+[[package]]
 name = "nltk"
 version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3799,6 +3833,7 @@ dependencies = [
     { name = "llama-cloud" },
     { name = "llama-index" },
     { name = "llama-index-readers-file" },
+    { name = "nh3" },
     { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -3860,6 +3895,7 @@ requires-dist = [
     { name = "llama-cloud", specifier = ">=1.0.0" },
     { name = "llama-index", specifier = ">=0.10.0" },
     { name = "llama-index-readers-file", specifier = ">=0.1.0" },
+    { name = "nh3", specifier = ">=0.3.6" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },

--- a/docs/superpowers/plans/2026-07-08-parser-eval-table-grid-editor.md
+++ b/docs/superpowers/plans/2026-07-08-parser-eval-table-grid-editor.md
@@ -1,0 +1,1273 @@
+# Parser Eval — Table Grid Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user open a draft table eval case and correct its ground truth in a real grid editor (edit cells, add/remove rows & columns, merge/split cells, mark headers, fix the table set), then save and verify it.
+
+**Architecture:** Storage stays HTML (`expected.tables[].html`) — the scorer/engine/text dimension are untouched. The frontend owns `html ↔ grid` conversion (native `DOMParser` in, canonical serializer out) and holds the grid as a transient `TableModel`. The backend adds one `PUT` endpoint that sanitizes HTML against a tight allowlist, shallow-validates it, replaces `expected`, and always resets `review_status` to `draft`. Verifying stays the existing `PATCH`.
+
+**Tech Stack:** Backend — Python 3.12, FastAPI, SQLAlchemy 2.0, Pydantic v2, `nh3` (new). Frontend — React 18, TypeScript, Vite, shadcn/ui, Tailwind, Vitest + Testing Library.
+
+## Global Constraints
+
+- **Storage shape is unchanged:** `expected = {"tables": [{"page": int, "html": str}]}`. No new DB column, no `cells` field on the wire or in the DB.
+- **`gridToHtml`/`modelToHtml` output MUST match the backend `table_to_html` convention** (`backend/app/services/parser_eval/table_html.py`): flat `<table>` → `<tr>` rows, no `thead`/`tbody`, `<th>` for header cells else `<td>`, `colspan`/`rowspan` attributes emitted **only when > 1**, text escaped as Python `html.escape(quote=True)` does (`&amp; &lt; &gt; &quot; &#x27;`).
+- **`PUT` always sets `review_status = draft`.** Verified means a human approved exactly the current content. Verifying is a separate explicit `PATCH`.
+- **Sanitizer allowlist — tags:** `table, thead, tbody, tr, td, th`. **Attributes:** `colspan`, `rowspan` (on `td`/`th`), `scope` (on `th`). Everything else stripped, text kept.
+- **Size caps (post-sanitization):** ≤ 50 tables per case, ≤ 2000 cells per table.
+- **Scope:** dimension `table` only. From-scratch *case* creation and bootstrap-to-text are out of scope (deferred).
+- **Frontend:** shadcn/ui + Tailwind, hand-rolled — no table-editor library.
+- **Backend tests run on SQLite** via the `test_db` / `client` / `seed_project_user_source` fixtures. Route prefix is `/api/v1`.
+- **Test commands:** backend `cd backend && uv run python -m pytest -o "addopts=" <path> -v`; frontend `cd frontend && npx vitest run <path>`.
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `backend/app/services/parser_eval/table_html.py` — add `sanitize_table_html`.
+- Modify `backend/app/repositories/parser_eval_repository.py` — add `replace_case_expected`.
+- Modify `backend/app/schemas/parser_eval.py` — add `CaseExpectedUpdate`.
+- Modify `backend/app/services/parser_eval/service.py` — add `replace_case_tables`.
+- Modify `backend/app/routers/parser_eval.py` — add `PUT .../cases/{case_id}`.
+- Modify `backend/pyproject.toml` — add `nh3`.
+- Tests: `backend/tests/services/test_table_html_sanitize.py` (new), and additions to `test_parser_eval_repository.py`, `test_parser_eval_schema.py`, `test_parser_eval_router.py`.
+
+**Frontend**
+- Create `frontend/src/components/parser-eval/tableGrid.ts` — model, conversion, ops (pure).
+- Create `frontend/src/components/parser-eval/TableGridEditor.tsx` — single-table editor UI.
+- Create `frontend/src/components/parser-eval/TableCaseEditor.tsx` — table-set + save/verify.
+- Modify `frontend/src/components/parser-eval/CaseDetailView.tsx` — view/edit mode toggle.
+- Modify `frontend/src/api/parserEval.ts` — add `replaceCaseTables`.
+- Modify `frontend/src/hooks/useParserEval.ts` — add `saveTables` to `useParserEvalCase`.
+- Modify `frontend/src/types/parserEval.ts` — reuse `TableGroundTruth` for the PUT body.
+- Tests: `tableGrid.test.ts` (new), `TableGridEditor.test.tsx` (new), additions to `CaseDetailView.test.tsx`.
+
+---
+
+## Task 1: Backend — HTML sanitizer
+
+**Files:**
+- Modify: `backend/pyproject.toml` (add `nh3`)
+- Modify: `backend/app/services/parser_eval/table_html.py`
+- Test: `backend/tests/services/test_table_html_sanitize.py`
+
+**Interfaces:**
+- Produces: `sanitize_table_html(html: str) -> str` — returns HTML containing only allowlisted table tags/attributes, text preserved.
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `cd backend && uv add nh3`
+Expected: `pyproject.toml` gains an `nh3` entry and the lockfile updates.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `backend/tests/services/test_table_html_sanitize.py`:
+
+```python
+from app.services.parser_eval.table_html import sanitize_table_html
+
+
+def test_strips_script_and_handlers_keeps_text():
+    dirty = '<table><tr><td onclick="x()">Hi<script>alert(1)</script></td></tr></table>'
+    clean = sanitize_table_html(dirty)
+    assert "script" not in clean.lower()
+    assert "onclick" not in clean.lower()
+    assert "Hi" in clean
+
+
+def test_keeps_table_tags_and_span_attrs():
+    html = '<table><tr><th colspan="2" scope="col">H</th></tr>' \
+           '<tr><td rowspan="2">a</td><td>b</td></tr></table>'
+    clean = sanitize_table_html(html)
+    assert "<th" in clean and 'colspan="2"' in clean and 'scope="col"' in clean
+    assert 'rowspan="2"' in clean
+
+
+def test_drops_non_table_wrapper_tags():
+    clean = sanitize_table_html('<div style="x"><table><tr><td>c</td></tr></table></div>')
+    assert "<div" not in clean
+    assert "style" not in clean
+    assert "<td>c</td>" in clean
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/test_table_html_sanitize.py -v`
+Expected: FAIL with `ImportError: cannot import name 'sanitize_table_html'`.
+
+- [ ] **Step 4: Implement the sanitizer**
+
+Add to the top-of-file imports of `backend/app/services/parser_eval/table_html.py`:
+
+```python
+import nh3
+```
+
+Append to the same file:
+
+```python
+_ALLOWED_TAGS = {"table", "thead", "tbody", "tr", "td", "th"}
+_ALLOWED_ATTRS = {"td": {"colspan", "rowspan"}, "th": {"colspan", "rowspan", "scope"}}
+
+
+def sanitize_table_html(html: str) -> str:
+    """Strip everything outside the table-structure allowlist; keep text content.
+
+    Ground-truth HTML is authored by a trusted human but is rendered via
+    dangerouslySetInnerHTML and scored, so it is sanitized at the write boundary.
+    """
+    return nh3.clean(
+        html or "",
+        tags=_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRS,
+        strip_comments=True,
+    )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/test_table_html_sanitize.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/pyproject.toml backend/uv.lock backend/app/services/parser_eval/table_html.py backend/tests/services/test_table_html_sanitize.py
+git commit -m "feat(parser-eval): add table HTML sanitizer (nh3 allowlist)"
+```
+
+---
+
+## Task 2: Backend — repository `replace_case_expected`
+
+**Files:**
+- Modify: `backend/app/repositories/parser_eval_repository.py`
+- Test: `backend/tests/repositories/test_parser_eval_repository.py`
+
+**Interfaces:**
+- Consumes: existing `ParserEvalRepository.create_case`, `get_case`.
+- Produces: `ParserEvalRepository.replace_case_expected(case_id: UUID, expected: dict) -> ParserEvalCase | None` — sets `expected`, forces `review_status = draft`, commits, refreshes; `None` if the case is missing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/repositories/test_parser_eval_repository.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_replace_case_expected_resets_to_draft(test_db, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+    repo = ParserEvalRepository(test_db)
+    case = await repo.create_case(
+        project_id, source_id, ParserEvalDimension.table,
+        {"tables": [{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}]}, user_id,
+        review_status=ParserEvalReviewStatus.verified)
+
+    new_expected = {"tables": [{"page": 2, "html": "<table><tr><td>b</td></tr></table>"}]}
+    updated = await repo.replace_case_expected(case.id, new_expected)
+
+    assert updated is not None
+    assert updated.expected == new_expected
+    assert updated.review_status == ParserEvalReviewStatus.draft
+    assert await repo.replace_case_expected(uuid4(), new_expected) is None
+```
+
+Add `from uuid import uuid4` to the test file's imports if absent.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/repositories/test_parser_eval_repository.py::test_replace_case_expected_resets_to_draft -v`
+Expected: FAIL with `AttributeError: 'ParserEvalRepository' object has no attribute 'replace_case_expected'`.
+
+- [ ] **Step 3: Implement the repository method**
+
+Add to `ParserEvalRepository` in `backend/app/repositories/parser_eval_repository.py`, right after `update_case_review_status`:
+
+```python
+    async def replace_case_expected(self, case_id: UUID, expected: dict) -> ParserEvalCase | None:
+        case = await self.get_case(case_id)
+        if case is None:
+            return None
+        case.expected = expected
+        case.review_status = ParserEvalReviewStatus.draft
+        await self.session.commit()
+        await self.session.refresh(case)
+        return case
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/repositories/test_parser_eval_repository.py::test_replace_case_expected_resets_to_draft -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/repositories/parser_eval_repository.py backend/tests/repositories/test_parser_eval_repository.py
+git commit -m "feat(parser-eval): repo.replace_case_expected resets case to draft"
+```
+
+---
+
+## Task 3: Backend — `CaseExpectedUpdate` schema
+
+**Files:**
+- Modify: `backend/app/schemas/parser_eval.py`
+- Test: `backend/tests/schemas/test_parser_eval_schema.py`
+
+**Interfaces:**
+- Produces: `CaseExpectedUpdate` with field `tables: list[dict]` (camelCase JSON, `populate_by_name`). Validates: non-empty list; each item has an `html: str` and an integer `page`; ≤ 50 tables.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/schemas/test_parser_eval_schema.py`:
+
+```python
+import pytest
+from pydantic import ValidationError
+from app.schemas.parser_eval import CaseExpectedUpdate
+
+
+def test_case_expected_update_accepts_tables():
+    m = CaseExpectedUpdate(tables=[{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}])
+    assert m.tables[0]["html"].startswith("<table")
+
+
+def test_case_expected_update_rejects_empty():
+    with pytest.raises(ValidationError):
+        CaseExpectedUpdate(tables=[])
+
+
+def test_case_expected_update_rejects_missing_html():
+    with pytest.raises(ValidationError):
+        CaseExpectedUpdate(tables=[{"page": 1}])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/schemas/test_parser_eval_schema.py -k case_expected_update -v`
+Expected: FAIL with `ImportError: cannot import name 'CaseExpectedUpdate'`.
+
+- [ ] **Step 3: Implement the schema**
+
+Add to `backend/app/schemas/parser_eval.py` (after `CaseReviewUpdate`):
+
+```python
+_MAX_TABLES = 50
+
+
+class CaseExpectedUpdate(BaseModel):
+    tables: list[dict]
+
+    model_config = _CAMEL
+
+    @field_validator("tables")
+    @classmethod
+    def _validate_tables(cls, value: list[dict]) -> list[dict]:
+        if not value:
+            raise ValueError("at least one table is required")
+        if len(value) > _MAX_TABLES:
+            raise ValueError(f"at most {_MAX_TABLES} tables allowed")
+        for t in value:
+            if not isinstance(t.get("html"), str) or not t["html"].strip():
+                raise ValueError("each table requires a non-empty 'html' string")
+            if not isinstance(t.get("page"), int):
+                raise ValueError("each table requires an integer 'page'")
+        return value
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/schemas/test_parser_eval_schema.py -k case_expected_update -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/schemas/parser_eval.py backend/tests/schemas/test_parser_eval_schema.py
+git commit -m "feat(parser-eval): CaseExpectedUpdate schema"
+```
+
+---
+
+## Task 4: Backend — service `replace_case_tables` + `PUT` route
+
+**Files:**
+- Modify: `backend/app/services/parser_eval/service.py`
+- Modify: `backend/app/routers/parser_eval.py`
+- Test: `backend/tests/routers/test_parser_eval_router.py`
+
+**Interfaces:**
+- Consumes: `sanitize_table_html` (Task 1), `repo.replace_case_expected` (Task 2), `CaseExpectedUpdate` (Task 3).
+- Produces:
+  - `ParserEvalService.replace_case_tables(case_id: UUID, data: CaseExpectedUpdate) -> CaseDetailResponse` — sanitizes each table's HTML, validates it contains a table with ≥1 cell and ≤ 2000 cells, persists, returns the (now `draft`) case. Raises `NotFoundError`, `ValidationError`.
+  - Route `PUT /projects/{project_id}/parser-eval/cases/{case_id}` → `CaseDetailResponse`; 404 / 400 mapping.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `backend/tests/routers/test_parser_eval_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_put_case_replaces_tables_and_resets_draft(client: AsyncClient, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+
+    class _FakeUser:
+        id = user_id
+
+    app.dependency_overrides[get_current_active_user] = lambda: _FakeUser()
+    try:
+        r = await client.post(
+            f"/api/v1/projects/{project_id}/parser-eval/cases",
+            json={"source_document_id": str(source_id), "dimension": "table",
+                  "expected": {"tables": [{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}]},
+                  "reviewStatus": "verified"})
+        assert r.status_code == 200, r.text
+        case_id = r.json()["id"]
+
+        r = await client.put(
+            f"/api/v1/projects/{project_id}/parser-eval/cases/{case_id}",
+            json={"tables": [{"page": 2,
+                              "html": '<table><tr><td onclick="x">b</td></tr></table>'}]})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["reviewStatus"] == "draft"
+        assert body["expected"]["tables"][0]["page"] == 2
+        assert "onclick" not in body["expected"]["tables"][0]["html"].lower()
+
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+@pytest.mark.asyncio
+async def test_put_case_rejects_text_dimension(client: AsyncClient, seed_project_user_source):
+    project_id, user_id, source_id = seed_project_user_source
+
+    class _FakeUser:
+        id = user_id
+
+    app.dependency_overrides[get_current_active_user] = lambda: _FakeUser()
+    try:
+        r = await client.post(
+            f"/api/v1/projects/{project_id}/parser-eval/cases",
+            json={"source_document_id": str(source_id), "dimension": "text",
+                  "expected": {"pages": ["hi"]}})
+        case_id = r.json()["id"]
+        r = await client.put(
+            f"/api/v1/projects/{project_id}/parser-eval/cases/{case_id}",
+            json={"tables": [{"page": 1, "html": "<table><tr><td>a</td></tr></table>"}]})
+        assert r.status_code == 400, r.text
+    finally:
+        app.dependency_overrides.pop(get_current_active_user, None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/routers/test_parser_eval_router.py -k put_case -v`
+Expected: FAIL (405 Method Not Allowed — no `PUT` route yet).
+
+- [ ] **Step 3: Implement the service method**
+
+In `backend/app/services/parser_eval/service.py`, update the `table_html` import to include the sanitizer:
+
+```python
+from app.services.parser_eval.table_html import extract_cdm_tables, sanitize_table_html
+```
+
+Add `CaseExpectedUpdate` to the schema import block, then add this method after `set_case_review`:
+
+```python
+    _MAX_CELLS_PER_TABLE = 2000
+
+    async def replace_case_tables(self, case_id: UUID,
+                                  data: "CaseExpectedUpdate") -> CaseDetailResponse:
+        case = await self.repo.get_case(case_id)
+        if case is None:
+            raise NotFoundError(f"Parser eval case {case_id} not found")
+        if case.dimension != ParserEvalDimension.table:
+            raise ValidationError("Only table cases support table replacement")
+
+        clean_tables = []
+        for t in data.tables:
+            html = sanitize_table_html(t["html"])
+            cell_count = html.lower().count("<td") + html.lower().count("<th")
+            if "<table" not in html.lower() or cell_count == 0:
+                raise ValidationError("each table must contain at least one cell")
+            if cell_count > self._MAX_CELLS_PER_TABLE:
+                raise ValidationError(
+                    f"table exceeds {self._MAX_CELLS_PER_TABLE} cells")
+            clean_tables.append({"page": t["page"], "html": html})
+
+        updated = await self.repo.replace_case_expected(case_id, {"tables": clean_tables})
+        return CaseDetailResponse.model_validate(updated)
+```
+
+Add the import for `CaseExpectedUpdate` to the existing `from app.schemas.parser_eval import (...)` block.
+
+- [ ] **Step 4: Implement the route**
+
+In `backend/app/routers/parser_eval.py`, add `CaseExpectedUpdate` to the `from app.schemas.parser_eval import (...)` block, then add after `update_case_review`:
+
+```python
+@router.put("/projects/{project_id}/parser-eval/cases/{case_id}",
+            response_model=CaseDetailResponse)
+async def replace_case_tables(
+    project_id: UUID,
+    case_id: UUID,
+    data: CaseExpectedUpdate,
+    current_user: User = Depends(get_current_active_user),
+    service: ParserEvalService = Depends(get_service),
+    project_repo: ProjectRepository = Depends(get_project_repo),
+):
+    await verify_project_access(project_id, current_user, project_repo)
+    try:
+        return await service.replace_case_tables(case_id, data)
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/routers/test_parser_eval_router.py -k put_case -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Run the full parser-eval backend suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/ -k parser_eval -v`
+Expected: PASS (no regressions).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/parser_eval/service.py backend/app/routers/parser_eval.py backend/tests/routers/test_parser_eval_router.py
+git commit -m "feat(parser-eval): PUT cases/{id} replaces table ground truth"
+```
+
+---
+
+## Task 5: Frontend — grid model + HTML conversion
+
+**Files:**
+- Create: `frontend/src/components/parser-eval/tableGrid.ts`
+- Test: `frontend/src/components/parser-eval/tableGrid.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface EditorCell { text: string; isHeader: boolean }`
+  - `interface AnchorCell extends EditorCell { row: number; col: number; rowspan: number; colspan: number }`
+  - `interface TableModel { rows: number; cols: number; cells: AnchorCell[] }`
+  - `type Slot = { kind: 'anchor'; cell: AnchorCell } | { kind: 'covered'; cell: AnchorCell }`
+  - `htmlToModel(html: string): TableModel`
+  - `modelToHtml(model: TableModel): string`
+  - `materialize(model: TableModel): Slot[][]`
+  - `emptyModel(rows: number, cols: number): TableModel`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/parser-eval/tableGrid.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { htmlToModel, modelToHtml, materialize, emptyModel } from './tableGrid'
+
+describe('tableGrid conversion', () => {
+  it('round-trips a flat table', () => {
+    const html = '<table><tr><th>H1</th><th>H2</th></tr><tr><td>a</td><td>b</td></tr></table>'
+    expect(modelToHtml(htmlToModel(html))).toBe(html)
+  })
+
+  it('round-trips colspan and rowspan', () => {
+    const html = '<table><tr><th colspan="2">Top</th></tr>'
+      + '<tr><td rowspan="2">L</td><td>b</td></tr><tr><td>c</td></tr></table>'
+    expect(modelToHtml(htmlToModel(html))).toBe(html)
+  })
+
+  it('escapes text like the backend serializer', () => {
+    const m = emptyModel(1, 1)
+    m.cells[0].text = 'a < b & "c"'
+    expect(modelToHtml(m)).toBe('<table><tr><td>a &lt; b &amp; &quot;c&quot;</td></tr></table>')
+  })
+
+  it('materialize marks covered slots for a colspan', () => {
+    const grid = materialize(htmlToModel('<table><tr><td colspan="2">x</td></tr></table>'))
+    expect(grid[0][0].kind).toBe('anchor')
+    expect(grid[0][1].kind).toBe('covered')
+  })
+
+  it('fills ragged rows with empty cells', () => {
+    const m = htmlToModel('<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>')
+    expect(m.rows).toBe(2)
+    expect(m.cols).toBe(2)
+    expect(m.cells).toHaveLength(4)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/tableGrid.test.ts`
+Expected: FAIL (cannot resolve `./tableGrid`).
+
+- [ ] **Step 3: Implement conversion**
+
+Create `frontend/src/components/parser-eval/tableGrid.ts`:
+
+```ts
+export interface EditorCell {
+  text: string
+  isHeader: boolean
+}
+
+export interface AnchorCell extends EditorCell {
+  row: number
+  col: number
+  rowspan: number
+  colspan: number
+}
+
+export interface TableModel {
+  rows: number
+  cols: number
+  cells: AnchorCell[]
+}
+
+export type Slot =
+  | { kind: 'anchor'; cell: AnchorCell }
+  | { kind: 'covered'; cell: AnchorCell }
+
+function newCell(row: number, col: number): AnchorCell {
+  return { row, col, rowspan: 1, colspan: 1, text: '', isHeader: false }
+}
+
+export function emptyModel(rows: number, cols: number): TableModel {
+  const cells: AnchorCell[] = []
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) cells.push(newCell(r, c))
+  return { rows, cols, cells }
+}
+
+/** Fill any unoccupied (r,c) inside rows×cols with empty 1×1 anchors. */
+function fillHoles(model: TableModel): TableModel {
+  const occupied = new Set<string>()
+  for (const cell of model.cells) {
+    for (let dr = 0; dr < cell.rowspan; dr++) {
+      for (let dc = 0; dc < cell.colspan; dc++) occupied.add(`${cell.row + dr},${cell.col + dc}`)
+    }
+  }
+  for (let r = 0; r < model.rows; r++) {
+    for (let c = 0; c < model.cols; c++) {
+      if (!occupied.has(`${r},${c}`)) model.cells.push(newCell(r, c))
+    }
+  }
+  model.cells.sort((a, b) => (a.row - b.row) || (a.col - b.col))
+  return model
+}
+
+export function htmlToModel(html: string): TableModel {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const table = doc.querySelector('table')
+  if (!table) return emptyModel(1, 1)
+
+  const occupied = new Set<string>()
+  const cells: AnchorCell[] = []
+  let maxRow = 0
+  let maxCol = 0
+
+  Array.from(table.querySelectorAll('tr')).forEach((tr, r) => {
+    let c = 0
+    for (const el of Array.from(tr.children)) {
+      if (el.tagName !== 'TD' && el.tagName !== 'TH') continue
+      while (occupied.has(`${r},${c}`)) c++
+      const td = el as HTMLTableCellElement
+      const rowspan = Math.max(1, td.rowSpan || 1)
+      const colspan = Math.max(1, td.colSpan || 1)
+      cells.push({ row: r, col: c, rowspan, colspan,
+        text: (el.textContent ?? '').trim(), isHeader: el.tagName === 'TH' })
+      for (let dr = 0; dr < rowspan; dr++) {
+        for (let dc = 0; dc < colspan; dc++) occupied.add(`${r + dr},${c + dc}`)
+      }
+      maxRow = Math.max(maxRow, r + rowspan)
+      maxCol = Math.max(maxCol, c + colspan)
+      c += colspan
+    }
+  })
+
+  if (cells.length === 0) return emptyModel(1, 1)
+  return fillHoles({ rows: maxRow, cols: maxCol, cells })
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+export function modelToHtml(model: TableModel): string {
+  const byRow = new Map<number, AnchorCell[]>()
+  for (const cell of model.cells) {
+    if (!byRow.has(cell.row)) byRow.set(cell.row, [])
+    byRow.get(cell.row)!.push(cell)
+  }
+  const parts = ['<table>']
+  for (let r = 0; r < model.rows; r++) {
+    parts.push('<tr>')
+    const row = (byRow.get(r) ?? []).slice().sort((a, b) => a.col - b.col)
+    for (const cell of row) {
+      const tag = cell.isHeader ? 'th' : 'td'
+      let attrs = ''
+      if (cell.colspan > 1) attrs += ` colspan="${cell.colspan}"`
+      if (cell.rowspan > 1) attrs += ` rowspan="${cell.rowspan}"`
+      parts.push(`<${tag}${attrs}>${escapeHtml(cell.text)}</${tag}>`)
+    }
+    parts.push('</tr>')
+  }
+  parts.push('</table>')
+  return parts.join('')
+}
+
+export function materialize(model: TableModel): Slot[][] {
+  const grid: Slot[][] = Array.from({ length: model.rows }, () =>
+    new Array<Slot>(model.cols))
+  for (const cell of model.cells) {
+    for (let dr = 0; dr < cell.rowspan; dr++) {
+      for (let dc = 0; dc < cell.colspan; dc++) {
+        grid[cell.row + dr][cell.col + dc] =
+          dr === 0 && dc === 0 ? { kind: 'anchor', cell } : { kind: 'covered', cell }
+      }
+    }
+  }
+  return grid
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/tableGrid.test.ts`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/parser-eval/tableGrid.ts frontend/src/components/parser-eval/tableGrid.test.ts
+git commit -m "feat(parser-eval): table grid model + HTML conversion"
+```
+
+---
+
+## Task 6: Frontend — grid operations
+
+**Files:**
+- Modify: `frontend/src/components/parser-eval/tableGrid.ts`
+- Test: `frontend/src/components/parser-eval/tableGrid.test.ts`
+
+**Interfaces:**
+- Consumes: `TableModel`, `AnchorCell`, `materialize`, `emptyModel` (Task 5).
+- Produces (all pure; return a new `TableModel`; throw `Error` on invalid input):
+  - `setText(m, row, col, text): TableModel`
+  - `toggleHeader(m, row, col): TableModel`
+  - `addRow(m, at): TableModel` / `removeRow(m, at): TableModel`
+  - `addColumn(m, at): TableModel` / `removeColumn(m, at): TableModel`
+  - `mergeCells(m, r1, c1, r2, c2): TableModel`
+  - `splitCell(m, row, col): TableModel`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `frontend/src/components/parser-eval/tableGrid.test.ts`:
+
+```ts
+import {
+  setText, toggleHeader, addRow, removeRow, addColumn, removeColumn, mergeCells, splitCell,
+} from './tableGrid'
+
+const anchorAt = (m: import('./tableGrid').TableModel, r: number, c: number) =>
+  m.cells.find((cell) => cell.row === r && cell.col === c)!
+
+describe('tableGrid operations', () => {
+  it('setText and toggleHeader mutate the anchor', () => {
+    let m = emptyModel(1, 1)
+    m = setText(m, 0, 0, 'hi')
+    m = toggleHeader(m, 0, 0)
+    expect(anchorAt(m, 0, 0).text).toBe('hi')
+    expect(anchorAt(m, 0, 0).isHeader).toBe(true)
+  })
+
+  it('addRow grows dimensions and shifts lower cells', () => {
+    const m = addRow(emptyModel(2, 2), 1)
+    expect(m.rows).toBe(3)
+    expect(m.cells.filter((c) => c.row === 1)).toHaveLength(2)
+  })
+
+  it('addColumn extends a crossing colspan', () => {
+    let m = emptyModel(1, 2)
+    m = mergeCells(m, 0, 0, 0, 1)
+    m = addColumn(m, 1)
+    expect(anchorAt(m, 0, 0).colspan).toBe(3)
+  })
+
+  it('removeRow deletes a plain row', () => {
+    const m = removeRow(emptyModel(2, 2), 0)
+    expect(m.rows).toBe(1)
+  })
+
+  it('removeRow rejects slicing a rowspan', () => {
+    let m = emptyModel(2, 1)
+    m = mergeCells(m, 0, 0, 1, 0)
+    expect(() => removeRow(m, 0)).toThrow()
+  })
+
+  it('mergeCells joins a rectangle and materialize covers it', () => {
+    let m = emptyModel(2, 2)
+    m = setText(m, 0, 0, 'a')
+    m = setText(m, 0, 1, 'b')
+    m = mergeCells(m, 0, 0, 0, 1)
+    expect(anchorAt(m, 0, 0).colspan).toBe(2)
+    expect(anchorAt(m, 0, 0).text).toBe('a b')
+    expect(materialize(m)[0][1].kind).toBe('covered')
+  })
+
+  it('mergeCells rejects a selection overlapping an existing span', () => {
+    let m = emptyModel(2, 2)
+    m = mergeCells(m, 0, 0, 1, 0)
+    expect(() => mergeCells(m, 0, 0, 0, 1)).toThrow()
+  })
+
+  it('splitCell restores 1x1 anchors', () => {
+    let m = emptyModel(2, 2)
+    m = mergeCells(m, 0, 0, 1, 1)
+    m = splitCell(m, 0, 0)
+    expect(anchorAt(m, 0, 0).rowspan).toBe(1)
+    expect(anchorAt(m, 0, 0).colspan).toBe(1)
+    expect(m.cells).toHaveLength(4)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/tableGrid.test.ts`
+Expected: FAIL (the operation functions are not exported).
+
+- [ ] **Step 3: Implement the operations**
+
+Append to `frontend/src/components/parser-eval/tableGrid.ts`:
+
+```ts
+function clone(model: TableModel): TableModel {
+  return { rows: model.rows, cols: model.cols, cells: model.cells.map((c) => ({ ...c })) }
+}
+
+function anchorAt(model: TableModel, row: number, col: number): AnchorCell {
+  const cell = model.cells.find((c) => c.row === row && c.col === col)
+  if (!cell) throw new Error(`No anchor cell at (${row}, ${col}); select a top-left cell`)
+  return cell
+}
+
+export function setText(model: TableModel, row: number, col: number, text: string): TableModel {
+  const next = clone(model)
+  anchorAt(next, row, col).text = text
+  return next
+}
+
+export function toggleHeader(model: TableModel, row: number, col: number): TableModel {
+  const next = clone(model)
+  const cell = anchorAt(next, row, col)
+  cell.isHeader = !cell.isHeader
+  return next
+}
+
+export function addRow(model: TableModel, at: number): TableModel {
+  const next = clone(model)
+  for (const cell of next.cells) {
+    if (at <= cell.row) cell.row++
+    else if (at <= cell.row + cell.rowspan - 1) cell.rowspan++
+  }
+  next.rows++
+  for (let c = 0; c < next.cols; c++) next.cells.push(newCell(at, c))
+  return fillHoles(next)
+}
+
+export function removeRow(model: TableModel, at: number): TableModel {
+  if (model.rows <= 1) throw new Error('A table needs at least one row')
+  for (const cell of model.cells) {
+    if (cell.rowspan > 1 && cell.row <= at && at <= cell.row + cell.rowspan - 1) {
+      throw new Error('Split the merged cell crossing this row before removing it')
+    }
+  }
+  const next = clone(model)
+  next.cells = next.cells.filter((cell) => cell.row !== at)
+  for (const cell of next.cells) if (cell.row > at) cell.row--
+  next.rows--
+  return next
+}
+
+export function addColumn(model: TableModel, at: number): TableModel {
+  const next = clone(model)
+  for (const cell of next.cells) {
+    if (at <= cell.col) cell.col++
+    else if (at <= cell.col + cell.colspan - 1) cell.colspan++
+  }
+  next.cols++
+  for (let r = 0; r < next.rows; r++) next.cells.push(newCell(r, at))
+  return fillHoles(next)
+}
+
+export function removeColumn(model: TableModel, at: number): TableModel {
+  if (model.cols <= 1) throw new Error('A table needs at least one column')
+  for (const cell of model.cells) {
+    if (cell.colspan > 1 && cell.col <= at && at <= cell.col + cell.colspan - 1) {
+      throw new Error('Split the merged cell crossing this column before removing it')
+    }
+  }
+  const next = clone(model)
+  next.cells = next.cells.filter((cell) => cell.col !== at)
+  for (const cell of next.cells) if (cell.col > at) cell.col--
+  next.cols--
+  return next
+}
+
+export function mergeCells(model: TableModel, r1: number, c1: number,
+                           r2: number, c2: number): TableModel {
+  const top = Math.min(r1, r2)
+  const bottom = Math.max(r1, r2)
+  const left = Math.min(c1, c2)
+  const right = Math.max(c1, c2)
+  const grid = materialize(model)
+  const members: AnchorCell[] = []
+  for (let r = top; r <= bottom; r++) {
+    for (let c = left; c <= right; c++) {
+      const slot = grid[r][c]
+      if (slot.kind !== 'anchor' || slot.cell.rowspan !== 1 || slot.cell.colspan !== 1) {
+        throw new Error('Merge only supports a clean rectangle of single cells')
+      }
+      members.push(slot.cell)
+    }
+  }
+  const next = clone(model)
+  const keep = anchorAt(next, top, left)
+  keep.rowspan = bottom - top + 1
+  keep.colspan = right - left + 1
+  keep.text = members.map((m) => m.text).filter((t) => t).join(' ')
+  const removed = new Set(members.filter((m) => !(m.row === top && m.col === left))
+    .map((m) => `${m.row},${m.col}`))
+  next.cells = next.cells.filter((c) => !removed.has(`${c.row},${c.col}`))
+  return next
+}
+
+export function splitCell(model: TableModel, row: number, col: number): TableModel {
+  const next = clone(model)
+  const cell = anchorAt(next, row, col)
+  const { rowspan, colspan } = cell
+  cell.rowspan = 1
+  cell.colspan = 1
+  for (let dr = 0; dr < rowspan; dr++) {
+    for (let dc = 0; dc < colspan; dc++) {
+      if (dr === 0 && dc === 0) continue
+      next.cells.push(newCell(row + dr, col + dc))
+    }
+  }
+  next.cells.sort((a, b) => (a.row - b.row) || (a.col - b.col))
+  return next
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/tableGrid.test.ts`
+Expected: PASS (all conversion + operation tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/parser-eval/tableGrid.ts frontend/src/components/parser-eval/tableGrid.test.ts
+git commit -m "feat(parser-eval): grid ops (rows, cols, merge, split, header)"
+```
+
+---
+
+## Task 7: Frontend — `TableGridEditor` component
+
+**Files:**
+- Create: `frontend/src/components/parser-eval/TableGridEditor.tsx`
+- Test: `frontend/src/components/parser-eval/TableGridEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: everything from `tableGrid.ts` (Tasks 5–6).
+- Produces: `TableGridEditor({ model, onChange }: { model: TableModel; onChange: (m: TableModel) => void })` — renders the materialized grid with per-anchor text inputs and a toolbar (Add row, Add column, Merge, Split, Header, Delete row, Delete column). Selection is a single anchor by default; shift-click extends a rectangle for Merge. Operation errors are shown inline (not thrown to the caller).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/parser-eval/TableGridEditor.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { TableGridEditor } from './TableGridEditor'
+import { emptyModel } from './tableGrid'
+
+describe('TableGridEditor', () => {
+  it('edits cell text through onChange', () => {
+    const onChange = vi.fn()
+    render(<TableGridEditor model={emptyModel(1, 1)} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } })
+    expect(onChange).toHaveBeenCalled()
+    const next = onChange.mock.calls.at(-1)![0]
+    expect(next.cells[0].text).toBe('hello')
+  })
+
+  it('adds a row via the toolbar', () => {
+    const onChange = vi.fn()
+    render(<TableGridEditor model={emptyModel(1, 1)} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /add row/i }))
+    expect(onChange.mock.calls.at(-1)![0].rows).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/TableGridEditor.test.tsx`
+Expected: FAIL (cannot resolve `./TableGridEditor`).
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/parser-eval/TableGridEditor.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  materialize, setText, toggleHeader, addRow, removeRow, addColumn, removeColumn,
+  mergeCells, splitCell, type TableModel,
+} from './tableGrid'
+
+interface Sel { r1: number; c1: number; r2: number; c2: number }
+
+export function TableGridEditor({ model, onChange }:
+  { model: TableModel; onChange: (m: TableModel) => void }) {
+  const [sel, setSel] = useState<Sel>({ r1: 0, c1: 0, r2: 0, c2: 0 })
+  const [error, setError] = useState<string | null>(null)
+  const grid = materialize(model)
+
+  const apply = (fn: () => TableModel) => {
+    try { setError(null); onChange(fn()) } catch (e) { setError((e as Error).message) }
+  }
+  const onCellMouseDown = (r: number, c: number, shift: boolean) =>
+    setSel((s) => shift ? { ...s, r2: r, c2: c } : { r1: r, c1: c, r2: r, c2: c })
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1">
+        <Button size="sm" variant="outline" onClick={() => apply(() => addRow(model, sel.r1 + 1))}>Add row</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => addColumn(model, sel.c1 + 1))}>Add column</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => removeRow(model, sel.r1))}>Delete row</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => removeColumn(model, sel.c1))}>Delete column</Button>
+        <Button size="sm" variant="outline"
+          onClick={() => apply(() => mergeCells(model, sel.r1, sel.c1, sel.r2, sel.c2))}>Merge</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => splitCell(model, sel.r1, sel.c1))}>Split</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => toggleHeader(model, sel.r1, sel.c1))}>Header</Button>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <table className="border-collapse">
+        <tbody>
+          {grid.map((row, r) => (
+            <tr key={r}>
+              {row.map((slot, c) => {
+                if (slot.kind === 'covered') return null
+                const { cell } = slot
+                const selected = r === sel.r1 && c === sel.c1
+                return (
+                  <td key={c} rowSpan={cell.rowspan} colSpan={cell.colspan}
+                    onMouseDown={(e) => onCellMouseDown(r, c, e.shiftKey)}
+                    className={`border p-0 ${selected ? 'ring-2 ring-primary' : ''} ${cell.isHeader ? 'bg-muted font-semibold' : ''}`}>
+                    <input
+                      aria-label={`cell ${r},${c}`}
+                      className="w-full min-w-24 bg-transparent px-2 py-1 text-sm outline-none"
+                      value={cell.text}
+                      onChange={(e) => apply(() => setText(model, r, c, e.target.value))} />
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/TableGridEditor.test.tsx`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/parser-eval/TableGridEditor.tsx frontend/src/components/parser-eval/TableGridEditor.test.tsx
+git commit -m "feat(parser-eval): TableGridEditor component"
+```
+
+---
+
+## Task 8: Frontend — case page edit mode, API + hook wiring
+
+**Files:**
+- Modify: `frontend/src/api/parserEval.ts`
+- Modify: `frontend/src/types/parserEval.ts`
+- Modify: `frontend/src/hooks/useParserEval.ts`
+- Create: `frontend/src/components/parser-eval/TableCaseEditor.tsx`
+- Modify: `frontend/src/components/parser-eval/CaseDetailView.tsx`
+- Test: `frontend/src/components/parser-eval/CaseDetailView.test.tsx`
+
+**Interfaces:**
+- Consumes: `TableGridEditor` (Task 7), `htmlToModel`/`modelToHtml` (Task 5), `PUT` endpoint (Task 4).
+- Produces:
+  - `replaceCaseTables(projectId, caseId, tables: { page: number; html: string }[]): Promise<ParserEvalCaseDetail>` in `api/parserEval.ts`.
+  - `useParserEvalCase(...)` gains `saveTables(tables, opts?: { verify?: boolean }): Promise<void>`.
+  - `TableCaseEditor({ tables, onSave, onCancel })` manages the table list + save actions.
+  - `CaseDetailView` gains an inline edit mode for `dimension === 'table'`.
+
+- [ ] **Step 1: Add the API function**
+
+Add to `frontend/src/api/parserEval.ts`:
+
+```ts
+export async function replaceCaseTables(
+  projectId: string, caseId: string, tables: { page: number; html: string }[],
+): Promise<ParserEvalCaseDetail> {
+  const r = await apiClient.put<ParserEvalCaseDetail>(
+    `/projects/${projectId}/parser-eval/cases/${caseId}`, { tables })
+  return r.data
+}
+```
+
+- [ ] **Step 2: Extend the hook**
+
+In `frontend/src/hooks/useParserEval.ts`, inside `useParserEvalCase`, add after `reject`:
+
+```ts
+  const saveTables = useCallback(
+    async (tables: { page: number; html: string }[], opts?: { verify?: boolean }) => {
+      if (!projectId || !caseId) return
+      let updated = await api.replaceCaseTables(projectId, caseId, tables)
+      if (opts?.verify) updated = await api.updateCaseReview(projectId, caseId, 'verified')
+      setCaseDetail(updated)
+    }, [projectId, caseId])
+```
+
+Add `saveTables` to the returned object: `return { caseDetail, isLoading, error, verify, reject, saveTables }`.
+
+- [ ] **Step 3: Write the failing test**
+
+Add to `frontend/src/components/parser-eval/CaseDetailView.test.tsx` (follow the file's existing mock/render setup; this test asserts the new edit affordance and save wiring):
+
+```tsx
+it('edits a draft table case and saves', async () => {
+  // Arrange: a draft table case detail is returned by the mocked hook/api.
+  renderCaseDetail({
+    dimension: 'table', reviewStatus: 'draft',
+    expected: { tables: [{ page: 1, html: '<table><tr><td>a</td></tr></table>' }] },
+  })
+  fireEvent.click(await screen.findByRole('button', { name: /edit/i }))
+  fireEvent.change(screen.getByLabelText('cell 0,0'), { target: { value: 'z' } })
+  fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+  await waitFor(() => expect(replaceCaseTablesMock).toHaveBeenCalled())
+  const tablesArg = replaceCaseTablesMock.mock.calls.at(-1)![2]
+  expect(tablesArg[0].html).toContain('z')
+})
+```
+
+Wire `replaceCaseTablesMock` into the file's existing `vi.mock('@/api/parserEval', ...)` (or hook mock) alongside the mocks already there, and add a `renderCaseDetail` helper if the file doesn't already expose one (mirror the existing render setup in this test file).
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/CaseDetailView.test.tsx`
+Expected: FAIL (no Edit button / `saveTables` not wired).
+
+- [ ] **Step 5: Implement `TableCaseEditor`**
+
+Create `frontend/src/components/parser-eval/TableCaseEditor.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { TableGridEditor } from './TableGridEditor'
+import { htmlToModel, modelToHtml, emptyModel, type TableModel } from './tableGrid'
+
+interface EditableTable { page: number; model: TableModel }
+
+export function TableCaseEditor({ tables, onSave, onCancel }: {
+  tables: { page: number; html: string }[]
+  onSave: (tables: { page: number; html: string }[], opts: { verify: boolean }) => Promise<void>
+  onCancel: () => void
+}) {
+  const [rows, setRows] = useState<EditableTable[]>(
+    () => tables.map((t) => ({ page: t.page, model: htmlToModel(t.html) })))
+  const [saving, setSaving] = useState(false)
+
+  const update = (i: number, patch: Partial<EditableTable>) =>
+    setRows((r) => r.map((t, idx) => (idx === i ? { ...t, ...patch } : t)))
+  const move = (i: number, dir: -1 | 1) => setRows((r) => {
+    const j = i + dir
+    if (j < 0 || j >= r.length) return r
+    const copy = [...r];[copy[i], copy[j]] = [copy[j], copy[i]]; return copy
+  })
+  const serialize = () => rows.map((t) => ({ page: t.page, html: modelToHtml(t.model) }))
+  const save = async (verify: boolean) => {
+    setSaving(true)
+    try { await onSave(serialize(), { verify }) } finally { setSaving(false) }
+  }
+
+  return (
+    <div className="space-y-6">
+      {rows.map((t, i) => (
+        <div key={i} className="space-y-2 rounded-md border p-3">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Page</span>
+            <Input type="number" className="w-20" value={t.page}
+              onChange={(e) => update(i, { page: Number(e.target.value) })} />
+            <Button size="sm" variant="ghost" onClick={() => move(i, -1)}>↑</Button>
+            <Button size="sm" variant="ghost" onClick={() => move(i, 1)}>↓</Button>
+            <Button size="sm" variant="ghost"
+              onClick={() => setRows((r) => r.filter((_, idx) => idx !== i))}>Delete table</Button>
+          </div>
+          <TableGridEditor model={t.model} onChange={(m) => update(i, { model: m })} />
+        </div>
+      ))}
+      <Button variant="outline" size="sm"
+        onClick={() => setRows((r) => [...r, { page: 1, model: emptyModel(2, 2) }])}>Add table</Button>
+      <div className="flex gap-2">
+        <Button disabled={saving} onClick={() => save(false)}>Save</Button>
+        <Button disabled={saving} variant="secondary" onClick={() => save(true)}>Save &amp; Accept</Button>
+        <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 6: Wire edit mode into `CaseDetailView`**
+
+In `frontend/src/components/parser-eval/CaseDetailView.tsx`: pull `saveTables` from `useParserEvalCase`, add an `editing` state, render an **Edit** button for draft table cases, and render `TableCaseEditor` when editing. Replace the existing table view/action block with:
+
+```tsx
+import { useState } from 'react'
+import { TableCaseEditor } from './TableCaseEditor'
+// ...existing imports...
+
+// inside the component, replace the hook line:
+const { caseDetail, isLoading, verify, reject, saveTables } = useParserEvalCase(projectId, caseId)
+const [editing, setEditing] = useState(false)
+
+// ...unchanged loading / not-found / header ...
+
+// table branch:
+{caseDetail.dimension === 'table' ? (
+  editing ? (
+    <TableCaseEditor
+      tables={tables}
+      onSave={async (t, opts) => { await saveTables(t, opts); setEditing(false) }}
+      onCancel={() => setEditing(false)} />
+  ) : (
+    <>
+      {tables.length === 0 ? (
+        <p className="text-muted-foreground">The parser found no tables in this document.</p>
+      ) : (
+        <div className="space-y-4">
+          {tables.map((t, i) => (
+            <div key={i} className="space-y-1">
+              <span className="text-xs text-muted-foreground">Page {t.page}</span>
+              <div className="rounded-md border p-3 overflow-x-auto [&_table]:border-collapse [&_td]:border [&_th]:border [&_td]:px-2 [&_th]:px-2"
+                dangerouslySetInnerHTML={{ __html: t.html }} />
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2">
+        <Button variant="outline" onClick={() => setEditing(true)}>Edit</Button>
+        {caseDetail.reviewStatus === 'draft' && (
+          <>
+            <Button onClick={() => verify()}>Accept</Button>
+            <Button variant="outline" onClick={handleReject}>Reject</Button>
+          </>
+        )}
+      </div>
+    </>
+  )
+) : (
+  <p className="text-muted-foreground">Text ground truth review is unchanged.</p>
+)}
+```
+
+Remove the now-superseded standalone draft action block and the `// Follow-up: sanitize (Slice 2).` comment (HTML is sanitized server-side on save now).
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/CaseDetailView.test.tsx`
+Expected: PASS (existing tests + the new edit test).
+
+- [ ] **Step 8: Lint and build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/api/parserEval.ts frontend/src/types/parserEval.ts frontend/src/hooks/useParserEval.ts frontend/src/components/parser-eval/TableCaseEditor.tsx frontend/src/components/parser-eval/CaseDetailView.tsx frontend/src/components/parser-eval/CaseDetailView.test.tsx
+git commit -m "feat(parser-eval): inline grid-editor edit mode on case page"
+```
+
+---
+
+## Task 9: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend parser-eval suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/ -k parser_eval -v`
+Expected: PASS.
+
+- [ ] **Step 2: Frontend parser-eval suite**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval`
+Expected: PASS.
+
+- [ ] **Step 3: Frontend lint + build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 4: Manual smoke (documented, run if a stack is up)**
+
+1. Open a draft table case at `/evaluation/parser/cases/:id` → click **Edit**.
+2. Change a cell, **Add row**, select two adjacent cells (shift-click) → **Merge**, **Split** it back.
+3. **Add table**, set its page, reorder with ↑/↓, delete it.
+4. **Save** → case stays `draft`; reopen edit, **Save & Accept** → badge shows `verified`.
+5. Start a run including the case → `teds`/`table_recall` reflect the edited ground truth.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Full merge/split editor → Tasks 6, 7. ✓
+- FE-owned html↔grid, canonical serializer matching `table_to_html` → Task 5 (+ format-match test). ✓
+- Backend sanitize + shallow validation + `PUT` replacing `expected`, always draft → Tasks 1–4. ✓
+- Save / Save & Accept / verified→draft-on-edit → Tasks 2 (repo reset), 8 (hook + UI). ✓
+- Table-set management (add/delete/reorder/page) → Task 8 (`TableCaseEditor`). ✓
+- Inline edit, no new route; retire sanitize TODO → Task 8. ✓
+- Size caps, allowlist, `nh3` dep → Tasks 1, 3, 4. ✓
+- Out of scope (bootstrap-to-text, from-scratch case) → not implemented. ✓
+
+**Placeholder scan:** none — every code step carries full code.
+
+**Type consistency:** `TableModel`/`AnchorCell`/`Slot` defined in Task 5 and used consistently in Tasks 6–8; `replaceCaseTables` signature `(projectId, caseId, tables)` matches its hook consumer and the Task 8 test assertion (`calls.at(-1)![2]` = the tables arg). `saveTables(tables, opts?)` matches `onSave` in `TableCaseEditor`. Backend `replace_case_tables(case_id, data)` matches the route call.

--- a/docs/superpowers/specs/2026-07-08-parser-eval-table-grid-editor-spec.md
+++ b/docs/superpowers/specs/2026-07-08-parser-eval-table-grid-editor-spec.md
@@ -1,0 +1,314 @@
+# Parser Eval — Slice 2: Table Grid Editor
+
+**Date:** 2026-07-08
+**Status:** Draft for review
+**Author:** brainstorming session (asanyaga)
+**Feature branch:** `feat/parser-eval-table-grid-editor` (suggested)
+**Parent design:** [Parser Eval — Table Dimension Design](2026-07-07-parser-eval-table-dimension-design.md) (Slice 2)
+**Builds on:** Slice 1 (merged, PR #151) — bootstrap-default table authoring, `teds`/`table_recall` scoring,
+case-as-a-page (`/evaluation/parser/cases/:id`), `CaseDetailView` read-only draft review.
+
+---
+
+## Purpose
+
+Slice 1 lets a user *bootstrap* draft table ground truth from a trusted parser and accept or reject it
+wholesale. It gives no way to **correct** what the parser got wrong. Since the ground truth is the
+reference every parser is TEDS-scored against, an uncorrected bootstrap means scoring against a
+possibly-wrong table — the metric is only as trustworthy as the reference.
+
+Slice 2 delivers a **table grid editor**: open a draft table case, fix cell text, add/remove rows and
+columns, merge/split cells, mark header cells, and correct the *set* of tables (add a missed table,
+delete a hallucinated one). Save persists the corrected ground truth; a human then verifies it. The
+result is ground truth the user actually trusts.
+
+---
+
+## Scope
+
+Slice 2 is delivered end-to-end (backend + frontend) as a single, self-contained unit: **the table
+grid editor and its save/verify round-trip.**
+
+### Decisions locked in brainstorming (2026-07-08)
+
+1. **Full merge/split editor.** The grid editor supports editing cell text, adding/removing rows and
+   columns, **merging and splitting cells** (`colspan`/`rowspan`), and toggling header cells. Merge
+   fidelity is a *metric-validity* requirement, not a nicety: TEDS is structure-aware, so a ground
+   truth that cannot represent a merged header would penalise parsers that correctly emit the merge —
+   on exactly the hard tables (grouped/spanning headers) that justify the table dimension. The
+   dominant implementation cost is the spanned-grid data model, which any fidelity-preserving option
+   pays anyway; merge/split is a small additive layer on top of it.
+2. **Bootstrap-correct-first; from-scratch *case* creation deferred.** A table case is still *created*
+   by bootstrapping a trusted parser (Slice 1). Slice 2 corrects that draft. Authoring a brand-new
+   table case with no bootstrap is deferred (low value — nobody hand-builds a merged table from a
+   blank grid; they fix a parse). Note this differs from *adding a blank table within an existing
+   case*, which **is** in scope (see below).
+3. **Frontend owns `html ↔ grid` conversion.** Canonical storage stays HTML
+   (`expected.tables[].html`) so the scorer, engine, and text dimension are untouched. The browser
+   parses HTML tables natively and robustly (`DOMParser` + `HTMLTableCellElement.rowSpan/colSpan`), so
+   both directions live in the frontend, next to the editor, with no new backend HTML-parsing
+   dependency and no dual parsers. This narrows the parent design's "Backend: HTML ↔ grid round-trip"
+   line — the backend does **not** round-trip; it guards (see #4).
+4. **Backend guards, doesn't convert.** A new `PUT .../cases/{id}` replaces `expected`. On save the
+   backend **sanitises** each table's HTML against a tight allowlist and does a **shallow** structural
+   check (parses, contains a table, non-empty, within size bounds). It does not reconstruct the grid.
+   Sanitisation also retires the standing `// Follow-up: sanitize (Slice 2)` TODO in `CaseDetailView`:
+   stored HTML becomes trusted-by-construction before it is ever `dangerouslySetInnerHTML`'d.
+5. **`PUT` always resets `review_status` to `draft`; verify stays an explicit `PATCH`.** Invariant,
+   enforced server-side: *"verified" means a human approved exactly the current content.* Editing a
+   verified case drops it back to draft. This deliberately supersedes the parent design's "verify on
+   save" phrasing; the one-click convenience is preserved in the UI as **Save & Accept** (a `PUT`
+   followed by the existing verify `PATCH`), but the backend primitive stays clean.
+6. **Table-set management on the case page.** Cell editing cannot fix a wrong *set* of tables (a missed
+   or hallucinated table corrupts `table_recall` and order-based matching). The page provides add
+   table / delete table / per-table page number / move up-down, around the per-table grid editors.
+7. **Inline edit mode, no new route.** Editing happens inline on the existing case page
+   (`/evaluation/parser/cases/:id`), preserving the draft's deep-linkable home. Entering Edit swaps
+   the Slice 1 read-only render for the editor.
+
+### Narrowing of the parent design (surfaced explicitly)
+
+The parent design's Slice 2 also listed **"bootstrapping generalises beyond `table`"** (e.g. text) and
+**"optional/manual authoring for every dimension."** Both are **deferred out of Slice 2**:
+
+- **Bootstrap-to-text is deferred.** It is independent of the grid editor, its value is lower (it only
+  pre-fills the per-page textareas that already exist and work), and deferring has no lock-in cost —
+  generalising `POST .../cases/bootstrap-table` to a dimension-parameterised endpoint is a trivial
+  isolated refactor whenever wanted. It moves to a later slice.
+- **From-scratch table-case authoring is deferred** (decision #2).
+
+### Non-goals
+
+- Bootstrap for non-table dimensions; from-scratch table-case creation (both deferred above).
+- Diagnostic metrics (`teds_struct`, `cell_content_f1`) and position/overlap-based multi-table
+  matching — still Slice 3. Order remains scoring-significant in Slice 2 (hence move up/down).
+- Judgment/Selection (thresholds, pass/fail, profiles) — seam #5, deferred for all dimensions.
+- Rich text inside cells, cell-level styling, nested tables, captions editing.
+
+---
+
+## Data model — no changes
+
+Storage shape is unchanged from Slice 1:
+
+```json
+{ "tables": [ { "page": 3, "html": "<table>…</table>" } ] }
+```
+
+No new columns, no new `cells` field on the wire or in the DB. The scorer keeps reading
+`expected.tables[].html`; the text dimension is untouched. The grid is a *transient* frontend
+representation, never persisted.
+
+---
+
+## Frontend
+
+### Grid model (transient, editor-only)
+
+A **spanned-grid** matrix. Each logical position `grid[r][c]` is either an **anchor** cell or a
+**covered** marker referencing its anchor (the second column of a `colspan=2` cell is covered):
+
+```ts
+interface EditorCell {
+  text: string
+  isHeader: boolean
+  rowspan: number   // ≥ 1
+  colspan: number   // ≥ 1
+}
+// grid[r][c] = { kind: 'anchor', cell: EditorCell } | { kind: 'covered', anchor: [number, number] }
+```
+
+Header cells → `<th>`, others → `<td>`. This mirrors the CDM `Cell` shape
+(`row/col/rowspan/colspan/text/is_header`) so it reads naturally to anyone who knows the parser output.
+
+### Conversion (`frontend/src/components/parser-eval/tableGrid.ts`)
+
+- **`htmlToGrid(html: string): Grid`** — parse via `DOMParser`, walk `<tr>` rows placing each `<td>/<th>`
+  into the next free position while honouring `rowSpan`/`colSpan` and skipping occupied positions
+  (the standard HTML table grid algorithm). Ragged/overlapping input is normalised to a rectangular
+  matrix; unknown tags/attributes are ignored (defence-in-depth alongside backend sanitisation).
+- **`gridToHtml(grid: Grid): string`** — emit **flat** `<table>` with `<tr>` rows; per anchor emit
+  `<th>`/`<td>` with `colspan`/`rowspan` attributes **only when > 1**; skip covered positions; escape
+  text. **Output must byte-for-byte match the backend `table_to_html` convention** (flat rows, no
+  `thead`/`tbody`, attribute-only-when-≠1) so ground-truth HTML and parsed HTML are directly
+  TEDS-comparable and canonical.
+
+Both are pure functions, unit-tested independently of React.
+
+### Grid operations (pure, in `tableGrid.ts`)
+
+Each returns a new grid; each preserves rectangularity and span consistency:
+
+- **Edit text / toggle header** — mutate the anchor at a position.
+- **Add / remove row** — insert or delete a logical row; spans that *cross* the boundary are
+  incremented (insert) or clipped/decremented (remove); an anchor whose span collapses to 0 is deleted.
+- **Add / remove column** — symmetric to rows.
+- **Merge** — given a rectangular selection `(r1..r2, c1..c2)`: **validate** the selection is a clean
+  rectangle whose members are all 1×1 anchors (reject partial overlap with an existing span). Collapse
+  to a single anchor with `rowspan=r2-r1+1`, `colspan=c2-c1+1`; concatenate member texts (space-joined,
+  order by row then col); mark the rest covered.
+- **Split** — an anchor with `rowspan>1 or colspan>1` → restore the covered positions to 1×1 anchors
+  (empty text); origin keeps its text.
+
+Validation failures surface as inline messages; they never produce an inconsistent grid.
+
+### Editor component (`TableGridEditor.tsx`)
+
+Renders the grid as an HTML `<table>` of focusable cells (text `<input>`/`contentEditable` per anchor),
+a toolbar (Add row, Add column, Merge, Split, Toggle header, Delete row, Delete column), and cell/range
+selection (click, shift-click to extend a rectangle for merge). shadcn/Tailwind, hand-rolled — no table
+library, consistent with the codebase.
+
+### Case page changes (`CaseDetailView.tsx`)
+
+`CaseDetailView` gains **view** and **edit** modes for `dimension === 'table'`:
+
+- **View (unchanged from Slice 1)** — read-only render of each table (now sanitised at source), page
+  labels, `EvalStatusBadge`. Draft cases add an **Edit** button beside Accept / Reject.
+- **Edit** — a `TableCaseEditor` sub-view: a list of tables, each with a page-number field, **move
+  up/down**, **delete**, and an embedded `TableGridEditor`. An **Add table** button appends a blank
+  1×1 grid on a new page. Footer actions:
+  - **Save** — `PUT` the tables; case returns to (or stays) `draft`.
+  - **Save & Accept** — `PUT`, then the existing verify `PATCH` → `verified`.
+  - **Cancel** — discard local edits, return to view.
+
+The `text` dimension render path is unchanged.
+
+### API + hook
+
+- `frontend/src/api/parserEval.ts`: add `replaceCaseTables(projectId, caseId, tables)` → `PUT`.
+- `useParserEvalCase` (`useParserEval.ts`): add a `saveTables(tables, { verify }: {...})` action that
+  calls `replaceCaseTables` and, when `verify`, chains the existing `verify()`; refresh `caseDetail`
+  from the response.
+- Types (`types/parserEval.ts`): reuse `TableGroundTruth` for the `PUT` body.
+
+### Sanitisation of rendered HTML
+
+The view-mode `dangerouslySetInnerHTML` is now safe because HTML is sanitised on write (below). No
+client-side sanitiser is added; the `// Follow-up: sanitize (Slice 2)` comment is removed.
+
+---
+
+## Backend
+
+### Endpoint — replace expected
+
+`PUT /projects/{project_id}/parser-eval/cases/{case_id}` (`routers/parser_eval.py`), body
+`CaseExpectedUpdate` = `{ tables: [ { page: int, html: str } ] }` (camelCase, reuses the Slice 1 table
+shape). Router → service; catches `NotFoundError` (404) and `ValidationError` (400). Returns
+`CaseDetailResponse`. Only valid for `dimension == 'table'` in Slice 2 (text replacement stays via the
+existing create path / is out of scope) — a text case → `ValidationError`.
+
+### Schema (`schemas/parser_eval.py`)
+
+```python
+class CaseExpectedUpdate(BaseModel):
+    tables: list[TableGT]              # non-empty; each TableGT = { page: int, html: str }
+    model_config = _CAMEL
+```
+
+Reuse/lift the per-table validation already in `CaseCreate._validate_expected` (each table needs an
+`html: str`). Cap counts as a paste/DoS guard: `≤ 50` tables per case, `≤ 2000` cells per table
+(enforced post-sanitisation).
+
+### Sanitisation — `services/parser_eval/table_html.py`
+
+Add `sanitize_table_html(html: str) -> str`. **Allowlist only:**
+
+- Tags: `table, thead, tbody, tr, td, th`.
+- Attributes: `colspan`, `rowspan` (on `td`/`th`), `scope` (on `th`).
+- Everything else (scripts, styles, event handlers, other tags/attrs) stripped; text content kept.
+
+**Dependency:** add **`nh3`** (`uv add nh3` — maintained Rust/ammonia bindings; `bleach` is
+deprecated). If a new dependency is unwelcome, the fallback is a stdlib `html.parser`-based allowlist
+filter, but a vetted sanitiser is strongly preferred for security-sensitive HTML. Contained to this one
+helper.
+
+### Service (`services/parser_eval/service.py`)
+
+`replace_case_tables(case_id, data: CaseExpectedUpdate) -> CaseDetailResponse`:
+
+1. Load case; `NotFoundError` if missing.
+2. `ValidationError` if `dimension != table`.
+3. For each table: `html = sanitize_table_html(t.html)`; **shallow-validate** the sanitised HTML —
+   parses, contains a `<table>` with ≥ 1 cell, non-empty, within size caps; else `ValidationError`.
+4. Persist `expected = { "tables": [ { "page", "html" } ] }` **and set `review_status = draft`** via a
+   new repo method.
+
+### Repository (`repositories/parser_eval_repository.py`)
+
+`replace_case_expected(case_id, expected: dict) -> ParserEvalCase | None` — set `case.expected`,
+`case.review_status = ParserEvalReviewStatus.draft`, commit, refresh (mirrors
+`update_case_review_status`).
+
+The verify transition reuses the existing `PATCH` / `set_case_review` / `update_case_review_status` —
+no change.
+
+---
+
+## Testing
+
+### Frontend (unit — the conversion/ops are pure and high-value)
+
+- **`htmlToGrid` / `gridToHtml` round-trip:** flat table; header row; a `colspan` header over sub-columns;
+  a `rowspan` cell; ragged input normalised. `gridToHtml(htmlToGrid(x))` is canonical and stable.
+- **Format match:** `gridToHtml` output equals the `table_to_html` convention (attribute-only-when-≠1,
+  flat rows, `<th>` for headers) for representative grids.
+- **Grid ops:** add/remove row & column adjust crossing spans correctly; merge validates rectangular
+  1×1-only selection and rejects partial-span overlap; split restores 1×1 anchors; header toggle.
+- **Component (light, per FE test pragmatism):** edit → Save calls `PUT` with expected tables; Save &
+  Accept chains verify; Add/Delete/Move table mutate the list.
+
+### Backend
+
+- **`sanitize_table_html`:** strips `<script>`/`onclick`/`style`; keeps `table/tr/td/th` +
+  `colspan/rowspan/scope`; preserves text.
+- **Service `replace_case_tables`:** persists sanitised tables and forces `review_status=draft` (even
+  when the case was `verified`); non-table dimension → 400; empty/no-table/oversized html → 400;
+  missing case → 404.
+- **Router:** `PUT` happy path returns `CaseDetailResponse` with `draft`; auth/project-access enforced
+  like sibling routes.
+
+---
+
+## Acceptance criteria
+
+- From a draft table case, a user can open an inline grid editor and: edit cell text, add/remove rows
+  and columns, merge a rectangular selection, split a merged cell, and toggle header cells.
+- The user can correct the table *set*: add a table, delete a table, change a table's page, and reorder
+  tables (move up/down).
+- **Save** persists the corrected ground truth and leaves the case `draft`; **Save & Accept** persists
+  and marks it `verified`; editing a `verified` case and saving returns it to `draft`.
+- Saved HTML is sanitised server-side (no scripts/handlers survive) and round-trips through
+  `htmlToGrid`/`gridToHtml` without structural loss, staying canonical and TEDS-comparable.
+- A run over a case verified through the editor produces `teds`/`table_recall` reflecting the corrected
+  ground truth (i.e. edits change scores), with tests proving the conversion and ops.
+
+---
+
+## Risks / open considerations
+
+- **`gridToHtml` ↔ `table_to_html` format drift.** The two serialisers must agree, or ground-truth and
+  parsed HTML diverge cosmetically and depress TEDS. Mitigation: a format-match test pinned to
+  `table_to_html`'s convention; treat that convention as the contract.
+- **Merge/split UX complexity.** Range selection over a spanned grid is the fiddliest UI. Mitigation:
+  strict validation (merge only clean rectangular 1×1 selections), pure well-tested grid ops, and
+  clear inline errors rather than silent corruption.
+- **Order still matters (Slice 1 matching).** Move up/down exists solely because scoring matches the
+  *i-th* expected to the *i-th* parsed table. Slice 3's position/overlap matching removes the
+  sensitivity and this control's necessity.
+- **New `nh3` dependency.** One small, well-maintained sanitiser, contained to `sanitize_table_html`.
+  Stdlib-allowlist fallback exists but is discouraged for security-sensitive HTML.
+- **Shallow backend validation.** Deep structural validity (no ragged rows, spans in bounds) is
+  guaranteed by the FE editor, not re-verified server-side. Acceptable — ground truth is authored by a
+  trusted human through the editor, not adversarial input. A backend `html→grid` validator can be added
+  later for defence-in-depth if needed.
+
+---
+
+## What is explicitly NOT in this doc
+
+- Exact React component tree, toolbar layout, and selection-interaction details — implementation plan.
+- Migrations/DDL (none needed — no schema change).
+- Bootstrap-to-text and from-scratch table-case authoring (deferred; later slice).
+- Slice 3 (diagnostics + multi-table robustness) — its own spec.

--- a/frontend/src/api/parserEval.ts
+++ b/frontend/src/api/parserEval.ts
@@ -36,6 +36,14 @@ export async function updateCaseReview(
   return r.data
 }
 
+export async function replaceCaseTables(
+  projectId: string, caseId: string, tables: { page: number; html: string }[],
+): Promise<ParserEvalCaseDetail> {
+  const r = await apiClient.put<ParserEvalCaseDetail>(
+    `/projects/${projectId}/parser-eval/cases/${caseId}`, { tables })
+  return r.data
+}
+
 export async function deleteCase(projectId: string, caseId: string): Promise<void> {
   await apiClient.delete(`/projects/${projectId}/parser-eval/cases/${caseId}`)
 }

--- a/frontend/src/components/parser-eval/CaseDetailView.test.tsx
+++ b/frontend/src/components/parser-eval/CaseDetailView.test.tsx
@@ -1,24 +1,46 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import { CaseDetailView } from './CaseDetailView'
 
+const hookState = vi.hoisted(() => ({
+  saveTables: vi.fn(),
+  verify: vi.fn(),
+  reject: vi.fn(),
+  caseDetail: {
+    id: 'c1', dimension: 'table', reviewStatus: 'draft',
+    sourceDocumentId: 'd1', sourceMethod: 'bootstrapped', createdAt: '',
+    expected: { tables: [{ page: 1, html: '<table><tr><td>Cell A</td></tr></table>' }] },
+  } as Record<string, unknown>,
+}))
+
 vi.mock('@/hooks/useParserEval', () => ({
   useParserEvalCase: () => ({
-    caseDetail: {
-      id: 'c1', dimension: 'table', reviewStatus: 'draft',
-      sourceDocumentId: 'd1', sourceMethod: 'bootstrapped', createdAt: '',
-      expected: { tables: [{ page: 1, html: '<table><tr><td>Cell A</td></tr></table>' }] },
-    },
-    isLoading: false, verify: vi.fn(), reject: vi.fn(),
+    caseDetail: hookState.caseDetail,
+    isLoading: false,
+    verify: hookState.verify,
+    reject: hookState.reject,
+    saveTables: hookState.saveTables,
   }),
 }))
 
 describe('CaseDetailView', () => {
-  it('renders draft tables with accept/reject actions', () => {
+  it('renders draft tables with edit/accept/reject actions', () => {
     render(<MemoryRouter><CaseDetailView projectId="p1" caseId="c1" /></MemoryRouter>)
     expect(screen.getByText('Cell A')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /accept/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
+  })
+
+  it('edits a draft table case and saves', async () => {
+    render(<MemoryRouter><CaseDetailView projectId="p1" caseId="c1" /></MemoryRouter>)
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    fireEvent.change(screen.getByLabelText('cell 0,0'), { target: { value: 'z' } })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => expect(hookState.saveTables).toHaveBeenCalled())
+    const calls = hookState.saveTables.mock.calls
+    const [tablesArg] = calls[calls.length - 1]
+    expect((tablesArg as { html: string }[])[0].html).toContain('z')
   })
 })

--- a/frontend/src/components/parser-eval/CaseDetailView.tsx
+++ b/frontend/src/components/parser-eval/CaseDetailView.tsx
@@ -1,13 +1,16 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { useParserEvalCase } from '@/hooks/useParserEval'
 import { EvalStatusBadge } from '@/components/evaluation/EvalStatusBadge'
 import { Button } from '@/components/ui/button'
 import type { TableGroundTruth } from '@/types/parserEval'
+import { TableCaseEditor } from './TableCaseEditor'
 
 export function CaseDetailView({ projectId, caseId }: { projectId: string | null; caseId: string }) {
-  const { caseDetail, isLoading, verify, reject } = useParserEvalCase(projectId, caseId)
+  const { caseDetail, isLoading, verify, reject, saveTables } = useParserEvalCase(projectId, caseId)
   const navigate = useNavigate()
+  const [editing, setEditing] = useState(false)
 
   const back = (
     <button onClick={() => navigate('/evaluation/parser')}
@@ -34,29 +37,40 @@ export function CaseDetailView({ projectId, caseId }: { projectId: string | null
       </div>
 
       {caseDetail.dimension === 'table' ? (
-        tables.length === 0 ? (
-          <p className="text-muted-foreground">The parser found no tables in this document.</p>
+        editing ? (
+          <TableCaseEditor
+            tables={tables}
+            onSave={async (t, opts) => { await saveTables(t, opts); setEditing(false) }}
+            onCancel={() => setEditing(false)} />
         ) : (
-          <div className="space-y-4">
-            {tables.map((t, i) => (
-              <div key={i} className="space-y-1">
-                <span className="text-xs text-muted-foreground">Page {t.page}</span>
-                {/* Parser-generated HTML rendered read-only for review. Follow-up: sanitize (Slice 2). */}
-                <div className="rounded-md border p-3 overflow-x-auto [&_table]:border-collapse [&_td]:border [&_th]:border [&_td]:px-2 [&_th]:px-2"
-                  dangerouslySetInnerHTML={{ __html: t.html }} />
+          <>
+            {tables.length === 0 ? (
+              <p className="text-muted-foreground">The parser found no tables in this document.</p>
+            ) : (
+              <div className="space-y-4">
+                {tables.map((t, i) => (
+                  <div key={i} className="space-y-1">
+                    <span className="text-xs text-muted-foreground">Page {t.page}</span>
+                    {/* HTML is sanitized server-side on save (nh3 allowlist) before storage. */}
+                    <div className="rounded-md border p-3 overflow-x-auto [&_table]:border-collapse [&_td]:border [&_th]:border [&_td]:px-2 [&_th]:px-2"
+                      dangerouslySetInnerHTML={{ __html: t.html }} />
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            )}
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setEditing(true)}>Edit</Button>
+              {caseDetail.reviewStatus === 'draft' && (
+                <>
+                  <Button onClick={() => verify()}>Accept</Button>
+                  <Button variant="outline" onClick={handleReject}>Reject</Button>
+                </>
+              )}
+            </div>
+          </>
         )
       ) : (
         <p className="text-muted-foreground">Text ground truth review is unchanged.</p>
-      )}
-
-      {caseDetail.reviewStatus === 'draft' && (
-        <div className="flex gap-2">
-          <Button onClick={() => verify()}>Accept</Button>
-          <Button variant="outline" onClick={handleReject}>Reject</Button>
-        </div>
       )}
     </div>
   )

--- a/frontend/src/components/parser-eval/TableCaseEditor.test.tsx
+++ b/frontend/src/components/parser-eval/TableCaseEditor.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { TableCaseEditor } from './TableCaseEditor'
+
+const oneTable = [{ page: 1, html: '<table><tr><td>a</td></tr></table>' }]
+
+describe('TableCaseEditor', () => {
+  it('adds a table on an existing page (stays same page)', async () => {
+    const onSave = vi.fn()
+    render(<TableCaseEditor tables={oneTable} onSave={onSave} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /add table on this page/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+    const [arg] = onSave.mock.calls[onSave.mock.calls.length - 1]
+    expect(arg).toHaveLength(2)
+    expect((arg as { page: number }[]).every((t) => t.page === 1)).toBe(true)
+  })
+
+  it('adds a new page with its own table, serialized page-major', async () => {
+    const onSave = vi.fn()
+    render(<TableCaseEditor tables={oneTable} onSave={onSave} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /add page/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+    const [arg] = onSave.mock.calls[onSave.mock.calls.length - 1]
+    expect((arg as { page: number }[]).map((t) => t.page)).toEqual([1, 2])
+  })
+})

--- a/frontend/src/components/parser-eval/TableCaseEditor.tsx
+++ b/frontend/src/components/parser-eval/TableCaseEditor.tsx
@@ -4,27 +4,60 @@ import { Input } from '@/components/ui/input'
 import { TableGridEditor } from './TableGridEditor'
 import { htmlToModel, modelToHtml, emptyModel, type TableModel } from './tableGrid'
 
-interface EditableTable { page: number; model: TableModel }
+interface PageGroup { page: number; tables: TableModel[] }
+
+function groupByPage(tables: { page: number; html: string }[]): PageGroup[] {
+  const byPage = new Map<number, TableModel[]>()
+  const order: number[] = []
+  for (const t of tables) {
+    if (!byPage.has(t.page)) { byPage.set(t.page, []); order.push(t.page) }
+    byPage.get(t.page)!.push(htmlToModel(t.html))
+  }
+  return order.sort((a, b) => a - b).map((page) => ({ page, tables: byPage.get(page)! }))
+}
 
 export function TableCaseEditor({ tables, onSave, onCancel }: {
   tables: { page: number; html: string }[]
   onSave: (tables: { page: number; html: string }[], opts: { verify: boolean }) => Promise<void>
   onCancel: () => void
 }) {
-  const [rows, setRows] = useState<EditableTable[]>(
-    () => tables.map((t) => ({ page: t.page, model: htmlToModel(t.html) })))
+  const [groups, setGroups] = useState<PageGroup[]>(() => groupByPage(tables))
   const [saving, setSaving] = useState(false)
 
-  const update = (i: number, patch: Partial<EditableTable>) =>
-    setRows((r) => r.map((t, idx) => (idx === i ? { ...t, ...patch } : t)))
-  const move = (i: number, dir: -1 | 1) => setRows((r) => {
-    const j = i + dir
-    if (j < 0 || j >= r.length) return r
-    const copy = [...r]
-    ;[copy[i], copy[j]] = [copy[j], copy[i]]
-    return copy
-  })
-  const serialize = () => rows.map((t) => ({ page: t.page, html: modelToHtml(t.model) }))
+  const updateGroup = (gi: number, patch: Partial<PageGroup>) =>
+    setGroups((gs) => gs.map((g, i) => (i === gi ? { ...g, ...patch } : g)))
+  const updateTable = (gi: number, ti: number, model: TableModel) =>
+    setGroups((gs) => gs.map((g, i) => i === gi
+      ? { ...g, tables: g.tables.map((m, j) => (j === ti ? model : m)) } : g))
+  const addTable = (gi: number) =>
+    setGroups((gs) => gs.map((g, i) => i === gi
+      ? { ...g, tables: [...g.tables, emptyModel(2, 2)] } : g))
+  const deleteTable = (gi: number, ti: number) =>
+    setGroups((gs) => gs
+      .map((g, i) => (i === gi ? { ...g, tables: g.tables.filter((_, j) => j !== ti) } : g))
+      .filter((g) => g.tables.length > 0))
+  const moveTable = (gi: number, ti: number, dir: -1 | 1) =>
+    setGroups((gs) => gs.map((g, i) => {
+      if (i !== gi) return g
+      const j = ti + dir
+      if (j < 0 || j >= g.tables.length) return g
+      const t = [...g.tables]
+      ;[t[ti], t[j]] = [t[j], t[ti]]
+      return { ...g, tables: t }
+    }))
+  const addPage = () =>
+    setGroups((gs) => {
+      const nextPage = gs.reduce((m, g) => Math.max(m, g.page), 0) + 1
+      return [...gs, { page: nextPage, tables: [emptyModel(2, 2)] }]
+    })
+
+  // The scorer matches the i-th expected table to the i-th parsed table, and parsed
+  // tables arrive in (page, reading-order). Serialize page-major so ground-truth order
+  // mirrors that and positional matching stays correct.
+  const serialize = () =>
+    [...groups].sort((a, b) => a.page - b.page)
+      .flatMap((g) => g.tables.map((m) => ({ page: g.page, html: modelToHtml(m) })))
+
   const save = async (verify: boolean) => {
     setSaving(true)
     try { await onSave(serialize(), { verify }) } finally { setSaving(false) }
@@ -32,22 +65,30 @@ export function TableCaseEditor({ tables, onSave, onCancel }: {
 
   return (
     <div className="space-y-6">
-      {rows.map((t, i) => (
-        <div key={i} className="space-y-2 rounded-md border p-3">
+      {groups.map((g, gi) => (
+        <div key={gi} className="space-y-3 rounded-md border p-3">
           <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">Page</span>
-            <Input type="number" className="w-20" value={t.page}
-              onChange={(e) => update(i, { page: Number(e.target.value) })} />
-            <Button size="sm" variant="ghost" onClick={() => move(i, -1)}>↑</Button>
-            <Button size="sm" variant="ghost" onClick={() => move(i, 1)}>↓</Button>
-            <Button size="sm" variant="ghost"
-              onClick={() => setRows((r) => r.filter((_, idx) => idx !== i))}>Delete table</Button>
+            <span className="text-sm font-medium">Page</span>
+            <Input type="number" className="w-20" value={g.page}
+              onChange={(e) => updateGroup(gi, { page: Number(e.target.value) })} />
           </div>
-          <TableGridEditor model={t.model} onChange={(m) => update(i, { model: m })} />
+          {g.tables.map((model, ti) => (
+            <div key={ti} className="space-y-2 rounded-md border bg-muted/30 p-3">
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Table {ti + 1}</span>
+                <Button size="sm" variant="ghost" onClick={() => moveTable(gi, ti, -1)}>↑</Button>
+                <Button size="sm" variant="ghost" onClick={() => moveTable(gi, ti, 1)}>↓</Button>
+                <Button size="sm" variant="ghost"
+                  onClick={() => deleteTable(gi, ti)}>Delete table</Button>
+              </div>
+              <TableGridEditor model={model} onChange={(m) => updateTable(gi, ti, m)} />
+            </div>
+          ))}
+          <Button variant="outline" size="sm"
+            onClick={() => addTable(gi)}>Add table on this page</Button>
         </div>
       ))}
-      <Button variant="outline" size="sm"
-        onClick={() => setRows((r) => [...r, { page: 1, model: emptyModel(2, 2) }])}>Add table</Button>
+      <Button variant="outline" size="sm" onClick={addPage}>Add page</Button>
       <div className="flex gap-2">
         <Button disabled={saving} onClick={() => save(false)}>Save</Button>
         <Button disabled={saving} variant="secondary" onClick={() => save(true)}>Save &amp; Accept</Button>

--- a/frontend/src/components/parser-eval/TableCaseEditor.tsx
+++ b/frontend/src/components/parser-eval/TableCaseEditor.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { TableGridEditor } from './TableGridEditor'
+import { htmlToModel, modelToHtml, emptyModel, type TableModel } from './tableGrid'
+
+interface EditableTable { page: number; model: TableModel }
+
+export function TableCaseEditor({ tables, onSave, onCancel }: {
+  tables: { page: number; html: string }[]
+  onSave: (tables: { page: number; html: string }[], opts: { verify: boolean }) => Promise<void>
+  onCancel: () => void
+}) {
+  const [rows, setRows] = useState<EditableTable[]>(
+    () => tables.map((t) => ({ page: t.page, model: htmlToModel(t.html) })))
+  const [saving, setSaving] = useState(false)
+
+  const update = (i: number, patch: Partial<EditableTable>) =>
+    setRows((r) => r.map((t, idx) => (idx === i ? { ...t, ...patch } : t)))
+  const move = (i: number, dir: -1 | 1) => setRows((r) => {
+    const j = i + dir
+    if (j < 0 || j >= r.length) return r
+    const copy = [...r]
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    return copy
+  })
+  const serialize = () => rows.map((t) => ({ page: t.page, html: modelToHtml(t.model) }))
+  const save = async (verify: boolean) => {
+    setSaving(true)
+    try { await onSave(serialize(), { verify }) } finally { setSaving(false) }
+  }
+
+  return (
+    <div className="space-y-6">
+      {rows.map((t, i) => (
+        <div key={i} className="space-y-2 rounded-md border p-3">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Page</span>
+            <Input type="number" className="w-20" value={t.page}
+              onChange={(e) => update(i, { page: Number(e.target.value) })} />
+            <Button size="sm" variant="ghost" onClick={() => move(i, -1)}>↑</Button>
+            <Button size="sm" variant="ghost" onClick={() => move(i, 1)}>↓</Button>
+            <Button size="sm" variant="ghost"
+              onClick={() => setRows((r) => r.filter((_, idx) => idx !== i))}>Delete table</Button>
+          </div>
+          <TableGridEditor model={t.model} onChange={(m) => update(i, { model: m })} />
+        </div>
+      ))}
+      <Button variant="outline" size="sm"
+        onClick={() => setRows((r) => [...r, { page: 1, model: emptyModel(2, 2) }])}>Add table</Button>
+      <div className="flex gap-2">
+        <Button disabled={saving} onClick={() => save(false)}>Save</Button>
+        <Button disabled={saving} variant="secondary" onClick={() => save(true)}>Save &amp; Accept</Button>
+        <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/parser-eval/TableGridEditor.test.tsx
+++ b/frontend/src/components/parser-eval/TableGridEditor.test.tsx
@@ -19,4 +19,22 @@ describe('TableGridEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: /add row/i }))
     expect(onChange.mock.calls[onChange.mock.calls.length - 1][0].rows).toBe(2)
   })
+
+  it('highlights the anchor cell on mousedown', () => {
+    render(<TableGridEditor model={emptyModel(1, 2)} onChange={vi.fn()} />)
+    const cell = screen.getByLabelText('cell 0,0').closest('td')!
+    fireEvent.mouseDown(cell)
+    expect(cell.className).toContain('ring-primary')
+  })
+
+  it('drag-selects a range and merges it', () => {
+    const onChange = vi.fn()
+    render(<TableGridEditor model={emptyModel(1, 2)} onChange={onChange} />)
+    fireEvent.mouseDown(screen.getByLabelText('cell 0,0').closest('td')!)
+    fireEvent.mouseEnter(screen.getByLabelText('cell 0,1').closest('td')!)
+    fireEvent.click(screen.getByRole('button', { name: /merge/i }))
+    const next = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+    expect(next.cells.find((c: { row: number; col: number }) => c.row === 0 && c.col === 0).colspan)
+      .toBe(2)
+  })
 })

--- a/frontend/src/components/parser-eval/TableGridEditor.test.tsx
+++ b/frontend/src/components/parser-eval/TableGridEditor.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { TableGridEditor } from './TableGridEditor'
+import { emptyModel } from './tableGrid'
+
+describe('TableGridEditor', () => {
+  it('edits cell text through onChange', () => {
+    const onChange = vi.fn()
+    render(<TableGridEditor model={emptyModel(1, 1)} onChange={onChange} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } })
+    expect(onChange).toHaveBeenCalled()
+    const next = onChange.mock.calls.at(-1)![0]
+    expect(next.cells[0].text).toBe('hello')
+  })
+
+  it('adds a row via the toolbar', () => {
+    const onChange = vi.fn()
+    render(<TableGridEditor model={emptyModel(1, 1)} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /add row/i }))
+    expect(onChange.mock.calls.at(-1)![0].rows).toBe(2)
+  })
+})

--- a/frontend/src/components/parser-eval/TableGridEditor.test.tsx
+++ b/frontend/src/components/parser-eval/TableGridEditor.test.tsx
@@ -9,7 +9,7 @@ describe('TableGridEditor', () => {
     render(<TableGridEditor model={emptyModel(1, 1)} onChange={onChange} />)
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } })
     expect(onChange).toHaveBeenCalled()
-    const next = onChange.mock.calls.at(-1)![0]
+    const next = onChange.mock.calls[onChange.mock.calls.length - 1][0]
     expect(next.cells[0].text).toBe('hello')
   })
 
@@ -17,6 +17,6 @@ describe('TableGridEditor', () => {
     const onChange = vi.fn()
     render(<TableGridEditor model={emptyModel(1, 1)} onChange={onChange} />)
     fireEvent.click(screen.getByRole('button', { name: /add row/i }))
-    expect(onChange.mock.calls.at(-1)![0].rows).toBe(2)
+    expect(onChange.mock.calls[onChange.mock.calls.length - 1][0].rows).toBe(2)
   })
 })

--- a/frontend/src/components/parser-eval/TableGridEditor.tsx
+++ b/frontend/src/components/parser-eval/TableGridEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   materialize, setText, toggleHeader, addRow, removeRow, addColumn, removeColumn,
@@ -11,13 +11,35 @@ export function TableGridEditor({ model, onChange }:
   { model: TableModel; onChange: (m: TableModel) => void }) {
   const [sel, setSel] = useState<Sel>({ r1: 0, c1: 0, r2: 0, c2: 0 })
   const [error, setError] = useState<string | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const draggingRef = useRef(false)
   const grid = materialize(model)
+
+  // End the drag on any mouse release, even outside the table.
+  useEffect(() => {
+    const stop = () => { draggingRef.current = false; setDragging(false) }
+    window.addEventListener('mouseup', stop)
+    return () => window.removeEventListener('mouseup', stop)
+  }, [])
 
   const apply = (fn: () => TableModel) => {
     try { setError(null); onChange(fn()) } catch (e) { setError((e as Error).message) }
   }
-  const onCellMouseDown = (r: number, c: number, shift: boolean) =>
-    setSel((s) => shift ? { ...s, r2: r, c2: c } : { r1: r, c1: c, r2: r, c2: c })
+  const startSelect = (r: number, c: number, shift: boolean) => {
+    if (shift) { setSel((s) => ({ ...s, r2: r, c2: c })); return }
+    setSel({ r1: r, c1: c, r2: r, c2: c })
+    draggingRef.current = true
+    setDragging(true)
+  }
+  const extendSelect = (r: number, c: number) => {
+    if (draggingRef.current) setSel((s) => ({ ...s, r2: r, c2: c }))
+  }
+
+  const top = Math.min(sel.r1, sel.r2)
+  const bottom = Math.max(sel.r1, sel.r2)
+  const left = Math.min(sel.c1, sel.c2)
+  const right = Math.max(sel.c1, sel.c2)
+  const inSel = (r: number, c: number) => r >= top && r <= bottom && c >= left && c <= right
 
   return (
     <div className="space-y-2">
@@ -32,18 +54,21 @@ export function TableGridEditor({ model, onChange }:
         <Button size="sm" variant="outline" onClick={() => apply(() => toggleHeader(model, sel.r1, sel.c1))}>Header</Button>
       </div>
       {error && <p className="text-xs text-destructive">{error}</p>}
-      <table className="border-collapse">
+      <table className={`border-collapse ${dragging ? 'select-none' : ''}`}>
         <tbody>
           {grid.map((row, r) => (
             <tr key={r}>
               {row.map((slot, c) => {
                 if (slot.kind === 'covered') return null
                 const { cell } = slot
-                const selected = r === sel.r1 && c === sel.c1
+                const selected = inSel(r, c)
                 return (
                   <td key={c} rowSpan={cell.rowspan} colSpan={cell.colspan}
-                    onMouseDown={(e) => onCellMouseDown(r, c, e.shiftKey)}
-                    className={`border p-0 ${selected ? 'ring-2 ring-primary' : ''} ${cell.isHeader ? 'bg-muted font-semibold' : ''}`}>
+                    onMouseDown={(e) => startSelect(r, c, e.shiftKey)}
+                    onMouseEnter={() => extendSelect(r, c)}
+                    className={`border p-0 ${cell.isHeader ? 'font-semibold' : ''} `
+                      + (selected ? 'bg-primary/10 ring-2 ring-inset ring-primary'
+                        : cell.isHeader ? 'bg-muted' : '')}>
                     <input
                       aria-label={`cell ${r},${c}`}
                       className="w-full min-w-24 bg-transparent px-2 py-1 text-sm outline-none"

--- a/frontend/src/components/parser-eval/TableGridEditor.tsx
+++ b/frontend/src/components/parser-eval/TableGridEditor.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  materialize, setText, toggleHeader, addRow, removeRow, addColumn, removeColumn,
+  mergeCells, splitCell, type TableModel,
+} from './tableGrid'
+
+interface Sel { r1: number; c1: number; r2: number; c2: number }
+
+export function TableGridEditor({ model, onChange }:
+  { model: TableModel; onChange: (m: TableModel) => void }) {
+  const [sel, setSel] = useState<Sel>({ r1: 0, c1: 0, r2: 0, c2: 0 })
+  const [error, setError] = useState<string | null>(null)
+  const grid = materialize(model)
+
+  const apply = (fn: () => TableModel) => {
+    try { setError(null); onChange(fn()) } catch (e) { setError((e as Error).message) }
+  }
+  const onCellMouseDown = (r: number, c: number, shift: boolean) =>
+    setSel((s) => shift ? { ...s, r2: r, c2: c } : { r1: r, c1: c, r2: r, c2: c })
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1">
+        <Button size="sm" variant="outline" onClick={() => apply(() => addRow(model, sel.r1 + 1))}>Add row</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => addColumn(model, sel.c1 + 1))}>Add column</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => removeRow(model, sel.r1))}>Delete row</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => removeColumn(model, sel.c1))}>Delete column</Button>
+        <Button size="sm" variant="outline"
+          onClick={() => apply(() => mergeCells(model, sel.r1, sel.c1, sel.r2, sel.c2))}>Merge</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => splitCell(model, sel.r1, sel.c1))}>Split</Button>
+        <Button size="sm" variant="outline" onClick={() => apply(() => toggleHeader(model, sel.r1, sel.c1))}>Header</Button>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <table className="border-collapse">
+        <tbody>
+          {grid.map((row, r) => (
+            <tr key={r}>
+              {row.map((slot, c) => {
+                if (slot.kind === 'covered') return null
+                const { cell } = slot
+                const selected = r === sel.r1 && c === sel.c1
+                return (
+                  <td key={c} rowSpan={cell.rowspan} colSpan={cell.colspan}
+                    onMouseDown={(e) => onCellMouseDown(r, c, e.shiftKey)}
+                    className={`border p-0 ${selected ? 'ring-2 ring-primary' : ''} ${cell.isHeader ? 'bg-muted font-semibold' : ''}`}>
+                    <input
+                      aria-label={`cell ${r},${c}`}
+                      className="w-full min-w-24 bg-transparent px-2 py-1 text-sm outline-none"
+                      value={cell.text}
+                      onChange={(e) => apply(() => setText(model, r, c, e.target.value))} />
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/parser-eval/tableGrid.test.ts
+++ b/frontend/src/components/parser-eval/tableGrid.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { htmlToModel, modelToHtml, materialize, emptyModel } from './tableGrid'
+import {
+  setText, toggleHeader, addRow, removeRow, addColumn, removeColumn, mergeCells, splitCell,
+  type TableModel,
+} from './tableGrid'
+
+const anchorAt = (m: TableModel, r: number, c: number) =>
+  m.cells.find((cell) => cell.row === r && cell.col === c)!
 
 describe('tableGrid conversion', () => {
   it('round-trips a flat table', () => {
@@ -29,6 +36,65 @@ describe('tableGrid conversion', () => {
     const m = htmlToModel('<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>')
     expect(m.rows).toBe(2)
     expect(m.cols).toBe(2)
+    expect(m.cells).toHaveLength(4)
+  })
+})
+
+describe('tableGrid operations', () => {
+  it('setText and toggleHeader mutate the anchor', () => {
+    let m = emptyModel(1, 1)
+    m = setText(m, 0, 0, 'hi')
+    m = toggleHeader(m, 0, 0)
+    expect(anchorAt(m, 0, 0).text).toBe('hi')
+    expect(anchorAt(m, 0, 0).isHeader).toBe(true)
+  })
+
+  it('addRow grows dimensions and shifts lower cells', () => {
+    const m = addRow(emptyModel(2, 2), 1)
+    expect(m.rows).toBe(3)
+    expect(m.cells.filter((c) => c.row === 1)).toHaveLength(2)
+  })
+
+  it('addColumn extends a crossing colspan', () => {
+    let m = emptyModel(1, 2)
+    m = mergeCells(m, 0, 0, 0, 1)
+    m = addColumn(m, 1)
+    expect(anchorAt(m, 0, 0).colspan).toBe(3)
+  })
+
+  it('removeRow deletes a plain row', () => {
+    const m = removeRow(emptyModel(2, 2), 0)
+    expect(m.rows).toBe(1)
+  })
+
+  it('removeRow rejects slicing a rowspan', () => {
+    let m = emptyModel(2, 1)
+    m = mergeCells(m, 0, 0, 1, 0)
+    expect(() => removeRow(m, 0)).toThrow()
+  })
+
+  it('mergeCells joins a rectangle and materialize covers it', () => {
+    let m = emptyModel(2, 2)
+    m = setText(m, 0, 0, 'a')
+    m = setText(m, 0, 1, 'b')
+    m = mergeCells(m, 0, 0, 0, 1)
+    expect(anchorAt(m, 0, 0).colspan).toBe(2)
+    expect(anchorAt(m, 0, 0).text).toBe('a b')
+    expect(materialize(m)[0][1].kind).toBe('covered')
+  })
+
+  it('mergeCells rejects a selection overlapping an existing span', () => {
+    let m = emptyModel(2, 2)
+    m = mergeCells(m, 0, 0, 1, 0)
+    expect(() => mergeCells(m, 0, 0, 0, 1)).toThrow()
+  })
+
+  it('splitCell restores 1x1 anchors', () => {
+    let m = emptyModel(2, 2)
+    m = mergeCells(m, 0, 0, 1, 1)
+    m = splitCell(m, 0, 0)
+    expect(anchorAt(m, 0, 0).rowspan).toBe(1)
+    expect(anchorAt(m, 0, 0).colspan).toBe(1)
     expect(m.cells).toHaveLength(4)
   })
 })

--- a/frontend/src/components/parser-eval/tableGrid.test.ts
+++ b/frontend/src/components/parser-eval/tableGrid.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { htmlToModel, modelToHtml, materialize, emptyModel } from './tableGrid'
+
+describe('tableGrid conversion', () => {
+  it('round-trips a flat table', () => {
+    const html = '<table><tr><th>H1</th><th>H2</th></tr><tr><td>a</td><td>b</td></tr></table>'
+    expect(modelToHtml(htmlToModel(html))).toBe(html)
+  })
+
+  it('round-trips colspan and rowspan', () => {
+    const html = '<table><tr><th colspan="2">Top</th></tr>'
+      + '<tr><td rowspan="2">L</td><td>b</td></tr><tr><td>c</td></tr></table>'
+    expect(modelToHtml(htmlToModel(html))).toBe(html)
+  })
+
+  it('escapes text like the backend serializer', () => {
+    const m = emptyModel(1, 1)
+    m.cells[0].text = 'a < b & "c"'
+    expect(modelToHtml(m)).toBe('<table><tr><td>a &lt; b &amp; &quot;c&quot;</td></tr></table>')
+  })
+
+  it('materialize marks covered slots for a colspan', () => {
+    const grid = materialize(htmlToModel('<table><tr><td colspan="2">x</td></tr></table>'))
+    expect(grid[0][0].kind).toBe('anchor')
+    expect(grid[0][1].kind).toBe('covered')
+  })
+
+  it('fills ragged rows with empty cells', () => {
+    const m = htmlToModel('<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>')
+    expect(m.rows).toBe(2)
+    expect(m.cols).toBe(2)
+    expect(m.cells).toHaveLength(4)
+  })
+})

--- a/frontend/src/components/parser-eval/tableGrid.test.ts
+++ b/frontend/src/components/parser-eval/tableGrid.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { htmlToModel, modelToHtml, materialize, emptyModel } from './tableGrid'
 import {
-  setText, toggleHeader, addRow, removeRow, addColumn, removeColumn, mergeCells, splitCell,
+  setText, toggleHeader, addRow, removeRow, addColumn, mergeCells, splitCell,
   type TableModel,
 } from './tableGrid'
 

--- a/frontend/src/components/parser-eval/tableGrid.ts
+++ b/frontend/src/components/parser-eval/tableGrid.ts
@@ -125,3 +125,120 @@ export function materialize(model: TableModel): Slot[][] {
   }
   return grid
 }
+
+function clone(model: TableModel): TableModel {
+  return { rows: model.rows, cols: model.cols, cells: model.cells.map((c) => ({ ...c })) }
+}
+
+function anchorAt(model: TableModel, row: number, col: number): AnchorCell {
+  const cell = model.cells.find((c) => c.row === row && c.col === col)
+  if (!cell) throw new Error(`No anchor cell at (${row}, ${col}); select a top-left cell`)
+  return cell
+}
+
+export function setText(model: TableModel, row: number, col: number, text: string): TableModel {
+  const next = clone(model)
+  anchorAt(next, row, col).text = text
+  return next
+}
+
+export function toggleHeader(model: TableModel, row: number, col: number): TableModel {
+  const next = clone(model)
+  const cell = anchorAt(next, row, col)
+  cell.isHeader = !cell.isHeader
+  return next
+}
+
+export function addRow(model: TableModel, at: number): TableModel {
+  const next = clone(model)
+  for (const cell of next.cells) {
+    if (at <= cell.row) cell.row++
+    else if (at <= cell.row + cell.rowspan - 1) cell.rowspan++
+  }
+  next.rows++
+  for (let c = 0; c < next.cols; c++) next.cells.push(newCell(at, c))
+  return fillHoles(next)
+}
+
+export function removeRow(model: TableModel, at: number): TableModel {
+  if (model.rows <= 1) throw new Error('A table needs at least one row')
+  for (const cell of model.cells) {
+    if (cell.rowspan > 1 && cell.row <= at && at <= cell.row + cell.rowspan - 1) {
+      throw new Error('Split the merged cell crossing this row before removing it')
+    }
+  }
+  const next = clone(model)
+  next.cells = next.cells.filter((cell) => cell.row !== at)
+  for (const cell of next.cells) if (cell.row > at) cell.row--
+  next.rows--
+  return next
+}
+
+export function addColumn(model: TableModel, at: number): TableModel {
+  const next = clone(model)
+  for (const cell of next.cells) {
+    if (at <= cell.col) cell.col++
+    else if (at <= cell.col + cell.colspan - 1) cell.colspan++
+  }
+  next.cols++
+  for (let r = 0; r < next.rows; r++) next.cells.push(newCell(r, at))
+  return fillHoles(next)
+}
+
+export function removeColumn(model: TableModel, at: number): TableModel {
+  if (model.cols <= 1) throw new Error('A table needs at least one column')
+  for (const cell of model.cells) {
+    if (cell.colspan > 1 && cell.col <= at && at <= cell.col + cell.colspan - 1) {
+      throw new Error('Split the merged cell crossing this column before removing it')
+    }
+  }
+  const next = clone(model)
+  next.cells = next.cells.filter((cell) => cell.col !== at)
+  for (const cell of next.cells) if (cell.col > at) cell.col--
+  next.cols--
+  return next
+}
+
+export function mergeCells(model: TableModel, r1: number, c1: number,
+                           r2: number, c2: number): TableModel {
+  const top = Math.min(r1, r2)
+  const bottom = Math.max(r1, r2)
+  const left = Math.min(c1, c2)
+  const right = Math.max(c1, c2)
+  const grid = materialize(model)
+  const members: AnchorCell[] = []
+  for (let r = top; r <= bottom; r++) {
+    for (let c = left; c <= right; c++) {
+      const slot = grid[r][c]
+      if (slot.kind !== 'anchor' || slot.cell.rowspan !== 1 || slot.cell.colspan !== 1) {
+        throw new Error('Merge only supports a clean rectangle of single cells')
+      }
+      members.push(slot.cell)
+    }
+  }
+  const next = clone(model)
+  const keep = anchorAt(next, top, left)
+  keep.rowspan = bottom - top + 1
+  keep.colspan = right - left + 1
+  keep.text = members.map((m) => m.text).filter((t) => t).join(' ')
+  const removed = new Set(members.filter((m) => !(m.row === top && m.col === left))
+    .map((m) => `${m.row},${m.col}`))
+  next.cells = next.cells.filter((c) => !removed.has(`${c.row},${c.col}`))
+  return next
+}
+
+export function splitCell(model: TableModel, row: number, col: number): TableModel {
+  const next = clone(model)
+  const cell = anchorAt(next, row, col)
+  const { rowspan, colspan } = cell
+  cell.rowspan = 1
+  cell.colspan = 1
+  for (let dr = 0; dr < rowspan; dr++) {
+    for (let dc = 0; dc < colspan; dc++) {
+      if (dr === 0 && dc === 0) continue
+      next.cells.push(newCell(row + dr, col + dc))
+    }
+  }
+  next.cells.sort((a, b) => (a.row - b.row) || (a.col - b.col))
+  return next
+}

--- a/frontend/src/components/parser-eval/tableGrid.ts
+++ b/frontend/src/components/parser-eval/tableGrid.ts
@@ -1,0 +1,127 @@
+export interface EditorCell {
+  text: string
+  isHeader: boolean
+}
+
+export interface AnchorCell extends EditorCell {
+  row: number
+  col: number
+  rowspan: number
+  colspan: number
+}
+
+export interface TableModel {
+  rows: number
+  cols: number
+  cells: AnchorCell[]
+}
+
+export type Slot =
+  | { kind: 'anchor'; cell: AnchorCell }
+  | { kind: 'covered'; cell: AnchorCell }
+
+function newCell(row: number, col: number): AnchorCell {
+  return { row, col, rowspan: 1, colspan: 1, text: '', isHeader: false }
+}
+
+export function emptyModel(rows: number, cols: number): TableModel {
+  const cells: AnchorCell[] = []
+  for (let r = 0; r < rows; r++) for (let c = 0; c < cols; c++) cells.push(newCell(r, c))
+  return { rows, cols, cells }
+}
+
+/** Fill any unoccupied (r,c) inside rows×cols with empty 1×1 anchors. */
+function fillHoles(model: TableModel): TableModel {
+  const occupied = new Set<string>()
+  for (const cell of model.cells) {
+    for (let dr = 0; dr < cell.rowspan; dr++) {
+      for (let dc = 0; dc < cell.colspan; dc++) occupied.add(`${cell.row + dr},${cell.col + dc}`)
+    }
+  }
+  for (let r = 0; r < model.rows; r++) {
+    for (let c = 0; c < model.cols; c++) {
+      if (!occupied.has(`${r},${c}`)) model.cells.push(newCell(r, c))
+    }
+  }
+  model.cells.sort((a, b) => (a.row - b.row) || (a.col - b.col))
+  return model
+}
+
+export function htmlToModel(html: string): TableModel {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const table = doc.querySelector('table')
+  if (!table) return emptyModel(1, 1)
+
+  const occupied = new Set<string>()
+  const cells: AnchorCell[] = []
+  let maxRow = 0
+  let maxCol = 0
+
+  Array.from(table.querySelectorAll('tr')).forEach((tr, r) => {
+    let c = 0
+    for (const el of Array.from(tr.children)) {
+      if (el.tagName !== 'TD' && el.tagName !== 'TH') continue
+      while (occupied.has(`${r},${c}`)) c++
+      const td = el as HTMLTableCellElement
+      const rowspan = Math.max(1, td.rowSpan || 1)
+      const colspan = Math.max(1, td.colSpan || 1)
+      cells.push({ row: r, col: c, rowspan, colspan,
+        text: (el.textContent ?? '').trim(), isHeader: el.tagName === 'TH' })
+      for (let dr = 0; dr < rowspan; dr++) {
+        for (let dc = 0; dc < colspan; dc++) occupied.add(`${r + dr},${c + dc}`)
+      }
+      maxRow = Math.max(maxRow, r + rowspan)
+      maxCol = Math.max(maxCol, c + colspan)
+      c += colspan
+    }
+  })
+
+  if (cells.length === 0) return emptyModel(1, 1)
+  return fillHoles({ rows: maxRow, cols: maxCol, cells })
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+export function modelToHtml(model: TableModel): string {
+  const byRow = new Map<number, AnchorCell[]>()
+  for (const cell of model.cells) {
+    if (!byRow.has(cell.row)) byRow.set(cell.row, [])
+    byRow.get(cell.row)!.push(cell)
+  }
+  const parts = ['<table>']
+  for (let r = 0; r < model.rows; r++) {
+    parts.push('<tr>')
+    const row = (byRow.get(r) ?? []).slice().sort((a, b) => a.col - b.col)
+    for (const cell of row) {
+      const tag = cell.isHeader ? 'th' : 'td'
+      let attrs = ''
+      if (cell.colspan > 1) attrs += ` colspan="${cell.colspan}"`
+      if (cell.rowspan > 1) attrs += ` rowspan="${cell.rowspan}"`
+      parts.push(`<${tag}${attrs}>${escapeHtml(cell.text)}</${tag}>`)
+    }
+    parts.push('</tr>')
+  }
+  parts.push('</table>')
+  return parts.join('')
+}
+
+export function materialize(model: TableModel): Slot[][] {
+  const grid: Slot[][] = Array.from({ length: model.rows }, () =>
+    new Array<Slot>(model.cols))
+  for (const cell of model.cells) {
+    for (let dr = 0; dr < cell.rowspan; dr++) {
+      for (let dc = 0; dc < cell.colspan; dc++) {
+        grid[cell.row + dr][cell.col + dc] =
+          dr === 0 && dc === 0 ? { kind: 'anchor', cell } : { kind: 'covered', cell }
+      }
+    }
+  }
+  return grid
+}

--- a/frontend/src/hooks/useParserEval.ts
+++ b/frontend/src/hooks/useParserEval.ts
@@ -165,5 +165,13 @@ export function useParserEvalCase(projectId: string | null, caseId: string | nul
     await api.deleteCase(projectId, caseId)
   }, [projectId, caseId])
 
-  return { caseDetail, isLoading, error, verify, reject }
+  const saveTables = useCallback(
+    async (tables: { page: number; html: string }[], opts?: { verify?: boolean }) => {
+      if (!projectId || !caseId) return
+      let updated = await api.replaceCaseTables(projectId, caseId, tables)
+      if (opts?.verify) updated = await api.updateCaseReview(projectId, caseId, 'verified')
+      setCaseDetail(updated)
+    }, [projectId, caseId])
+
+  return { caseDetail, isLoading, error, verify, reject, saveTables }
 }


### PR DESCRIPTION
Closes #152.

Slice 2 of the parser-eval table dimension. Adds a real grid editor so users can **correct** bootstrapped table ground truth (Slice 1 only allowed accept/reject wholesale).

## What's included

**Backend**
- `sanitize_table_html` (nh3 allowlist: `table/thead/tbody/tr/td/th` + `colspan/rowspan/scope`).
- `repo.replace_case_expected` — replaces `expected` and resets `review_status` to `draft`.
- `CaseExpectedUpdate` schema (non-empty tables, `page:int`, `html:str`, ≤50 tables).
- `PUT /projects/{id}/parser-eval/cases/{case_id}` — sanitizes, shallow-validates (contains a table, ≥1 cell, ≤2000 cells), replaces ground truth; table dimension only.

**Frontend**
- `tableGrid.ts` — spanned-grid `TableModel`, `htmlToModel`/`modelToHtml` (native `DOMParser`; serializer matches backend `table_to_html`), plus ops: add/remove row & column, merge, split, header toggle.
- `TableGridEditor` — single-table editor with toolbar, **drag-to-select** (drag across cells to build the selection rectangle; shift-click also extends) and a **full-rectangle selection highlight**.
- `TableCaseEditor` — table-set management (add/delete/reorder/page) + Save / Save & Accept.
- `CaseDetailView` — inline edit mode; retires the `sanitize (Slice 2)` TODO.

## Design decisions (locked in brainstorming)

- Full merge/split (metric-validity requirement — TEDS is structure-aware).
- Canonical storage stays HTML; frontend owns `html↔grid`, backend guards (sanitize + validate).
- `PUT` always resets to `draft`; verifying stays an explicit `PATCH` (Save & Accept chains both).
- Bootstrap-correct-first; **deferred** (narrows parent design): bootstrap-to-text, from-scratch case authoring.

## Testing

- Backend: 65 parser-eval tests pass (sanitizer, repo reset, schema, PUT integration).
- Frontend: 27 parser-eval tests pass (conversion round-trip incl. format-match to `table_to_html`, all grid ops, editor incl. drag-select→merge and selection highlight, case-page edit/save). Lint clean, build passes.

## References

- Spec: `docs/superpowers/specs/2026-07-08-parser-eval-table-grid-editor-spec.md`
- Plan: `docs/superpowers/plans/2026-07-08-parser-eval-table-grid-editor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)