### PR TITLE
fix(tests): repair two stale frontend tests

### DIFF
--- a/frontend/src/components/documents/ParseMethodSelector.test.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.test.tsx
@@ -84,7 +84,8 @@ describe('ParseMethodSelector', () => {
       />
     )
     expect(screen.getByText(/fitz \(text \+ images\)/i)).toBeInTheDocument()
-    expect(screen.getByRole('checkbox', { name: /camelot/i })).toBeInTheDocument()
+    // Table tools (fitz_tables / camelot) are chosen via a select, not checkboxes.
+    expect(screen.getByRole('combobox', { name: /table extraction/i })).toBeInTheDocument()
     expect(
       screen.getByText(/Composable tools/i)
     ).toBeInTheDocument()

--- a/frontend/src/components/extraction/SchemaBuilder.test.tsx
+++ b/frontend/src/components/extraction/SchemaBuilder.test.tsx
@@ -52,7 +52,8 @@ describe('SchemaBuilder', () => {
     await user.click(screen.getByRole('tab', { name: /json/i }))
     const textarea = screen.getByRole('textbox')
     await user.clear(textarea)
-    await user.type(textarea, '{bad json')
+    // `{` opens a key descriptor in user-event; `{{` types a literal brace.
+    await user.type(textarea, '{{bad json')
     act(() => { vi.advanceTimersByTime(400) })
     expect(screen.getByText(/invalid json/i)).toBeInTheDocument()
     vi.useRealTimers()


### PR DESCRIPTION
## Summary

Repairs two frontend tests that were failing on `main`. **Both are defects in the tests themselves — no product code was wrong.** They surfaced while verifying #159; I kept them out of that PR so it stayed a pure removal.

## 1. `ParseMethodSelector` — stale assertion after a refactor

```
Unable to find an accessible element with the role "checkbox" and name /camelot/i
```

`CustomPipelineConfig` used to expose table tools (`fitz_tables`, `camelot`) as checkboxes. It was later refactored to a single **"Table extraction"** select. Its own test (`CustomPipelineConfig.test.tsx`) was updated to use `getByRole('combobox', …)`, but `ParseMethodSelector.test.tsx` was missed and still looked for a checkbox that no longer exists.

**Fix:** assert the `Table extraction` combobox instead.

## 2. `SchemaBuilder` — `{` is a user-event control character

```
Expected repeat modifier or release modifier or "}" but found " " in "{bad json"
```

In `@testing-library/user-event` v14, `{` opens a key descriptor (`{Enter}`, `{Shift>}`). So `user.type(textarea, '{bad json')` threw while *parsing the keystrokes* — the component never received the input, and its invalid-JSON branch was never exercised. (The sibling test types `'not valid json'`, with no brace, and passes.)

**Fix:** escape the brace as `'{{bad json'`, which types a literal `{`.

Worth noting: this means `SchemaBuilder`'s invalid-JSON path had effectively never been tested. It passes now that the input actually lands — the component was right all along, but that path only becomes genuinely covered with this change.

## Verification

Rebased onto `main` after #159 merged (which touched `CustomPipelineConfig`), then re-ran the full suite:

- Before: 2 failed, 358 passed
- After: **69/69 files, 360 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
