### PR TITLE
Parser Eval Slice 3: table diagnostics + robust matching

### DIFF
--- a/backend/app/services/parser_eval/scorers/__init__.py
+++ b/backend/app/services/parser_eval/scorers/__init__.py
@@ -21,7 +21,9 @@ class ScorerSpec:
 SCORERS: dict[str, ScorerSpec] = {
     "text": ScorerSpec(fn=score_text, emits=("similarity", "omission", "hallucination"),
                        primary="similarity"),
-    "table": ScorerSpec(fn=score_table, emits=("teds", "table_recall"), primary="teds"),
+    "table": ScorerSpec(fn=score_table,
+                        emits=("teds", "teds_struct", "cell_content_f1", "table_recall"),
+                        primary="teds"),
 }
 
 

--- a/backend/app/services/parser_eval/scorers/table.py
+++ b/backend/app/services/parser_eval/scorers/table.py
@@ -1,45 +1,66 @@
-"""Table-structure+content scorer — compares parsed tables to expected tables via TEDS.
+"""Table scorer — matches GT tables to parsed tables by page+content, then scores each pair.
 
-Slice 1 matches tables by order (i-th expected vs i-th parsed); an unmatched table on
-either side scores TEDS 0. Aggregate TEDS is size-weighted by the larger table's cell
-count so big tables dominate. Robust position-based matching is Slice 3.
+Emits `teds` (primary), `teds_struct` (structure-only), `cell_content_f1` (content-only),
+and `table_recall`. Aggregates the TEDS-family metrics as a size-weighted mean over matched
+pairs; unmatched tables (missing or extra) contribute 0. Matching is order-independent
+(Slice 3), replacing Slice 1's positional matching.
 """
 from __future__ import annotations
 
 from typing import Any
 
 from app.cdm.models import ParsedDocument
-from app.services.parser_eval.scorers.teds import cell_count, teds
+from app.services.parser_eval.scorers.table_match import match_tables
+from app.services.parser_eval.scorers.teds import cell_content_f1, cell_count, teds
 from app.services.parser_eval.table_html import extract_cdm_tables
+
+_ZERO = {"teds": 0.0, "teds_struct": 0.0, "cell_content_f1": 0.0}
 
 
 def score_table(cdm: ParsedDocument, expected: dict[str, Any]) -> tuple[dict[str, float], dict]:
-    expected_html = [t.get("html", "") for t in expected.get("tables", [])]
-    parsed_html = [html for _page, html in extract_cdm_tables(cdm)]
+    expected_tables = expected.get("tables", [])
+    parsed = extract_cdm_tables(cdm)  # list[(page_index, html)]
+    pairs = match_tables(expected_tables, parsed)
 
-    n = max(len(expected_html), len(parsed_html))
     per_table: list[dict[str, Any]] = []
-    weighted_sum = 0.0
+    acc = {"teds": 0.0, "teds_struct": 0.0, "cell_content_f1": 0.0}
     total_weight = 0.0
-    for i in range(n):
-        exp = expected_html[i] if i < len(expected_html) else None
-        par = parsed_html[i] if i < len(parsed_html) else None
-        score = teds(exp, par) if (exp is not None and par is not None) else 0.0
-        weight = max(cell_count(exp) if exp else 0, cell_count(par) if par else 0, 1)
-        weighted_sum += score * weight
+    for ei, pj in pairs:
+        gt_html = expected_tables[ei]["html"] if ei is not None else None
+        par_html = parsed[pj][1] if pj is not None else None
+        if ei is not None and pj is not None:
+            scores = {"teds": teds(gt_html, par_html),
+                      "teds_struct": teds(gt_html, par_html, structure_only=True),
+                      "cell_content_f1": cell_content_f1(gt_html, par_html)}
+            status = "matched"
+            page = int(expected_tables[ei].get("page", 0))
+        elif ei is not None:
+            scores, status = dict(_ZERO), "missing"
+            page = int(expected_tables[ei].get("page", 0))
+        else:
+            scores, status = dict(_ZERO), "extra"
+            page = parsed[pj][0] + 1
+
+        weight = max(cell_count(gt_html) if gt_html else 0,
+                     cell_count(par_html) if par_html else 0, 1)
+        for k in acc:
+            acc[k] += scores[k] * weight
         total_weight += weight
-        per_table.append({"index": i, "teds": score,
-                          "expected_present": exp is not None, "parsed_present": par is not None})
+        per_table.append({"expected_index": ei, "parsed_index": pj, "page": page,
+                          "status": status, **scores})
 
-    teds_metric = weighted_sum / total_weight if total_weight else 1.0
-
-    expected_count = len(expected_html)
-    if expected_count == 0:
-        recall = 1.0 if len(parsed_html) == 0 else 0.0
+    if total_weight:
+        metrics = {k: acc[k] / total_weight for k in acc}
     else:
-        recall = min(len(parsed_html), expected_count) / expected_count
+        metrics = {"teds": 1.0, "teds_struct": 1.0, "cell_content_f1": 1.0}
 
-    metrics = {"teds": teds_metric, "table_recall": recall}
+    expected_count = len(expected_tables)
+    parsed_count = len(parsed)
+    if expected_count == 0:
+        metrics["table_recall"] = 1.0 if parsed_count == 0 else 0.0
+    else:
+        metrics["table_recall"] = min(parsed_count, expected_count) / expected_count
+
     details = {"per_table": per_table,
-               "expected_count": expected_count, "parsed_count": len(parsed_html)}
+               "expected_count": expected_count, "parsed_count": parsed_count}
     return metrics, details

--- a/backend/app/services/parser_eval/scorers/table_match.py
+++ b/backend/app/services/parser_eval/scorers/table_match.py
@@ -1,0 +1,40 @@
+"""Match ground-truth tables to parsed tables by page bucket + content similarity.
+
+Slice 3: replaces Slice 1's order-based matching. Within each page, greedily pair
+the highest-TEDS GT/parsed tables; leftovers are missing (GT) or extra (parsed).
+Page is the only locator shared by both sides — GT is authored HTML with no bbox.
+"""
+from __future__ import annotations
+
+from app.services.parser_eval.scorers.teds import teds
+
+
+def match_tables(expected: list[dict],
+                 parsed: list[tuple[int, str]]) -> list[tuple[int | None, int | None]]:
+    exp_by_page: dict[int, list[int]] = {}
+    for i, t in enumerate(expected):
+        exp_by_page.setdefault(int(t.get("page", 0)), []).append(i)
+    par_by_page: dict[int, list[int]] = {}
+    for j, (page_index, _html) in enumerate(parsed):
+        par_by_page.setdefault(page_index + 1, []).append(j)
+
+    matched: list[tuple[int, int]] = []
+    used_exp: set[int] = set()
+    used_par: set[int] = set()
+    for page in sorted(set(exp_by_page) | set(par_by_page)):
+        pairs = [(teds(expected[ei]["html"], parsed[pj][1]), ei, pj)
+                 for ei in exp_by_page.get(page, [])
+                 for pj in par_by_page.get(page, [])]
+        pairs.sort(key=lambda p: (-p[0], p[1], p[2]))  # best first, deterministic ties
+        for _score, ei, pj in pairs:
+            if ei in used_exp or pj in used_par:
+                continue
+            used_exp.add(ei)
+            used_par.add(pj)
+            matched.append((ei, pj))
+
+    result: list[tuple[int | None, int | None]] = [
+        (i, next((p for e, p in matched if e == i), None)) for i in range(len(expected))
+    ]
+    result.extend((None, j) for j in range(len(parsed)) if j not in used_par)
+    return result

--- a/backend/app/services/parser_eval/scorers/teds.py
+++ b/backend/app/services/parser_eval/scorers/teds.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import difflib
 import re
+from collections import Counter
 from html.parser import HTMLParser
 
 from apted import APTED, Config
@@ -82,6 +83,9 @@ def _count(node: _Node) -> int:
 
 
 class _TedsConfig(Config):
+    def __init__(self, structure_only: bool = False):
+        self.structure_only = structure_only
+
     def children(self, node):
         return node.children
 
@@ -95,20 +99,39 @@ class _TedsConfig(Config):
         if (node1.tag != node2.tag or node1.colspan != node2.colspan
                 or node1.rowspan != node2.rowspan):
             return 1.0
+        if self.structure_only:
+            return 0.0
         if node1.tag in ("td", "th") and node1.text != node2.text:
             return 1.0 - difflib.SequenceMatcher(None, node1.text, node2.text).ratio()
         return 0.0
 
 
-def teds(html_a: str, html_b: str) -> float:
+def teds(html_a: str, html_b: str, *, structure_only: bool = False) -> float:
     tree_a, tree_b = _parse(html_a), _parse(html_b)
     denom = max(_count(tree_a), _count(tree_b))
     if denom == 0:
         return 1.0
-    distance = APTED(tree_a, tree_b, _TedsConfig()).compute_edit_distance()
+    distance = APTED(tree_a, tree_b, _TedsConfig(structure_only)).compute_edit_distance()
     return max(0.0, 1.0 - distance / denom)
 
 
 def cell_count(html: str) -> int:
     root = _parse(html)
     return sum(len(row.children) for row in root.children)
+
+
+def _cell_texts(html: str) -> Counter:
+    root = _parse(html)  # _parse already normalizes each cell's text
+    return Counter(cell.text for row in root.children for cell in row.children
+                   if cell.tag in ("td", "th"))
+
+
+def cell_content_f1(html_a: str, html_b: str) -> float:
+    a, b = _cell_texts(html_a), _cell_texts(html_b)
+    total = sum(a.values()) + sum(b.values())
+    if total == 0:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    intersection = sum((a & b).values())  # multiset intersection
+    return 2 * intersection / total

--- a/backend/tests/services/parser_eval/test_table_match.py
+++ b/backend/tests/services/parser_eval/test_table_match.py
@@ -1,0 +1,29 @@
+from app.services.parser_eval.scorers.table_match import match_tables
+
+A = "<table><tr><td>a</td><td>b</td></tr></table>"
+B = "<table><tr><td>c</td><td>d</td></tr></table>"
+
+
+def test_identity_order():
+    expected = [{"page": 1, "html": A}, {"page": 1, "html": B}]
+    assert match_tables(expected, [(0, A), (0, B)]) == [(0, 0), (1, 1)]
+
+
+def test_reversed_parsed_matches_by_content():
+    expected = [{"page": 1, "html": A}, {"page": 1, "html": B}]
+    assert match_tables(expected, [(0, B), (0, A)]) == [(0, 1), (1, 0)]
+
+
+def test_missing_gt_table():
+    expected = [{"page": 1, "html": A}, {"page": 1, "html": B}]
+    assert match_tables(expected, [(0, A)]) == [(0, 0), (1, None)]
+
+
+def test_extra_parsed_table():
+    expected = [{"page": 1, "html": A}]
+    assert match_tables(expected, [(0, A), (0, B)]) == [(0, 0), (None, 1)]
+
+
+def test_pages_do_not_cross_match():
+    # GT page 1, parsed page_index 2 -> page 3: different buckets, no match.
+    assert match_tables([{"page": 1, "html": A}], [(2, A)]) == [(0, None), (None, 0)]

--- a/backend/tests/services/parser_eval/test_table_scorer.py
+++ b/backend/tests/services/parser_eval/test_table_scorer.py
@@ -55,4 +55,55 @@ def test_no_tables_expected_or_parsed_is_perfect():
 def test_registered_in_scorers():
     spec = get_scorer("table")
     assert spec.primary == "teds"
-    assert set(spec.emits) == {"teds", "table_recall"}
+    assert set(spec.emits) == {"teds", "teds_struct", "cell_content_f1", "table_recall"}
+
+
+def _doc_pages(tables):  # tables: list[(page_index, html)]
+    blocks = [Block(id=f"b{i}", role=BlockRole.TABLE, native_type="table",
+                    page_index=pi, reading_order=i, table=Table(rows=1, cols=2, cells=[], html=h))
+              for i, (pi, h) in enumerate(tables)]
+    return ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                          page_count=3, pages=[Page(index=0), Page(index=1), Page(index=2)],
+                          blocks=blocks)
+
+
+def test_extra_spurious_table_does_not_shift_matches():
+    t1 = "<table><tr><td>a</td><td>b</td></tr></table>"
+    t2 = "<table><tr><td>c</td><td>d</td></tr></table>"
+    spurious = "<table><tr><td>zzz</td></tr></table>"
+    expected = {"tables": [{"page": 1, "html": t1}, {"page": 1, "html": t2}]}
+    doc = _doc(Table(rows=1, cols=2, cells=[], html=t1),
+               Table(rows=1, cols=1, cells=[], html=spurious),
+               Table(rows=1, cols=2, cells=[], html=t2))
+    _metrics, details = score_table(doc, expected)
+    matched = [e for e in details["per_table"] if e["status"] == "matched"]
+    assert len(matched) == 2
+    assert all(e["teds"] == 1.0 for e in matched)
+
+
+def test_emits_structure_and_content_axes():
+    gt = "<table><tr><td>Item</td><td>Qty</td></tr><tr><td>Widget</td><td>3</td></tr></table>"
+    text_wrong = "<table><tr><td>xxx</td><td>yyy</td></tr><tr><td>zzz</td><td>9</td></tr></table>"
+    doc = _doc(Table(rows=2, cols=2, cells=[], html=text_wrong))
+    metrics, _ = score_table(doc, {"tables": [{"page": 1, "html": gt}]})
+    assert metrics["teds_struct"] == 1.0
+    assert metrics["cell_content_f1"] < 0.5
+
+
+def test_details_per_table_carries_axes_and_status():
+    doc = _doc(Table(rows=2, cols=2, cells=[], html=_HTML))
+    _metrics, details = score_table(doc, {"tables": [{"page": 1, "html": _HTML}]})
+    entry = details["per_table"][0]
+    assert entry["status"] == "matched"
+    assert entry["page"] == 1
+    assert entry["expected_index"] == 0 and entry["parsed_index"] == 0
+    assert entry["teds"] == 1.0 and entry["teds_struct"] == 1.0 and entry["cell_content_f1"] == 1.0
+
+
+def test_cross_page_matching():
+    t1 = "<table><tr><td>a</td></tr></table>"
+    t2 = "<table><tr><td>b</td></tr></table>"
+    expected = {"tables": [{"page": 1, "html": t1}, {"page": 2, "html": t2}]}
+    doc = _doc_pages([(0, t1), (1, t2)])
+    metrics, _ = score_table(doc, expected)
+    assert metrics["teds"] == 1.0

--- a/backend/tests/services/parser_eval/test_teds.py
+++ b/backend/tests/services/parser_eval/test_teds.py
@@ -1,4 +1,4 @@
-from app.services.parser_eval.scorers.teds import cell_count, teds
+from app.services.parser_eval.scorers.teds import cell_content_f1, cell_count, teds
 
 _T = "<table><tr><td>Item</td><td>Qty</td></tr><tr><td>Widget</td><td>3</td></tr></table>"
 
@@ -32,3 +32,33 @@ def test_colspan_mismatch_penalized():
 def test_cell_count():
     assert cell_count(_T) == 4
     assert cell_count("<table></table>") == 0
+
+
+def test_structure_only_ignores_text():
+    changed = _T.replace("<td>3</td>", "<td>999</td>").replace("<td>Item</td>", "<td>zzz</td>")
+    assert teds(_T, changed, structure_only=True) == 1.0
+    assert teds(_T, changed) < 1.0
+
+
+def test_structure_only_penalizes_grid_change():
+    dropped_col = "<table><tr><td>Item</td></tr><tr><td>Widget</td></tr></table>"
+    assert teds(_T, dropped_col, structure_only=True) < 1.0
+
+
+def test_cell_content_f1_identical():
+    assert cell_content_f1(_T, _T) == 1.0
+
+
+def test_cell_content_f1_structure_independent():
+    flat = ("<table><tr><td>Item</td></tr><tr><td>Qty</td></tr>"
+            "<tr><td>Widget</td></tr><tr><td>3</td></tr></table>")
+    assert cell_content_f1(_T, flat) == 1.0
+
+
+def test_cell_content_f1_disjoint_is_zero():
+    other = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+    assert cell_content_f1(_T, other) == 0.0
+
+
+def test_cell_content_f1_one_empty_is_zero():
+    assert cell_content_f1(_T, "<table></table>") == 0.0

--- a/docs/superpowers/plans/2026-07-09-parser-eval-table-diagnostics.md
+++ b/docs/superpowers/plans/2026-07-09-parser-eval-table-diagnostics.md
@@ -1,0 +1,662 @@
+# Parser Eval — Table Diagnostics + Robust Matching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Match ground-truth tables to parsed tables by page + content (order-independent), emit `teds_struct` and `cell_content_f1` diagnostics alongside `teds`, and surface a per-table structure-vs-content breakdown on run detail.
+
+**Architecture:** A new pure `table_match` module buckets tables by page and greedily pairs them by TEDS. `teds.py` gains a `structure_only` flag and a `cell_content_f1` function. `score_table` is rewritten to match, then compute three metrics per matched pair (size-weighted aggregate) plus an enriched `details.per_table`. Frontend adds two metric columns and an expandable per-table diagnostics row. No schema or `expected`-shape change.
+
+**Tech Stack:** Backend — Python 3.12, `apted` (existing), pytest on SQLite. Frontend — React 18, TypeScript, shadcn/ui, Vitest + Testing Library (happy-dom).
+
+## Global Constraints
+
+- **No schema / migration / `expected`-shape change.** `expected.tables[]` stays `{page, html}`; results keep the free-form `metrics` map + `details` JSON.
+- **`emits` for `table` becomes** `("teds", "teds_struct", "cell_content_f1", "table_recall")`; **primary stays `teds`**.
+- **Aggregation** for `teds`, `teds_struct`, `cell_content_f1`: size-weighted mean, weight = `max(cell_count(gt), cell_count(parsed), 1)`; unmatched tables contribute 0. `table_recall` unchanged: `min(parsed, expected)/expected` (`expected==0` → 1.0 if none parsed else 0.0).
+- **Page convention:** GT `page` is 1-based; `extract_cdm_tables` returns 0-based `page_index`. The matcher normalises parsed to 1-based (`page_index + 1`). `Block.page_index` is required; GT `page` is required — bucketing is always defined.
+- **Bbox is not used** (GT has no coordinates; scoring is GT-vs-one-parser). Matching is page + content only.
+- **Scope:** `table` dimension only. No change to `text` dimension, authoring, bootstrap, or the grid editor. No thresholds/profiles (deferred Judgment layer).
+- **Test commands:** backend `cd backend && uv run python -m pytest -o "addopts=" <path> -v`; frontend `cd frontend && npx vitest run <path>` (run from the `frontend` dir).
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `backend/app/services/parser_eval/scorers/teds.py` — add `structure_only` flag + `cell_content_f1`.
+- Create `backend/app/services/parser_eval/scorers/table_match.py` — page+content matcher.
+- Modify `backend/app/services/parser_eval/scorers/table.py` — rewrite `score_table`.
+- Modify `backend/app/services/parser_eval/scorers/__init__.py` — update `emits`.
+- Tests: additions to `backend/tests/services/parser_eval/test_teds.py`, `test_table_scorer.py`; new `test_table_match.py`.
+
+**Frontend**
+- Modify `frontend/src/components/parser-eval/ParserComparisonTable.tsx` — columns + expandable per-table diagnostics.
+- Test: additions to `frontend/src/components/parser-eval/ParserComparisonTable.test.tsx`.
+
+---
+
+## Task 1: TEDS structure-only flag + cell_content_f1
+
+**Files:**
+- Modify: `backend/app/services/parser_eval/scorers/teds.py`
+- Test: `backend/tests/services/parser_eval/test_teds.py`
+
+**Interfaces:**
+- Consumes: existing `_parse`, `_normalize`, `_count`, `_Node`, `APTED`, `_TedsConfig`.
+- Produces:
+  - `teds(html_a: str, html_b: str, *, structure_only: bool = False) -> float`
+  - `cell_content_f1(html_a: str, html_b: str) -> float`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/services/parser_eval/test_teds.py`:
+
+```python
+from app.services.parser_eval.scorers.teds import cell_content_f1
+
+
+def test_structure_only_ignores_text():
+    changed = _T.replace("<td>3</td>", "<td>999</td>").replace("<td>Item</td>", "<td>zzz</td>")
+    assert teds(_T, changed, structure_only=True) == 1.0
+    assert teds(_T, changed) < 1.0
+
+
+def test_structure_only_penalizes_grid_change():
+    dropped_col = "<table><tr><td>Item</td></tr><tr><td>Widget</td></tr></table>"
+    assert teds(_T, dropped_col, structure_only=True) < 1.0
+
+
+def test_cell_content_f1_identical():
+    assert cell_content_f1(_T, _T) == 1.0
+
+
+def test_cell_content_f1_structure_independent():
+    flat = ("<table><tr><td>Item</td></tr><tr><td>Qty</td></tr>"
+            "<tr><td>Widget</td></tr><tr><td>3</td></tr></table>")
+    assert cell_content_f1(_T, flat) == 1.0
+
+
+def test_cell_content_f1_disjoint_is_zero():
+    other = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+    assert cell_content_f1(_T, other) == 0.0
+
+
+def test_cell_content_f1_one_empty_is_zero():
+    assert cell_content_f1(_T, "<table></table>") == 0.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_teds.py -k "structure_only or cell_content_f1" -v`
+Expected: FAIL — `ImportError: cannot import name 'cell_content_f1'`.
+
+- [ ] **Step 3: Add `structure_only` to `_TedsConfig` and `teds`**
+
+In `backend/app/services/parser_eval/scorers/teds.py`, replace the `_TedsConfig` class and `teds` function with:
+
+```python
+class _TedsConfig(Config):
+    def __init__(self, structure_only: bool = False):
+        self.structure_only = structure_only
+
+    def children(self, node):
+        return node.children
+
+    def insert(self, node):
+        return 1.0
+
+    def delete(self, node):
+        return 1.0
+
+    def rename(self, node1, node2):
+        if (node1.tag != node2.tag or node1.colspan != node2.colspan
+                or node1.rowspan != node2.rowspan):
+            return 1.0
+        if self.structure_only:
+            return 0.0
+        if node1.tag in ("td", "th") and node1.text != node2.text:
+            return 1.0 - difflib.SequenceMatcher(None, node1.text, node2.text).ratio()
+        return 0.0
+
+
+def teds(html_a: str, html_b: str, *, structure_only: bool = False) -> float:
+    tree_a, tree_b = _parse(html_a), _parse(html_b)
+    denom = max(_count(tree_a), _count(tree_b))
+    if denom == 0:
+        return 1.0
+    distance = APTED(tree_a, tree_b, _TedsConfig(structure_only)).compute_edit_distance()
+    return max(0.0, 1.0 - distance / denom)
+```
+
+- [ ] **Step 4: Add `cell_content_f1`**
+
+Add `from collections import Counter` to the imports at the top of `teds.py`, then append at the end of the file:
+
+```python
+def _cell_texts(html: str) -> Counter:
+    root = _parse(html)  # _parse already normalizes each cell's text
+    return Counter(cell.text for row in root.children for cell in row.children
+                   if cell.tag in ("td", "th"))
+
+
+def cell_content_f1(html_a: str, html_b: str) -> float:
+    a, b = _cell_texts(html_a), _cell_texts(html_b)
+    total = sum(a.values()) + sum(b.values())
+    if total == 0:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    intersection = sum((a & b).values())  # multiset intersection
+    return 2 * intersection / total
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_teds.py -v`
+Expected: PASS (existing + 6 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/parser_eval/scorers/teds.py backend/tests/services/parser_eval/test_teds.py
+git commit -m "feat(parser-eval): teds structure_only flag + cell_content_f1"
+```
+
+---
+
+## Task 2: Page + content table matcher
+
+**Files:**
+- Create: `backend/app/services/parser_eval/scorers/table_match.py`
+- Test: `backend/tests/services/parser_eval/test_table_match.py`
+
+**Interfaces:**
+- Consumes: `teds` (Task 1).
+- Produces: `match_tables(expected: list[dict], parsed: list[tuple[int, str]]) -> list[tuple[int | None, int | None]]` — returns `(expected_index, parsed_index)` pairs: matched pairs and missing GT tables (`(i, None)`) in `expected_index` order, then extra parsed tables (`(None, j)`) in `parsed_index` order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/services/parser_eval/test_table_match.py`:
+
+```python
+from app.services.parser_eval.scorers.table_match import match_tables
+
+A = "<table><tr><td>a</td><td>b</td></tr></table>"
+B = "<table><tr><td>c</td><td>d</td></tr></table>"
+
+
+def test_identity_order():
+    expected = [{"page": 1, "html": A}, {"page": 1, "html": B}]
+    assert match_tables(expected, [(0, A), (0, B)]) == [(0, 0), (1, 1)]
+
+
+def test_reversed_parsed_matches_by_content():
+    expected = [{"page": 1, "html": A}, {"page": 1, "html": B}]
+    assert match_tables(expected, [(0, B), (0, A)]) == [(0, 1), (1, 0)]
+
+
+def test_missing_gt_table():
+    expected = [{"page": 1, "html": A}, {"page": 1, "html": B}]
+    assert match_tables(expected, [(0, A)]) == [(0, 0), (1, None)]
+
+
+def test_extra_parsed_table():
+    expected = [{"page": 1, "html": A}]
+    assert match_tables(expected, [(0, A), (0, B)]) == [(0, 0), (None, 1)]
+
+
+def test_pages_do_not_cross_match():
+    # GT page 1, parsed page_index 2 -> page 3: different buckets, no match.
+    assert match_tables([{"page": 1, "html": A}], [(2, A)]) == [(0, None), (None, 0)]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_table_match.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the matcher**
+
+Create `backend/app/services/parser_eval/scorers/table_match.py`:
+
+```python
+"""Match ground-truth tables to parsed tables by page bucket + content similarity.
+
+Slice 3: replaces Slice 1's order-based matching. Within each page, greedily pair
+the highest-TEDS GT/parsed tables; leftovers are missing (GT) or extra (parsed).
+Page is the only locator shared by both sides — GT is authored HTML with no bbox.
+"""
+from __future__ import annotations
+
+from app.services.parser_eval.scorers.teds import teds
+
+
+def match_tables(expected: list[dict],
+                 parsed: list[tuple[int, str]]) -> list[tuple[int | None, int | None]]:
+    exp_by_page: dict[int, list[int]] = {}
+    for i, t in enumerate(expected):
+        exp_by_page.setdefault(int(t.get("page", 0)), []).append(i)
+    par_by_page: dict[int, list[int]] = {}
+    for j, (page_index, _html) in enumerate(parsed):
+        par_by_page.setdefault(page_index + 1, []).append(j)
+
+    matched: list[tuple[int, int]] = []
+    used_exp: set[int] = set()
+    used_par: set[int] = set()
+    for page in sorted(set(exp_by_page) | set(par_by_page)):
+        pairs = [(teds(expected[ei]["html"], parsed[pj][1]), ei, pj)
+                 for ei in exp_by_page.get(page, [])
+                 for pj in par_by_page.get(page, [])]
+        pairs.sort(key=lambda p: (-p[0], p[1], p[2]))  # best first, deterministic ties
+        for _score, ei, pj in pairs:
+            if ei in used_exp or pj in used_par:
+                continue
+            used_exp.add(ei)
+            used_par.add(pj)
+            matched.append((ei, pj))
+
+    result: list[tuple[int | None, int | None]] = [
+        (i, next((p for e, p in matched if e == i), None)) for i in range(len(expected))
+    ]
+    result.extend((None, j) for j in range(len(parsed)) if j not in used_par)
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_table_match.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parser_eval/scorers/table_match.py backend/tests/services/parser_eval/test_table_match.py
+git commit -m "feat(parser-eval): page+content table matcher (order-independent)"
+```
+
+---
+
+## Task 3: Rewrite `score_table` + register new metrics
+
+**Files:**
+- Modify: `backend/app/services/parser_eval/scorers/table.py`
+- Modify: `backend/app/services/parser_eval/scorers/__init__.py`
+- Test: `backend/tests/services/parser_eval/test_table_scorer.py`
+
+**Interfaces:**
+- Consumes: `match_tables` (Task 2); `teds`, `cell_content_f1`, `cell_count` (Task 1); `extract_cdm_tables` (existing).
+- Produces: `score_table(cdm, expected) -> (metrics, details)` emitting `teds`, `teds_struct`, `cell_content_f1`, `table_recall`; `details.per_table[]` entries `{expected_index, parsed_index, page, status, teds, teds_struct, cell_content_f1}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `backend/tests/services/parser_eval/test_table_scorer.py` — first update the registry assertion, then add new tests. Replace the body of `test_registered_in_scorers`:
+
+```python
+def test_registered_in_scorers():
+    spec = get_scorer("table")
+    assert spec.primary == "teds"
+    assert set(spec.emits) == {"teds", "teds_struct", "cell_content_f1", "table_recall"}
+```
+
+Then append:
+
+```python
+def _doc_pages(tables):  # tables: list[(page_index, html)]
+    blocks = [Block(id=f"b{i}", role=BlockRole.TABLE, native_type="table",
+                    page_index=pi, reading_order=i, table=Table(rows=1, cols=2, cells=[], html=h))
+              for i, (pi, h) in enumerate(tables)]
+    return ParsedDocument(id="d", source_document_id="s", parse_run_id="r",
+                          page_count=3, pages=[Page(index=0), Page(index=1), Page(index=2)],
+                          blocks=blocks)
+
+
+def test_extra_spurious_table_does_not_shift_matches():
+    t1 = "<table><tr><td>a</td><td>b</td></tr></table>"
+    t2 = "<table><tr><td>c</td><td>d</td></tr></table>"
+    spurious = "<table><tr><td>zzz</td></tr></table>"
+    expected = {"tables": [{"page": 1, "html": t1}, {"page": 1, "html": t2}]}
+    doc = _doc(Table(rows=1, cols=2, cells=[], html=t1),
+               Table(rows=1, cols=1, cells=[], html=spurious),
+               Table(rows=1, cols=2, cells=[], html=t2))
+    _metrics, details = score_table(doc, expected)
+    matched = [e for e in details["per_table"] if e["status"] == "matched"]
+    assert len(matched) == 2
+    assert all(e["teds"] == 1.0 for e in matched)
+
+
+def test_emits_structure_and_content_axes():
+    gt = "<table><tr><td>Item</td><td>Qty</td></tr><tr><td>Widget</td><td>3</td></tr></table>"
+    text_wrong = "<table><tr><td>xxx</td><td>yyy</td></tr><tr><td>zzz</td><td>9</td></tr></table>"
+    doc = _doc(Table(rows=2, cols=2, cells=[], html=text_wrong))
+    metrics, _ = score_table(doc, {"tables": [{"page": 1, "html": gt}]})
+    assert metrics["teds_struct"] == 1.0
+    assert metrics["cell_content_f1"] < 0.5
+
+
+def test_details_per_table_carries_axes_and_status():
+    doc = _doc(Table(rows=2, cols=2, cells=[], html=_HTML))
+    _metrics, details = score_table(doc, {"tables": [{"page": 1, "html": _HTML}]})
+    entry = details["per_table"][0]
+    assert entry["status"] == "matched"
+    assert entry["page"] == 1
+    assert entry["expected_index"] == 0 and entry["parsed_index"] == 0
+    assert entry["teds"] == 1.0 and entry["teds_struct"] == 1.0 and entry["cell_content_f1"] == 1.0
+
+
+def test_cross_page_matching():
+    t1 = "<table><tr><td>a</td></tr></table>"
+    t2 = "<table><tr><td>b</td></tr></table>"
+    expected = {"tables": [{"page": 1, "html": t1}, {"page": 2, "html": t2}]}
+    doc = _doc_pages([(0, t1), (1, t2)])
+    metrics, _ = score_table(doc, expected)
+    assert metrics["teds"] == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_table_scorer.py -v`
+Expected: FAIL — new metrics/details fields absent; registry assertion mismatch.
+
+- [ ] **Step 3: Update the registry**
+
+In `backend/app/services/parser_eval/scorers/__init__.py`, replace the `"table"` entry:
+
+```python
+    "table": ScorerSpec(fn=score_table,
+                        emits=("teds", "teds_struct", "cell_content_f1", "table_recall"),
+                        primary="teds"),
+```
+
+- [ ] **Step 4: Rewrite `score_table`**
+
+Replace the entire contents of `backend/app/services/parser_eval/scorers/table.py` with:
+
+```python
+"""Table scorer — matches GT tables to parsed tables by page+content, then scores each pair.
+
+Emits `teds` (primary), `teds_struct` (structure-only), `cell_content_f1` (content-only),
+and `table_recall`. Aggregates the TEDS-family metrics as a size-weighted mean over matched
+pairs; unmatched tables (missing or extra) contribute 0. Matching is order-independent
+(Slice 3), replacing Slice 1's positional matching.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.cdm.models import ParsedDocument
+from app.services.parser_eval.scorers.table_match import match_tables
+from app.services.parser_eval.scorers.teds import cell_content_f1, cell_count, teds
+from app.services.parser_eval.table_html import extract_cdm_tables
+
+_ZERO = {"teds": 0.0, "teds_struct": 0.0, "cell_content_f1": 0.0}
+
+
+def score_table(cdm: ParsedDocument, expected: dict[str, Any]) -> tuple[dict[str, float], dict]:
+    expected_tables = expected.get("tables", [])
+    parsed = extract_cdm_tables(cdm)  # list[(page_index, html)]
+    pairs = match_tables(expected_tables, parsed)
+
+    per_table: list[dict[str, Any]] = []
+    acc = {"teds": 0.0, "teds_struct": 0.0, "cell_content_f1": 0.0}
+    total_weight = 0.0
+    for ei, pj in pairs:
+        gt_html = expected_tables[ei]["html"] if ei is not None else None
+        par_html = parsed[pj][1] if pj is not None else None
+        if ei is not None and pj is not None:
+            scores = {"teds": teds(gt_html, par_html),
+                      "teds_struct": teds(gt_html, par_html, structure_only=True),
+                      "cell_content_f1": cell_content_f1(gt_html, par_html)}
+            status = "matched"
+            page = int(expected_tables[ei].get("page", 0))
+        elif ei is not None:
+            scores, status = dict(_ZERO), "missing"
+            page = int(expected_tables[ei].get("page", 0))
+        else:
+            scores, status = dict(_ZERO), "extra"
+            page = parsed[pj][0] + 1
+
+        weight = max(cell_count(gt_html) if gt_html else 0,
+                     cell_count(par_html) if par_html else 0, 1)
+        for k in acc:
+            acc[k] += scores[k] * weight
+        total_weight += weight
+        per_table.append({"expected_index": ei, "parsed_index": pj, "page": page,
+                          "status": status, **scores})
+
+    if total_weight:
+        metrics = {k: acc[k] / total_weight for k in acc}
+    else:
+        metrics = {"teds": 1.0, "teds_struct": 1.0, "cell_content_f1": 1.0}
+
+    expected_count = len(expected_tables)
+    parsed_count = len(parsed)
+    if expected_count == 0:
+        metrics["table_recall"] = 1.0 if parsed_count == 0 else 0.0
+    else:
+        metrics["table_recall"] = min(parsed_count, expected_count) / expected_count
+
+    details = {"per_table": per_table,
+               "expected_count": expected_count, "parsed_count": parsed_count}
+    return metrics, details
+```
+
+- [ ] **Step 5: Run the full parser-eval scorer + registry tests**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parser_eval/test_table_scorer.py -v`
+Expected: PASS (existing 7 kept green + 4 new).
+
+- [ ] **Step 6: Run the full parser-eval backend suite (no regressions)**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/ -k parser_eval`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/parser_eval/scorers/table.py backend/app/services/parser_eval/scorers/__init__.py backend/tests/services/parser_eval/test_table_scorer.py
+git commit -m "feat(parser-eval): order-independent scoring + teds_struct/cell_content_f1 diagnostics"
+```
+
+---
+
+## Task 4: Frontend — diagnostic columns + per-table drill-down
+
+**Files:**
+- Modify: `frontend/src/components/parser-eval/ParserComparisonTable.tsx`
+- Test: `frontend/src/components/parser-eval/ParserComparisonTable.test.tsx`
+
+**Interfaces:**
+- Consumes: `ParserEvalResult.metrics` (`teds_struct`, `cell_content_f1`) and `ParserEvalResult.details.per_table` (Task 3).
+- Produces: table-dimension comparison rows with Structure/Content columns and an expandable per-table diagnostics row.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/components/parser-eval/ParserComparisonTable.test.tsx` (inside the `describe`), and add `fireEvent` to the testing-library import (`import { render, screen, within, fireEvent } from '@testing-library/react'`):
+
+```tsx
+it('shows structure/content columns and expands per-table diagnostics for a table case', () => {
+  const r = one({
+    metrics: { teds: 0.9, teds_struct: 1.0, cell_content_f1: 0.8, table_recall: 1 },
+    primaryMetric: 'teds',
+    details: {
+      per_table: [{ expected_index: 0, parsed_index: 0, page: 3, status: 'matched',
+        teds: 0.9, teds_struct: 1.0, cell_content_f1: 0.8 }],
+      expected_count: 1, parsed_count: 1,
+    },
+  })
+  render(<ParserComparisonTable results={[r]} caseLabels={{ c1: 'a.pdf' }}
+    caseDimensions={{ c1: 'table' }} />)
+  expect(screen.getByText('Structure')).toBeInTheDocument()
+  expect(screen.getByText('Content')).toBeInTheDocument()
+  fireEvent.click(screen.getByRole('button', { name: /diagnostics/i }))
+  expect(screen.getByText(/page 3/i)).toBeInTheDocument()
+  expect(screen.getByText(/matched/i)).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/ParserComparisonTable.test.tsx`
+Expected: FAIL — no Structure/Content columns, no diagnostics button.
+
+- [ ] **Step 3: Add the two columns**
+
+In `frontend/src/components/parser-eval/ParserComparisonTable.tsx`, replace the `table` entry of `METRIC_COLUMNS`:
+
+```ts
+  table: {
+    primary: { key: 'teds', label: 'TEDS' },
+    rest: [
+      { key: 'teds_struct', label: 'Structure' },
+      { key: 'cell_content_f1', label: 'Content' },
+      { key: 'table_recall', label: 'Table recall' },
+    ],
+  },
+```
+
+- [ ] **Step 4: Add the expandable per-table diagnostics**
+
+In the same file: add `Fragment` and `useState` to the React import (`import { Fragment, useState } from 'react'`), and a `PerTable` type + expansion state. Replace the component body so each table-dimension row carries a toggle and an optional detail row.
+
+Add near the top (after the imports):
+
+```tsx
+interface PerTable {
+  expected_index: number | null
+  parsed_index: number | null
+  page: number | null
+  status: string
+  teds: number
+  teds_struct: number
+  cell_content_f1: number
+}
+```
+
+Inside `ParserComparisonTable`, add expansion state right after the `byCase` map is built:
+
+```tsx
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const toggle = (key: string) => setExpanded((prev) => {
+    const next = new Set(prev)
+    next.has(key) ? next.delete(key) : next.add(key)
+    return next
+  })
+```
+
+Replace the `<TableRow key={r.variantKey} ...>` block (the mapped variant row) with a fragment that renders the row plus an optional diagnostics row:
+
+```tsx
+                {sorted.map((r) => {
+                  const perTable = (r.details?.per_table as PerTable[] | undefined) ?? []
+                  const canExpand = dimension === 'table' && perTable.length > 0
+                  const isOpen = expanded.has(r.variantKey)
+                  const colSpan = 2 + cols.rest.length + 2
+                  return (
+                    <Fragment key={r.variantKey}>
+                      <TableRow data-testid="cmp-row">
+                        <TableCell>
+                          {canExpand && (
+                            <button type="button" aria-label="Toggle diagnostics"
+                              className="mr-1 text-muted-foreground hover:text-foreground"
+                              onClick={() => toggle(r.variantKey)}>{isOpen ? '▾' : '▸'}</button>
+                          )}
+                          {adapterLabel(r.adapter)}
+                        </TableCell>
+                        <TableCell><ScorePill score={r.metrics[cols.primary.key] ?? null} /></TableCell>
+                        {cols.rest.map((c) => <TableCell key={c.key}>{pct(r.metrics[c.key])}</TableCell>)}
+                        <TableCell>{fmtCost(r.cost)}</TableCell>
+                        <TableCell>{fmtLatency(r.latencyMs)}</TableCell>
+                      </TableRow>
+                      {canExpand && isOpen && (
+                        <TableRow>
+                          <TableCell colSpan={colSpan} className="bg-muted/30">
+                            <table className="w-full text-xs">
+                              <thead>
+                                <tr className="text-muted-foreground">
+                                  <th className="py-1 text-left">Table</th>
+                                  <th className="text-left">TEDS</th>
+                                  <th className="text-left">Structure</th>
+                                  <th className="text-left">Content</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {perTable.map((t, i) => (
+                                  <tr key={i}>
+                                    <td className="py-1">Page {t.page ?? '—'} · {t.status}</td>
+                                    <td>{pct(t.teds)}</td>
+                                    <td>{pct(t.teds_struct)}</td>
+                                    <td>{pct(t.cell_content_f1)}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  )
+                })}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval/ParserComparisonTable.test.tsx`
+Expected: PASS (existing 3 + new 1).
+
+- [ ] **Step 6: Lint + build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: no errors. (If lint flags the ternary in `toggle` as an unused-expression, convert it to an `if/else`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/parser-eval/ParserComparisonTable.tsx frontend/src/components/parser-eval/ParserComparisonTable.test.tsx
+git commit -m "feat(parser-eval): structure/content columns + per-table diagnostics drill-down"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend parser-eval suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/ -k parser_eval`
+Expected: PASS.
+
+- [ ] **Step 2: Frontend parser-eval suite**
+
+Run: `cd frontend && npx vitest run src/components/parser-eval`
+Expected: PASS.
+
+- [ ] **Step 3: Frontend lint + build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: no errors.
+
+- [ ] **Step 4: Manual smoke (documented; run if a stack is up)**
+
+1. Run a table-dimension case across ≥2 parser variants.
+2. On run detail, confirm the table comparison shows TEDS / Structure / Content / Table recall columns.
+3. Expand a variant row → per-table breakdown lists each ground-truth table with page, status, and the three scores.
+4. Sanity: a parser that emits an extra/misordered table still scores its real tables correctly (no order penalty).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Page-bucketed content-similarity matching, bbox dropped → Task 2. ✓
+- `teds_struct` (structure_only), `cell_content_f1` (multiset F1) → Task 1. ✓
+- `score_table` emits 4 metrics, size-weighted aggregate, enriched `details.per_table` → Task 3. ✓
+- Registry `emits` update, primary `teds` → Task 3. ✓
+- FE Structure/Content columns + per-table drill-down → Task 4. ✓
+- Page convention (1-based GT vs 0-based page_index) → Task 2 matcher + Task 3 `page` derivation. ✓
+- `table_recall` unchanged → Task 3. ✓
+- Out of scope (text dimension, authoring, thresholds, bbox) → untouched. ✓
+
+**Placeholder scan:** none — every code step carries full code.
+
+**Type consistency:** `match_tables(expected, parsed) -> list[tuple[int|None, int|None]]` defined in Task 2 and consumed in Task 3 with matching destructuring `for ei, pj in pairs`. `teds(..., structure_only=...)` and `cell_content_f1(a, b)` defined in Task 1 and used in Task 3. FE `PerTable` fields (`page`, `status`, `teds`, `teds_struct`, `cell_content_f1`) match the backend `details.per_table` entry keys from Task 3. `cols.rest.length` used for `colSpan` matches the 3-entry `rest` added in Task 4 Step 3.

--- a/docs/superpowers/specs/2026-07-09-parser-eval-table-diagnostics-spec.md
+++ b/docs/superpowers/specs/2026-07-09-parser-eval-table-diagnostics-spec.md
@@ -1,0 +1,251 @@
+# Parser Eval — Slice 3: Table Diagnostics + Robust Matching
+
+**Date:** 2026-07-09
+**Status:** Draft for review
+**Author:** brainstorming session (asanyaga)
+**Feature branch:** `feat/parser-eval-table-diagnostics` (suggested)
+**Parent design:** [Parser Eval — Table Dimension Design](2026-07-07-parser-eval-table-dimension-design.md) (Slice 3)
+**Builds on:** Slice 1 (PR #151, TEDS scoring + bootstrap authoring) and Slice 2 (PR #153, grid editor).
+
+---
+
+## Purpose
+
+Slice 1's table scorer answers *"how good is this parser's table extraction?"* with a single `teds`
+number, but two problems blunt it:
+
+1. **A low `teds` isn't diagnosable.** Is the parser getting the *grid shape* wrong (merged/split/missed
+   cells) or the *text* wrong (OCR errors)? One number can't say.
+2. **Order-based matching is unfair.** Slice 1 compares the i-th ground-truth table to the i-th parsed
+   table. A parser that emits tables in a different order than authored is penalised for a difference
+   that doesn't exist.
+
+Slice 3 fixes both: **robust page-and-content matching** (so a table is compared to its true
+counterpart regardless of extraction order) and **two diagnostic metrics** (`teds_struct`,
+`cell_content_f1`) that decompose `teds` into a structure axis and a content axis, surfaced per-table on
+run detail.
+
+---
+
+## Scope
+
+Delivered end-to-end (backend + frontend) as one slice: robust matching, the two diagnostics, and the
+run-detail diagnostic view.
+
+### Decisions locked in brainstorming (2026-07-09)
+
+1. **Matching = page-bucketed content-similarity assignment.** Bucket ground-truth and parsed tables by
+   `page`; within each page, compute TEDS for every GT×parsed pair and greedily assign highest-TEDS
+   pairs first (each table used once). Unmatched tables on either side score 0. Robust to extraction
+   order (cross-page *and* within-page), uses only signals that reliably exist, and page-gating keeps
+   it cheap and prevents cross-page mis-pairs.
+2. **`teds_struct` (structure-only)** — TEDS with cell text blanked, so edit cost depends only on
+   `tag`/`colspan`/`rowspan`. Implemented as a `structure_only` flag on the existing `teds()`.
+3. **`cell_content_f1` (content-only)** — multiset F1 over normalised cell texts of a matched pair:
+   `2·|GT ∩ parsed| / (|GT| + |parsed|)`, structure-independent. Multiset so duplicate values count
+   faithfully. `1.0` if both empty, `0.0` if exactly one empty.
+4. **`emits` becomes** `("teds", "teds_struct", "cell_content_f1", "table_recall")`; **primary stays
+   `teds`**. Aggregation for all three TEDS-family metrics is unchanged from Slice 1 — size-weighted
+   mean (weight = larger cell count of the pair), unmatched tables contribute 0.
+5. **Frontend = aggregate columns + per-table drill-down.** Add `teds_struct` and `cell_content_f1`
+   columns to the table-dimension comparison table, and an expandable per-(case, variant) breakdown
+   listing each ground-truth table with its page, matched/missing status, and three scores.
+
+### Correction to the parent design (surfaced explicitly)
+
+The parent design said matching would use "`bbox`/`page` when available." **Bbox is not usable here and
+is dropped from Slice 3.** The scoring unit is always *ground truth vs. one parser* (each variant scored
+independently against the same GT), never parser-vs-parser. Ground truth is authored HTML carrying only
+`{page, html}` — it has **no bounding boxes**. So the only cross-side signals are `page` (both sides)
+and content similarity (TEDS). `Block.bbox` on the parsed side has no GT counterpart to overlap against,
+so it plays no role. Matching is therefore page + content, not spatial.
+
+### Non-goals
+
+- Thresholds / pass-fail / weighted profiles on any metric — Judgment/Selection layer (seam #5),
+  deferred for all dimensions. `table_recall` stays a coverage proxy (`min(parsed, expected)/expected`).
+- Bbox/spatial matching (dropped — see above).
+- Diagnostics for the `text` dimension — unchanged.
+- Changes to authoring, bootstrap, or the grid editor (Slice 2).
+
+---
+
+## Data model — no changes
+
+No schema, migration, or `expected` shape change. `expected.tables[]` stays `{page, html}`; results
+still carry a free-form `metrics` map + `details` JSON. Slice 3 only changes what the scorer *computes*
+and what the FE *renders*.
+
+**Page convention (made explicit):** GT `page` is 1-based (bootstrap stored `page_index + 1`);
+`extract_cdm_tables` returns 0-based `page_index`. The matcher normalises the parsed side to 1-based
+(`page_index + 1`) so buckets line up. `Block.page_index` is a required field, so every parsed table has
+a page; GT `page` is required by the schema — page-bucketing is always well-defined.
+
+---
+
+## Backend
+
+### Matching — `backend/app/services/parser_eval/scorers/table_match.py` (new)
+
+Small, pure, independently testable module.
+
+`match_tables(expected: list[dict], parsed: list[tuple[int, str]]) -> list[tuple[int | None, int | None]]`
+
+- `expected` is `expected.tables` (each `{page, html}`); `parsed` is the `(page_index, html)` list from
+  `extract_cdm_tables`.
+- Bucket both sides by 1-based page (`parsed` normalised via `page_index + 1`).
+- For each page present in either bucket: compute `teds(gt_html, parsed_html)` for all pairs in that
+  page, sort pairs by descending TEDS (tie-break by `(expected_index, parsed_index)` for determinism),
+  and greedily assign — a pair is taken if both members are still free.
+- Emit one tuple per matched pair `(expected_index, parsed_index)`, one per unmatched GT table
+  `(expected_index, None)`, and one per unmatched parsed table `(None, parsed_index)`.
+- Ordering of the returned list: matched/missing in `expected_index` order, then extras in
+  `parsed_index` order (stable, for readable details).
+
+The matcher computes TEDS only to *decide* pairing; `score_table` recomputes the three metrics for the
+chosen pairs (the extra TEDS pass is negligible for realistic table counts).
+
+### TEDS additions — `backend/app/services/parser_eval/scorers/teds.py`
+
+- **`teds(html_a, html_b, *, structure_only: bool = False) -> float`** — new keyword flag threaded into
+  `_TedsConfig(structure_only=...)`. When set, `rename` ignores cell text: returns `1.0` only when
+  `tag`/`colspan`/`rowspan` differ, else `0.0` (no fractional text cost). Default `False` preserves
+  current behaviour exactly.
+- **`cell_content_f1(html_a, html_b) -> float`** — parse each side (reusing `_parse`, which already
+  `_normalize`s text), collect a `Counter` of cell texts, compute multiset F1
+  `2·Σ min(a[k], b[k]) / (Σa + Σb)`. `1.0` if both bags empty; `0.0` if exactly one is empty.
+
+### Scorer rewrite — `backend/app/services/parser_eval/scorers/table.py`
+
+`score_table(cdm, expected)` becomes:
+
+1. `expected_tables = expected.get("tables", [])`; `parsed = extract_cdm_tables(cdm)`.
+2. `pairs = match_tables(expected_tables, parsed)`.
+3. For each pair compute per-table `teds`, `teds_struct` (`structure_only=True`), `cell_content_f1`
+   (0 for any unmatched side). Weight = `max(cell_count(gt), cell_count(parsed), 1)` where a missing
+   side counts as its present side's cells.
+4. Aggregate each of `teds`, `teds_struct`, `cell_content_f1` as the size-weighted mean over all pairs.
+5. `table_recall = min(len(parsed), len(expected_tables)) / len(expected_tables)` (unchanged;
+   `expected == 0` → `1.0` when no tables parsed else `0.0`).
+6. `metrics = {"teds", "teds_struct", "cell_content_f1", "table_recall"}`.
+7. `details = {"per_table": [...], "expected_count", "parsed_count"}` where each `per_table` entry is:
+
+   ```json
+   {
+     "expected_index": 0,        // null for an extra parsed table
+     "parsed_index": 1,          // null for a missing GT table
+     "page": 3,                  // GT page if matched/missing, else parsed page
+     "status": "matched",        // "matched" | "missing" | "extra"
+     "teds": 0.94,
+     "teds_struct": 1.0,
+     "cell_content_f1": 0.88
+   }
+   ```
+
+### Registry — `backend/app/services/parser_eval/scorers/__init__.py`
+
+```python
+"table": ScorerSpec(fn=score_table,
+                    emits=("teds", "teds_struct", "cell_content_f1", "table_recall"),
+                    primary="teds"),
+```
+
+The engine needs no change — it persists whatever `metrics`/`details` the scorer returns.
+
+---
+
+## Frontend
+
+### Comparison columns — `frontend/src/components/parser-eval/ParserComparisonTable.tsx`
+
+Extend the `table` entry in `METRIC_COLUMNS`:
+
+```ts
+table: {
+  primary: { key: 'teds', label: 'TEDS' },
+  rest: [
+    { key: 'teds_struct', label: 'Structure' },
+    { key: 'cell_content_f1', label: 'Content' },
+    { key: 'table_recall', label: 'Table recall' },
+  ],
+},
+```
+
+The generic metrics map renders these with the existing `pct()` treatment — no other change to the
+aggregate table.
+
+### Per-table drill-down (new)
+
+Each variant row in the table dimension gains an expander. When expanded, render a compact sub-table
+from `result.details.per_table`: one row per entry showing **page**, **status** (matched / missing /
+extra badge), and **TEDS / Structure / Content** scores. This localises which ground-truth table is
+dragging the aggregate down and shows the structure-vs-content split per table. Text-dimension rows have
+no expander (their `details` shape is unchanged and out of scope).
+
+Implementation: a small `TableDiagnosticsRow` (or inline expandable `<tr>`) inside
+`ParserComparisonTable`, gated on `dimension === 'table'` and `result.details?.per_table`. Reuse
+`ScorePill`/`pct` and the existing status-badge styling.
+
+---
+
+## Testing
+
+### Backend
+
+- **`match_tables`:** identical order → identity pairing; reversed parsed order → still pairs by
+  content; a missing GT table → `(idx, None)`; an extra parsed table → `(None, idx)`; two tables on
+  different pages don't cross-match; two tables on the same page pair by best TEDS.
+- **`teds` structure_only:** identical tables → `1.0`; same grid but all cell text changed →
+  `teds_struct == 1.0` while plain `teds < 1.0`; a merged/split cell (colspan change) → `teds_struct < 1`.
+- **`cell_content_f1`:** identical cell bags → `1.0`; same texts in a totally different grid → `1.0`
+  (structure-independent); disjoint texts → `0.0`; multiset duplicates counted; one-empty → `0.0`.
+- **`score_table`:** reordered parsed tables now score the same as in-order (regression vs. Slice 1's
+  order penalty); emits all four metrics; `details.per_table` carries indices, page, status, and three
+  scores; missing/extra tables reflected in aggregate and in `per_table`.
+
+### Frontend
+
+- **`ParserComparisonTable`:** table-dimension rows show Structure and Content columns; expanding a row
+  renders the per-table breakdown from `details.per_table` with page/status/scores; text-dimension rows
+  are unchanged and have no expander. (Light coverage, per FE test pragmatism; happy-dom env.)
+
+---
+
+## Acceptance criteria
+
+- A parser that extracts the correct tables in a different order than authored scores the same `teds` as
+  one that extracts them in order (order no longer penalised), with a test proving it.
+- `score_table` emits `teds`, `teds_struct`, `cell_content_f1`, and `table_recall`; `teds_struct`
+  isolates structure (high when the grid is right regardless of text) and `cell_content_f1` isolates
+  content (high when text is right regardless of grid), with tests proving each axis.
+- `details.per_table` carries, per ground-truth (and extra parsed) table, its page, matched/missing/extra
+  status, and the three scores.
+- On run detail, the table comparison shows Structure and Content columns, and each variant row expands
+  to a per-table breakdown surfacing which table is weak and on which axis.
+
+---
+
+## Risks / open considerations
+
+- **Content-matching self-reference.** The matcher uses TEDS to choose pairings and then reports TEDS for
+  those pairings — self-consistent, but two near-identical tables on one page could be paired differently
+  than a human would. Low risk given page-gating and that such duplicates are rare; if it ever bites,
+  a page+order tiebreaker within equal-TEDS pairs is an easy refinement.
+- **Cost.** Matching computes TEDS for all same-page GT×parsed pairs, then `score_table` recomputes three
+  metrics for chosen pairs. For realistic per-page table counts (≤ ~3) this is a handful of APTED runs
+  per (case, variant); acceptable. If a pathological page ever holds many tables, capping per-page pair
+  computation is a future guard.
+- **`table_recall` unchanged.** Still a blunt coverage proxy; turning "matched above a threshold" into a
+  pass/fail belongs to the deferred Judgment layer, not here.
+- **Aggregate comparability with Slice 1.** For in-order, well-matched cases the aggregate `teds` is
+  numerically unchanged; only mis-ordered cases move (upward, correctly). Note this when comparing old
+  and new run numbers.
+
+---
+
+## What is explicitly NOT in this doc
+
+- Exact per-table breakdown component markup and expander interaction — implementation plan.
+- Judgment/Selection (thresholds, profiles) — seam #5, deferred for all dimensions.
+- Any change to authoring/bootstrap/grid editor, or to the `text` dimension.
+- Bbox/spatial matching (dropped).

--- a/frontend/src/components/parser-eval/ParserComparisonTable.test.tsx
+++ b/frontend/src/components/parser-eval/ParserComparisonTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import { ParserComparisonTable } from './ParserComparisonTable'
 import type { ParserEvalResult } from '@/types/parserEval'
 
@@ -33,6 +33,25 @@ describe('ParserComparisonTable', () => {
       caseLabels={{ c1: 'a.pdf' }} caseDimensions={{ c1: 'table' }} />)
     expect(screen.getByText('TEDS')).toBeInTheDocument()
     expect(screen.getByText('Table recall')).toBeInTheDocument()
+  })
+
+  it('shows structure/content columns and expands per-table diagnostics for a table case', () => {
+    const r = one({
+      metrics: { teds: 0.9, teds_struct: 1.0, cell_content_f1: 0.8, table_recall: 1 },
+      primaryMetric: 'teds',
+      details: {
+        per_table: [{ expected_index: 0, parsed_index: 0, page: 3, status: 'matched',
+          teds: 0.9, teds_struct: 1.0, cell_content_f1: 0.8 }],
+        expected_count: 1, parsed_count: 1,
+      },
+    })
+    render(<ParserComparisonTable results={[r]} caseLabels={{ c1: 'a.pdf' }}
+      caseDimensions={{ c1: 'table' }} />)
+    expect(screen.getByText('Structure')).toBeInTheDocument()
+    expect(screen.getByText('Content')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /diagnostics/i }))
+    expect(screen.getByText(/page 3/i)).toBeInTheDocument()
+    expect(screen.getByText(/matched/i)).toBeInTheDocument()
   })
 
   it('renders text columns for a text case', () => {

--- a/frontend/src/components/parser-eval/ParserComparisonTable.tsx
+++ b/frontend/src/components/parser-eval/ParserComparisonTable.tsx
@@ -1,3 +1,4 @@
+import { Fragment, useState } from 'react'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { ScorePill } from '@/components/evaluation/ScorePill'
 import { PARSER_REGISTRY } from '@/components/documents/ParseMethodSelector'
@@ -8,6 +9,16 @@ interface MetricColumns {
   rest: { key: string; label: string }[]
 }
 
+interface PerTable {
+  expected_index: number | null
+  parsed_index: number | null
+  page: number | null
+  status: string
+  teds: number
+  teds_struct: number
+  cell_content_f1: number
+}
+
 const METRIC_COLUMNS: Record<string, MetricColumns> = {
   text: {
     primary: { key: 'similarity', label: 'Similarity' },
@@ -15,7 +26,11 @@ const METRIC_COLUMNS: Record<string, MetricColumns> = {
   },
   table: {
     primary: { key: 'teds', label: 'TEDS' },
-    rest: [{ key: 'table_recall', label: 'Table recall' }],
+    rest: [
+      { key: 'teds_struct', label: 'Structure' },
+      { key: 'cell_content_f1', label: 'Content' },
+      { key: 'table_recall', label: 'Table recall' },
+    ],
   },
 }
 
@@ -48,6 +63,14 @@ export function ParserComparisonTable({ results, caseLabels, caseDimensions }: P
     byCase.set(r.evalCaseId, arr)
   })
 
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const toggle = (key: string) => setExpanded((prev) => {
+    const next = new Set(prev)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
+
   return (
     <div className="space-y-6">
       {[...byCase.entries()].map(([caseId, rows]) => {
@@ -70,15 +93,56 @@ export function ParserComparisonTable({ results, caseLabels, caseDimensions }: P
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {sorted.map((r) => (
-                  <TableRow key={r.variantKey} data-testid="cmp-row">
-                    <TableCell>{adapterLabel(r.adapter)}</TableCell>
-                    <TableCell><ScorePill score={r.metrics[cols.primary.key] ?? null} /></TableCell>
-                    {cols.rest.map((c) => <TableCell key={c.key}>{pct(r.metrics[c.key])}</TableCell>)}
-                    <TableCell>{fmtCost(r.cost)}</TableCell>
-                    <TableCell>{fmtLatency(r.latencyMs)}</TableCell>
-                  </TableRow>
-                ))}
+                {sorted.map((r) => {
+                  const perTable = (r.details?.per_table as PerTable[] | undefined) ?? []
+                  const canExpand = dimension === 'table' && perTable.length > 0
+                  const isOpen = expanded.has(r.variantKey)
+                  const colSpan = 2 + cols.rest.length + 2
+                  return (
+                    <Fragment key={r.variantKey}>
+                      <TableRow data-testid="cmp-row">
+                        <TableCell>
+                          {canExpand && (
+                            <button type="button" aria-label="Toggle diagnostics"
+                              className="mr-1 text-muted-foreground hover:text-foreground"
+                              onClick={() => toggle(r.variantKey)}>{isOpen ? '▾' : '▸'}</button>
+                          )}
+                          {adapterLabel(r.adapter)}
+                        </TableCell>
+                        <TableCell><ScorePill score={r.metrics[cols.primary.key] ?? null} /></TableCell>
+                        {cols.rest.map((c) => <TableCell key={c.key}>{pct(r.metrics[c.key])}</TableCell>)}
+                        <TableCell>{fmtCost(r.cost)}</TableCell>
+                        <TableCell>{fmtLatency(r.latencyMs)}</TableCell>
+                      </TableRow>
+                      {canExpand && isOpen && (
+                        <TableRow>
+                          <TableCell colSpan={colSpan} className="bg-muted/30">
+                            <table className="w-full text-xs">
+                              <thead>
+                                <tr className="text-muted-foreground">
+                                  <th className="py-1 text-left">Table</th>
+                                  <th className="text-left">TEDS</th>
+                                  <th className="text-left">Structure</th>
+                                  <th className="text-left">Content</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {perTable.map((t, i) => (
+                                  <tr key={i}>
+                                    <td className="py-1">Page {t.page ?? '—'} · {t.status}</td>
+                                    <td>{pct(t.teds)}</td>
+                                    <td>{pct(t.teds_struct)}</td>
+                                    <td>{pct(t.cell_content_f1)}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  )
+                })}
               </TableBody>
             </Table>
           </div>


### PR DESCRIPTION
Closes #154.

Slice 3 of the parser-eval table dimension. Makes a low `teds` diagnosable and stops naive order-based matching from unfairly penalizing parsers.

## What's included

**Backend**
- `teds(..., structure_only=True)` — TEDS with cell text blanked (structure-only axis).
- `cell_content_f1` — multiset F1 over normalized cell texts (content-only axis, structure-independent).
- `scorers/table_match.py` — page-bucketed, content-similarity (greedy TEDS-max) matcher. Order-independent: an extra/missing/misordered parsed table no longer shifts and mis-scores the real tables.
- `score_table` rewrite — matches, then computes `teds` / `teds_struct` / `cell_content_f1` per matched pair (size-weighted aggregate; unmatched → 0), plus `table_recall` (unchanged). Enriched `details.per_table` carries per table: `expected_index`, `parsed_index`, `page`, `status` (matched/missing/extra), and the three scores.
- Registry `emits` → `("teds", "teds_struct", "cell_content_f1", "table_recall")`, primary stays `teds`.

**Frontend**
- `ParserComparisonTable` — Structure and Content columns for table cases, plus an expandable per-(case, variant) drill-down listing each ground-truth table (page, matched/missing/extra, three scores).

## Design decisions (locked in brainstorming)

- Matching = page + content similarity. **Bbox dropped** (correction to parent design): scoring is always ground-truth-vs-one-parser and GT is authored HTML with no coordinates, so there is nothing to overlap against.
- Diagnostics decompose `teds` into a structure axis (`teds_struct`) and a content axis (`cell_content_f1`).
- No thresholds/profiles (deferred Judgment layer); `table_recall` stays a coverage proxy.

## Testing

- Backend: 80 parser-eval tests pass — incl. `structure_only`/`cell_content_f1` axes, matcher (identity/reversed/missing/extra/cross-page), and the headline regression: a spurious extra table no longer shifts matches.
- Frontend: 30 parser-eval tests pass (Structure/Content columns + per-table drill-down). Lint clean, build passes.
- No schema change, no migration, no new dependency.

## References

- Spec: `docs/superpowers/specs/2026-07-09-parser-eval-table-diagnostics-spec.md`
- Plan: `docs/superpowers/plans/2026-07-09-parser-eval-table-diagnostics.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)