### PR TITLE
refactor(pipeline): capability slots + N-way capability-aware merger (WS2 PR A)

### DIFF
--- a/backend/app/cdm/adapters/custom_pipeline/__init__.py
+++ b/backend/app/cdm/adapters/custom_pipeline/__init__.py
@@ -6,7 +6,7 @@ from app.cdm.adapters.custom_pipeline.config import (
     build_pipeline_config,
 )
 from app.cdm.adapters.custom_pipeline.merger import MergeResult, merge, overlap_fraction
-from app.cdm.adapters.custom_pipeline.tools.base import LocalTool, PageMeta, ToolResult
+from app.cdm.adapters.custom_pipeline.tools.base import PipelineTool, PageMeta, ToolResult
 from app.cdm.adapters.custom_pipeline.tools.camelot_tool import CamelotTool
 from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool
 
@@ -19,7 +19,7 @@ __all__ = [
     "MergeResult",
     "merge",
     "overlap_fraction",
-    "LocalTool",
+    "PipelineTool",
     "PageMeta",
     "ToolResult",
     "CamelotTool",

--- a/backend/app/cdm/adapters/custom_pipeline/__init__.py
+++ b/backend/app/cdm/adapters/custom_pipeline/__init__.py
@@ -1,27 +1,51 @@
 from app.cdm.adapters.custom_pipeline.adapter import CustomPipelineAdapter
+from app.cdm.adapters.custom_pipeline.capabilities import (
+    BLOCK_PRODUCING,
+    STAGING,
+    Capability,
+    resolve_precedence,
+)
 from app.cdm.adapters.custom_pipeline.config import (
     CamelotConfig,
     FitzConfig,
-    CustomPipelineConfig,
+    FitzTablesConfig,
+    ResolvedInstance,
+    ResolvedPipeline,
     build_pipeline_config,
 )
 from app.cdm.adapters.custom_pipeline.merger import MergeResult, merge, overlap_fraction
+from app.cdm.adapters.custom_pipeline.page_flags import (
+    PageFlags,
+    PageFlagsConfig,
+    compute_page_flags,
+)
 from app.cdm.adapters.custom_pipeline.tools.base import PipelineTool, PageMeta, ToolResult
 from app.cdm.adapters.custom_pipeline.tools.camelot_tool import CamelotTool
+from app.cdm.adapters.custom_pipeline.tools.fitz_tables_tool import FitzTablesTool
 from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool
 
 __all__ = [
     "CustomPipelineAdapter",
+    "BLOCK_PRODUCING",
+    "STAGING",
+    "Capability",
+    "resolve_precedence",
     "CamelotConfig",
     "FitzConfig",
-    "CustomPipelineConfig",
+    "FitzTablesConfig",
+    "ResolvedInstance",
+    "ResolvedPipeline",
     "build_pipeline_config",
     "MergeResult",
     "merge",
     "overlap_fraction",
+    "PageFlags",
+    "PageFlagsConfig",
+    "compute_page_flags",
     "PipelineTool",
     "PageMeta",
     "ToolResult",
     "CamelotTool",
+    "FitzTablesTool",
     "FitzTool",
 ]

--- a/backend/app/cdm/adapters/custom_pipeline/capabilities.py
+++ b/backend/app/cdm/adapters/custom_pipeline/capabilities.py
@@ -1,0 +1,48 @@
+"""IDP capabilities and their precedence.
+
+One tool fills at most one capability slot. Blocks are tagged with the
+capability that produced them; the merger ranks blocks by that tag.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict
+
+
+class Capability(str, Enum):
+    TEXT_EXTRACTION = "text_extraction"
+    TABLE_DETECTION = "table_detection"
+    TEXT_OCR = "text_ocr"
+    LAYOUT_ANALYSIS = "layout_analysis"
+
+
+#: Capabilities whose blocks compete for page area (governed by precedence).
+BLOCK_PRODUCING = frozenset({
+    Capability.TEXT_EXTRACTION,
+    Capability.TABLE_DETECTION,
+    Capability.TEXT_OCR,
+})
+
+#: Capabilities that order/route rather than compete. No tools yet.
+STAGING = frozenset({Capability.LAYOUT_ANALYSIS})
+
+
+def resolve_precedence(*, cid_corrupt: bool, ocr_prefer: bool) -> Dict[Capability, int]:
+    """Rank block-producing capabilities for one page. Higher wins.
+
+    Structure always beats loose text. The only variable is whether OCR sits
+    above or below native text — the CID flip and `prefer` are the same
+    mechanism, applied per-page vs per-run.
+    """
+    ocr_outranks_text = ocr_prefer or cid_corrupt
+    if ocr_outranks_text:
+        return {
+            Capability.TABLE_DETECTION: 3,
+            Capability.TEXT_OCR: 2,
+            Capability.TEXT_EXTRACTION: 1,
+        }
+    return {
+        Capability.TABLE_DETECTION: 3,
+        Capability.TEXT_EXTRACTION: 2,
+        Capability.TEXT_OCR: 1,
+    }

--- a/backend/app/cdm/adapters/custom_pipeline/config.py
+++ b/backend/app/cdm/adapters/custom_pipeline/config.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel
 
-from app.cdm.adapters.custom_pipeline.tools.base import LocalTool, PageMeta
+from app.cdm.adapters.custom_pipeline.tools.base import PipelineTool, PageMeta
 
 
 class FitzConfig(BaseModel):
@@ -54,7 +54,7 @@ TOOL_REGISTRY: Dict[str, type[BaseModel]] = {
 @dataclass
 class CustomPipelineConfig:
     """Runtime pipeline config — ordered tools (later = higher priority)."""
-    tools: List[LocalTool]
+    tools: List[PipelineTool]
     eviction_overlap_threshold: float = 0.5
 
 
@@ -77,7 +77,7 @@ def build_pipeline_config(
             f"only one table tool allowed per pipeline, got: {table_ids_present}"
         )
 
-    tools: List[LocalTool] = []
+    tools: List[PipelineTool] = []
     for entry in tools_cfg:
         tool_id = entry.get("tool_id")
         raw_cfg = entry.get("config", {}) or {}

--- a/backend/app/cdm/adapters/custom_pipeline/config.py
+++ b/backend/app/cdm/adapters/custom_pipeline/config.py
@@ -1,12 +1,19 @@
-"""Configs for the custom pipeline tools and the pipeline itself."""
+"""Configs for the custom pipeline tools and the pipeline itself.
+
+The pipeline is a set of capability slots, each filled by at most one named
+tool instance. One instance runs once, however many slots reference it, and is
+told which capabilities to `emit` (masking).
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional, Set
 
 from pydantic import BaseModel
 
-from app.cdm.adapters.custom_pipeline.tools.base import PipelineTool, PageMeta
+from app.cdm.adapters.custom_pipeline.capabilities import BLOCK_PRODUCING, Capability
+from app.cdm.adapters.custom_pipeline.page_flags import PageFlagsConfig
+from app.cdm.adapters.custom_pipeline.tools.base import PipelineTool
 
 
 class FitzConfig(BaseModel):
@@ -42,55 +49,93 @@ class FitzTablesConfig(BaseModel):
     text_y_tolerance: Optional[float] = None
 
 
-TABLE_TOOL_IDS: frozenset[str] = frozenset({"camelot", "fitz_tables"})
-
-TOOL_REGISTRY: Dict[str, type[BaseModel]] = {
-    "fitz": FitzConfig,
-    "camelot": CamelotConfig,
-    "fitz_tables": FitzTablesConfig,
-}
+@dataclass(frozen=True)
+class ToolSpec:
+    config_cls: type[BaseModel]
+    provides: frozenset[Capability]
+    factory: Callable[[Any], PipelineTool]
 
 
-@dataclass
-class CustomPipelineConfig:
-    """Runtime pipeline config — ordered tools (later = higher priority)."""
-    tools: List[PipelineTool]
-    eviction_overlap_threshold: float = 0.5
-
-
-def build_pipeline_config(
-    config: Dict[str, Any],
-    page_meta: Optional[Dict[int, PageMeta]] = None,
-) -> CustomPipelineConfig:
+def _tool_registry() -> Dict[str, ToolSpec]:
     from app.cdm.adapters.custom_pipeline.tools.camelot_tool import CamelotTool
     from app.cdm.adapters.custom_pipeline.tools.fitz_tables_tool import FitzTablesTool
     from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool
 
-    tools_cfg = config.get("tools", [])
+    return {
+        "fitz": ToolSpec(FitzConfig, FitzTool.provides,
+                         lambda c: FitzTool(config=c)),
+        "camelot": ToolSpec(CamelotConfig, CamelotTool.provides,
+                            lambda c: CamelotTool(config=c)),
+        "fitz_tables": ToolSpec(FitzTablesConfig, FitzTablesTool.provides,
+                                lambda c: FitzTablesTool(config=c)),
+    }
 
-    table_ids_present = [
-        e.get("tool_id") for e in tools_cfg
-        if e.get("tool_id") in TABLE_TOOL_IDS
-    ]
-    if len(table_ids_present) > 1:
-        raise ValueError(
-            f"only one table tool allowed per pipeline, got: {table_ids_present}"
+
+@dataclass(frozen=True)
+class ResolvedInstance:
+    key: str
+    tool: PipelineTool
+    emit: frozenset[Capability]
+
+
+@dataclass(frozen=True)
+class ResolvedPipeline:
+    instances: List[ResolvedInstance]
+    page_flags: PageFlagsConfig
+    eviction_overlap_threshold: float
+    ocr_eviction_threshold: float
+
+    def for_capability(self, cap: Capability) -> Optional[ResolvedInstance]:
+        return next((i for i in self.instances if cap in i.emit), None)
+
+
+def build_pipeline_config(config: Dict[str, Any]) -> ResolvedPipeline:
+    registry = _tool_registry()
+    tools_cfg: Dict[str, Any] = config.get("tools", {}) or {}
+    caps_cfg: Dict[str, str] = config.get("capabilities", {}) or {}
+
+    # capability key -> Capability, validating the enum
+    slots: Dict[Capability, str] = {}
+    for raw_cap, instance_key in caps_cfg.items():
+        try:
+            cap = Capability(raw_cap)
+        except ValueError:
+            raise ValueError(f"unknown capability: {raw_cap!r}")
+        if cap not in BLOCK_PRODUCING:
+            raise ValueError(f"no tool provides staging capability {cap.value!r}")
+        slots[cap] = instance_key
+
+    if Capability.TEXT_EXTRACTION not in slots:
+        raise ValueError("capability 'text_extraction' is required")
+
+    # instance key -> assigned capabilities (this is the masking set)
+    assigned: Dict[str, Set[Capability]] = {}
+    for cap, key in slots.items():
+        if key not in tools_cfg:
+            raise ValueError(
+                f"capability {cap.value!r} references unknown instance {key!r}"
+            )
+        assigned.setdefault(key, set()).add(cap)
+
+    instances: List[ResolvedInstance] = []
+    for key in sorted(assigned):  # deterministic order
+        entry = tools_cfg[key]
+        tool_id = entry.get("tool")
+        spec = registry.get(tool_id)
+        if spec is None:
+            raise ValueError(f"unknown tool: {tool_id!r}")
+        emit = frozenset(assigned[key])
+        if not emit <= spec.provides:
+            missing = {c.value for c in emit - spec.provides}
+            raise ValueError(f"tool {tool_id!r} does not provide {missing}")
+        tool_cfg = spec.config_cls.model_validate(entry.get("config", {}) or {})
+        instances.append(
+            ResolvedInstance(key=key, tool=spec.factory(tool_cfg), emit=emit)
         )
 
-    tools: List[PipelineTool] = []
-    for entry in tools_cfg:
-        tool_id = entry.get("tool_id")
-        raw_cfg = entry.get("config", {}) or {}
-        cfg_cls = TOOL_REGISTRY.get(tool_id)
-        if cfg_cls is None:
-            raise ValueError(f"unknown tool: {tool_id!r}")
-        tool_cfg = cfg_cls.model_validate(raw_cfg)
-        if tool_id == "fitz":
-            tools.append(FitzTool(config=tool_cfg))  # type: ignore[arg-type]
-        elif tool_id == "camelot":
-            tools.append(CamelotTool(config=tool_cfg, page_meta=page_meta or {}))  # type: ignore[arg-type]
-        elif tool_id == "fitz_tables":
-            tools.append(FitzTablesTool(config=tool_cfg, page_meta=page_meta or {}))  # type: ignore[arg-type]
-
-    threshold = config.get("eviction_overlap_threshold", 0.5)
-    return CustomPipelineConfig(tools=tools, eviction_overlap_threshold=threshold)
+    return ResolvedPipeline(
+        instances=instances,
+        page_flags=PageFlagsConfig.model_validate(config.get("page_flags", {}) or {}),
+        eviction_overlap_threshold=config.get("eviction_overlap_threshold", 0.5),
+        ocr_eviction_threshold=config.get("ocr_eviction_threshold", 0.3),
+    )

--- a/backend/app/cdm/adapters/custom_pipeline/merger.py
+++ b/backend/app/cdm/adapters/custom_pipeline/merger.py
@@ -1,13 +1,17 @@
 """Merge tool outputs into a final ordered block list + an audit raw_output.
 
-Eviction rule: later-declared tools win. A fitz TEXT block that overlaps
-a table block beyond the threshold is evicted (logged, not deleted).
+Blocks are tagged with the capability that produced them. Precedence is
+per-page (see capabilities.resolve_precedence): structure beats loose text, and
+OCR sits below native text unless the page is CID-corrupt or the router set
+`ocr_prefer`. Losers are evicted (logged, not deleted).
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability, resolve_precedence
+from app.cdm.adapters.custom_pipeline.page_flags import PageFlags
 from app.cdm.adapters.custom_pipeline.tools.base import ToolResult
 from app.cdm.models import BBox, Block
 
@@ -16,17 +20,15 @@ def _area(b: BBox) -> float:
     return max(0.0, b.x1 - b.x0) * max(0.0, b.y1 - b.y0)
 
 
-def overlap_fraction(table_bbox: BBox, fitz_bbox: BBox) -> float:
-    """Intersection area / area(fitz_bbox), in normalized coords."""
-    fitz_area = _area(fitz_bbox)
-    if fitz_area == 0.0:
+def overlap_fraction(winner: BBox, loser: BBox) -> float:
+    """Intersection area / area(loser), in normalized coords."""
+    loser_area = _area(loser)
+    if loser_area == 0.0:
         return 0.0
-    ix0 = max(table_bbox.x0, fitz_bbox.x0)
-    iy0 = max(table_bbox.y0, fitz_bbox.y0)
-    ix1 = min(table_bbox.x1, fitz_bbox.x1)
-    iy1 = min(table_bbox.y1, fitz_bbox.y1)
+    ix0, iy0 = max(winner.x0, loser.x0), max(winner.y0, loser.y0)
+    ix1, iy1 = min(winner.x1, loser.x1), min(winner.y1, loser.y1)
     inter = max(0.0, ix1 - ix0) * max(0.0, iy1 - iy0)
-    return inter / fitz_area
+    return inter / loser_area
 
 
 @dataclass
@@ -42,80 +44,96 @@ def _sort_key(block: Block) -> Tuple[float, float]:
 
 
 def merge(
-    fitz_result: ToolResult,
-    table_result: ToolResult,
+    results: Sequence[ToolResult],
     *,
     source_document_id: str,
+    page_flags: Dict[int, PageFlags],
+    ocr_prefer: bool = False,
     eviction_overlap_threshold: float = 0.5,
+    ocr_eviction_threshold: float = 0.3,
 ) -> MergeResult:
-    table_blocks = list(table_result.blocks)
+    # Flatten to (block, capability, tool_id), preserving producer order.
+    tagged: List[Tuple[Block, Capability, str]] = [
+        (b, cap, r.tool_id)
+        for r in results
+        for cap, blocks in r.blocks_by_capability.items()
+        for b in blocks
+    ]
 
-    # 1. Eviction pass — fitz blocks overlapping any table beyond threshold.
-    evicted_ids = set()
-    eviction_winner: Dict[str, str] = {}
-    eviction_overlap: Dict[str, float] = {}
-    for fb in fitz_result.blocks:
-        if fb.bbox is None:
+    def _threshold(loser_cap: Capability) -> float:
+        return (ocr_eviction_threshold if loser_cap is Capability.TEXT_OCR
+                else eviction_overlap_threshold)
+
+    def _rank(page_index: int) -> Dict[Capability, int]:
+        flags = page_flags.get(page_index)
+        return resolve_precedence(
+            cid_corrupt=bool(flags and flags.cid_corrupt), ocr_prefer=ocr_prefer,
+        )
+
+    # 1. Eviction pass — a block loses to any higher-ranked block that covers it.
+    evicted: Dict[str, Dict[str, Any]] = {}
+    for loser, loser_cap, loser_tool in tagged:
+        if loser.bbox is None:
             continue
-        for tb in table_blocks:
-            if tb.page_index != fb.page_index or tb.bbox is None:
+        ranks = _rank(loser.page_index)
+        for winner, winner_cap, _ in tagged:
+            if winner.id == loser.id or winner.bbox is None:
                 continue
-            frac = overlap_fraction(tb.bbox, fb.bbox)
-            if frac > eviction_overlap_threshold:
-                evicted_ids.add(fb.id)
-                eviction_winner[fb.id] = tb.id
-                eviction_overlap[fb.id] = frac
+            if winner.page_index != loser.page_index:
+                continue
+            if ranks.get(winner_cap, 0) <= ranks.get(loser_cap, 0):
+                continue
+            frac = overlap_fraction(winner.bbox, loser.bbox)
+            if frac > _threshold(loser_cap):
+                evicted[loser.id] = {
+                    "block_id": loser.id,
+                    "capability": loser_cap.value,
+                    "winner_capability": winner_cap.value,
+                    "winner_prov_id": winner.id,
+                    "reason": "covered_by",
+                    "overlap_fraction": frac,
+                    "tool": loser_tool,
+                }
                 break
 
-    surviving_fitz = [b for b in fitz_result.blocks if b.id not in evicted_ids]
-    combined = surviving_fitz + table_blocks
+    survivors = [(b, c, t) for (b, c, t) in tagged if b.id not in evicted]
 
     # 2. Mint final ids + reading order, grouped per page.
     by_page: Dict[int, List[Block]] = {}
-    for b in combined:
+    for b, _, _ in survivors:
         by_page.setdefault(b.page_index, []).append(b)
 
     prov_to_final: Dict[str, str] = {}
     final_blocks: List[Block] = []
-    for page_index in sorted(by_page.keys()):
-        ordered = sorted(by_page[page_index], key=_sort_key)
-        for reading_order, block in enumerate(ordered):
+    for page_index in sorted(by_page):
+        for reading_order, block in enumerate(sorted(by_page[page_index], key=_sort_key)):
             final_id = f"{source_document_id}:{page_index}:{reading_order}"
             prov_to_final[block.id] = final_id
             final_blocks.append(
                 block.model_copy(update={"id": final_id, "reading_order": reading_order})
             )
 
-    # 3. Build raw_output (audit trail).
-    def _block_map(result: ToolResult) -> Dict[str, Any]:
-        out: Dict[str, Any] = {}
-        for prov_id, native in result.native_by_block.items():
-            final_id = prov_to_final.get(prov_id)
-            if final_id is not None:
-                out[final_id] = native
-        return out
-
-    evicted_records = [
-        {
-            "block_id": prov_id,
-            "tool": "fitz",
-            "reason": "spatial_overlap",
-            "won_by": prov_to_final[eviction_winner[prov_id]],
-            "overlap_fraction": eviction_overlap[prov_id],
-            "raw_block": fitz_result.native_by_block.get(prov_id),
+    # 3. Audit trail, keyed by instance and explained in capability terms.
+    instances: Dict[str, Any] = {}
+    for r in results:
+        block_map = {
+            prov_to_final[prov]: native
+            for prov, native in r.native_by_block.items()
+            if prov in prov_to_final
         }
-        for prov_id in evicted_ids
-    ]
+        instances[r.tool_id] = {
+            "tool": r.tool_id,
+            "capabilities": [c.value for c in r.blocks_by_capability],
+            "raw": r.raw,
+            "block_map": block_map,
+        }
 
-    raw_output = {
-        "tools": {
-            "fitz": {"raw": fitz_result.raw, "block_map": _block_map(fitz_result)},
-            table_result.tool_id: {
-                "raw": table_result.raw,
-                "block_map": _block_map(table_result),
-            },
-        },
-        "evicted": evicted_records,
-    }
+    evicted_records: List[Dict[str, Any]] = []
+    for record in evicted.values():
+        record["won_by"] = prov_to_final.get(record.pop("winner_prov_id"))
+        evicted_records.append(record)
 
-    return MergeResult(blocks=final_blocks, raw_output=raw_output)
+    return MergeResult(
+        blocks=final_blocks,
+        raw_output={"instances": instances, "evicted": evicted_records},
+    )

--- a/backend/app/cdm/adapters/custom_pipeline/page_flags.py
+++ b/backend/app/cdm/adapters/custom_pipeline/page_flags.py
@@ -1,0 +1,55 @@
+"""Per-page facts consumed by the merger (CID precedence flip) and, in PR B,
+by the OCR tool's `pages: "auto"` selector.
+
+fitz metadata only — no rasterization. Deliberately independent of `app/probe/`:
+the probe is advisory evidence, this is deterministic execution state.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import fitz
+from pydantic import BaseModel
+
+
+class PageFlagsConfig(BaseModel):
+    min_chars: int = 10      # below this, the page has no usable text layer
+    cid_ratio: float = 0.3   # private-use-area char ratio => cid_corrupt
+
+
+class PageFlags(BaseModel):
+    index: int
+    char_count: int
+    pua_ratio: float
+    cid_corrupt: bool
+
+
+def pua_ratio(text: str) -> float:
+    """Fraction of characters in the Unicode private-use area.
+
+    A broken CID font decodes to private-use codepoints, so a high ratio means
+    the page has a text layer that is present but unusable.
+    """
+    if not text:
+        return 0.0
+    pua = sum(1 for c in text if 0xE000 <= ord(c) <= 0xF8FF)
+    return pua / len(text)
+
+
+def compute_page_flags(pdf_path: Path, cfg: PageFlagsConfig) -> Dict[int, PageFlags]:
+    out: Dict[int, PageFlags] = {}
+    doc = fitz.open(str(pdf_path))
+    try:
+        for i in range(len(doc)):
+            text = doc[i].get_text("text")
+            ratio = pua_ratio(text)
+            out[i] = PageFlags(
+                index=i,
+                char_count=len(text.strip()),
+                pua_ratio=ratio,
+                cid_corrupt=ratio > cfg.cid_ratio,
+            )
+    finally:
+        doc.close()
+    return out

--- a/backend/app/cdm/adapters/custom_pipeline/tools/base.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/base.py
@@ -1,7 +1,7 @@
-"""Contracts shared by all local parsing tools.
+"""Contracts shared by all custom-pipeline tools.
 
-A LocalTool reads a PDF and returns CDM Blocks (with normalized bboxes) plus
-the native records that produced them, for the audit trail.
+A PipelineTool reads a PDF and returns CDM Blocks (normalized bboxes) keyed by
+the capability that produced them, plus the native records behind them.
 """
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.models import Block
 
 
@@ -19,7 +20,7 @@ def clamp01(v: float) -> float:
 
 
 class PageMeta(BaseModel):
-    """Authoritative page geometry, sourced from FitzTool."""
+    """Authoritative page geometry, sourced from the text_extraction tool."""
     index: int
     width: float       # PDF points
     height: float      # PDF points
@@ -28,20 +29,28 @@ class PageMeta(BaseModel):
 
 
 class ToolResult(BaseModel):
-    """Output of one LocalTool.run() invocation."""
+    """Output of one PipelineTool.run() invocation."""
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     tool_id: str
-    blocks: List[Block]
-    page_meta: Dict[int, PageMeta]          # keyed by 0-based page index
-    raw: Any = None                          # serializable native dump
-    native_by_block: Dict[str, Any] = {}     # provisional block id -> native record
+    blocks_by_capability: Dict[Capability, List[Block]] = {}
+    page_meta: Dict[int, PageMeta] = {}
+    raw: Any = None
+    native_by_block: Dict[str, Any] = {}
     warnings: List[str] = []
     duration_ms: int = 0
 
 
 @runtime_checkable
-class LocalTool(Protocol):
+class PipelineTool(Protocol):
     tool_id: str
+    provides: frozenset[Capability]
 
-    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult: ...
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+        emit: frozenset[Capability],
+    ) -> ToolResult: ...

--- a/backend/app/cdm/adapters/custom_pipeline/tools/camelot_tool.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/camelot_tool.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import camelot
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.config import CamelotConfig
 from app.cdm.adapters.custom_pipeline.tools.base import (
     PageMeta,
@@ -23,14 +24,11 @@ from app.cdm.models import BBox, Block, BlockRole, Cell, Table
 
 class CamelotTool:
     tool_id = "camelot"
+    provides = frozenset({Capability.TABLE_DETECTION})
 
-    def __init__(
-        self,
-        config: Optional[CamelotConfig] = None,
-        page_meta: Optional[Dict[int, PageMeta]] = None,
-    ) -> None:
+    def __init__(self, config: Optional[CamelotConfig] = None) -> None:
         self.config = config or CamelotConfig()
-        self.page_meta = page_meta or {}
+        self.page_meta: Dict[int, PageMeta] = {}
 
     @staticmethod
     def _pages_arg(pages: Optional[List[int]]) -> str:
@@ -108,7 +106,18 @@ class CamelotTool:
             },
         )
 
-    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+        emit: frozenset[Capability] = frozenset({Capability.TABLE_DETECTION}),
+    ) -> ToolResult:
+        if not emit <= self.provides:
+            raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
+        self.page_meta = page_meta or {}
+
         t0 = time.perf_counter()
         warnings: List[str] = []
         blocks: List[Block] = []
@@ -151,7 +160,7 @@ class CamelotTool:
 
         return ToolResult(
             tool_id=self.tool_id,
-            blocks=blocks,
+            blocks_by_capability={Capability.TABLE_DETECTION: blocks},
             page_meta=self.page_meta,
             raw={"tables": raw_tables},
             native_by_block=native_by_block,

--- a/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tables_tool.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tables_tool.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import fitz
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.config import FitzTablesConfig
 from app.cdm.adapters.custom_pipeline.tools.base import PageMeta, ToolResult, clamp01
 from app.cdm.models import BBox, Block, BlockRole, Cell, Table
@@ -40,14 +41,11 @@ def _plain_text(extracted: List[List[Optional[str]]]) -> str:
 
 class FitzTablesTool:
     tool_id = "fitz_tables"
+    provides = frozenset({Capability.TABLE_DETECTION})
 
-    def __init__(
-        self,
-        config: Optional[FitzTablesConfig] = None,
-        page_meta: Optional[Dict[int, PageMeta]] = None,
-    ) -> None:
+    def __init__(self, config: Optional[FitzTablesConfig] = None) -> None:
         self.config = config or FitzTablesConfig()
-        self.page_meta = page_meta or {}
+        self.page_meta: Dict[int, PageMeta] = {}
 
     def _config_kwargs(self) -> Dict[str, Any]:
         c = self.config
@@ -106,7 +104,18 @@ class FitzTablesTool:
                 cells.append(Cell(row=r, col=c, text=text.strip(), bbox=bbox))
         return cells
 
-    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+        emit: frozenset[Capability] = frozenset({Capability.TABLE_DETECTION}),
+    ) -> ToolResult:
+        if not emit <= self.provides:
+            raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
+        self.page_meta = page_meta or {}
+
         t0 = time.perf_counter()
         blocks: List[Block] = []
         native_by_block: Dict[str, Any] = {}
@@ -180,7 +189,7 @@ class FitzTablesTool:
 
         return ToolResult(
             tool_id=self.tool_id,
-            blocks=blocks,
+            blocks_by_capability={Capability.TABLE_DETECTION: blocks},
             page_meta=self.page_meta,
             raw={"tables": list(native_by_block.values())},
             native_by_block=native_by_block,

--- a/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import fitz  # PyMuPDF
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.config import FitzConfig
 from app.cdm.adapters.custom_pipeline.tools.base import (
     PageMeta,
@@ -57,14 +58,25 @@ def _spans(native_block: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 class FitzTool:
     tool_id = "fitz"
+    provides = frozenset({Capability.TEXT_EXTRACTION})
 
     def __init__(self, config: Optional[FitzConfig] = None) -> None:
         self.config = config or FitzConfig()
 
-    def run(self, pdf_path: Path, pages: Optional[List[int]] = None) -> ToolResult:
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,  # unused; fitz is the source
+        emit: frozenset[Capability] = frozenset({Capability.TEXT_EXTRACTION}),
+    ) -> ToolResult:
+        if not emit <= self.provides:
+            raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
+
         t0 = time.perf_counter()
         blocks: List[Block] = []
-        page_meta: Dict[int, PageMeta] = {}
+        page_meta_out: Dict[int, PageMeta] = {}
         native_raw: Dict[int, Any] = {}
         native_by_block: Dict[str, Any] = {}
         warnings: List[str] = []
@@ -78,7 +90,7 @@ class FitzTool:
                 pd = page.get_text("dict")
                 width = float(pd["width"])
                 height = float(pd["height"])
-                page_meta[i] = PageMeta(
+                page_meta_out[i] = PageMeta(
                     index=i, width=width, height=height, rotation=page.rotation
                 )
                 native_raw[i] = _json_safe(pd)
@@ -136,8 +148,8 @@ class FitzTool:
 
         return ToolResult(
             tool_id=self.tool_id,
-            blocks=blocks,
-            page_meta=page_meta,
+            blocks_by_capability={Capability.TEXT_EXTRACTION: blocks},
+            page_meta=page_meta_out,
             raw={"pages": native_raw},
             native_by_block=native_by_block,
             warnings=warnings,

--- a/backend/app/services/parsing/custom_pipeline_runner.py
+++ b/backend/app/services/parsing/custom_pipeline_runner.py
@@ -9,9 +9,10 @@ from typing import Any, Dict, Optional, Tuple
 
 from app.cdm.adapters.base import SourceMeta
 from app.cdm.adapters.custom_pipeline.adapter import CustomPipelineAdapter
-from app.cdm.adapters.custom_pipeline.config import TABLE_TOOL_IDS, build_pipeline_config
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.config import build_pipeline_config
 from app.cdm.adapters.custom_pipeline.merger import merge
-from app.cdm.adapters.custom_pipeline.tools.base import ToolResult
+from app.cdm.adapters.custom_pipeline.page_flags import compute_page_flags
 from app.cdm.models import ParsedDocument, ParserKind
 from app.cdm.source import ParseRun, ParseRunStatus, SourceDocument
 from app.services.parsing.errors import CustomPipelineRunError
@@ -51,33 +52,33 @@ async def run_custom_pipeline(
         pdf_path = Path(file_path)
 
         pipeline = build_pipeline_config(config)
+        flags = compute_page_flags(pdf_path, pipeline.page_flags)
 
-        fitz_tool = next((t for t in pipeline.tools if t.tool_id == "fitz"), None)
-        if fitz_tool is None:
-            raise ValueError("custom pipeline requires a 'fitz' tool")
+        text_instance = pipeline.for_capability(Capability.TEXT_EXTRACTION)
+        # build_pipeline_config guarantees this, but fail loudly if it ever does not.
+        if text_instance is None:
+            raise ValueError("capability 'text_extraction' is required")
 
-        fitz_result: ToolResult = fitz_tool.run(pdf_path)
-        warnings = list(fitz_result.warnings)
+        text_result = text_instance.tool.run(pdf_path, emit=text_instance.emit)
+        results = [text_result]
+        warnings = list(text_result.warnings)
 
-        table_entry = next(
-            (e for e in config.get("tools", []) if e.get("tool_id") in TABLE_TOOL_IDS),
-            None,
-        )
-        if table_entry is not None:
-            table_pipeline = build_pipeline_config(
-                {"tools": [table_entry]}, page_meta=fitz_result.page_meta
-            )
-            table_tool = table_pipeline.tools[0]
-            table_result = table_tool.run(pdf_path)
-            warnings.extend(table_result.warnings)
-        else:
-            table_result = ToolResult(tool_id="none", blocks=[], page_meta={}, raw={})
+        # Remaining instances run once each, in the deterministic order
+        # build_pipeline_config established, and receive page geometry from the
+        # text_extraction tool.
+        for inst in pipeline.instances:
+            if inst is text_instance:
+                continue
+            r = inst.tool.run(pdf_path, page_meta=text_result.page_meta, emit=inst.emit)
+            results.append(r)
+            warnings.extend(r.warnings)
 
         merge_result = merge(
-            fitz_result,
-            table_result,
+            results,
             source_document_id=source.id,
+            page_flags=flags,
             eviction_overlap_threshold=pipeline.eviction_overlap_threshold,
+            ocr_eviction_threshold=pipeline.ocr_eviction_threshold,
         )
     except Exception as exc:  # noqa: BLE001
         raise _fail(exc) from exc
@@ -101,7 +102,7 @@ async def run_custom_pipeline(
 
     adapter = CustomPipelineAdapter()
     doc = adapter.adapt(
-        {"page_meta": fitz_result.page_meta, "blocks": merge_result.blocks},
+        {"page_meta": text_result.page_meta, "blocks": merge_result.blocks},
         SourceMeta(
             source_document_id=source.id,
             parse_run_id=run.id,

--- a/backend/tests/cdm/adapters/custom_pipeline/test_camelot_tool.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_camelot_tool.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.config import CamelotConfig
 from app.cdm.adapters.custom_pipeline.tools.base import PageMeta
 from app.cdm.adapters.custom_pipeline.tools.camelot_tool import CamelotTool
@@ -31,7 +32,7 @@ def test_camelot_tool_id():
 
 def test_table_to_block_role_and_page_index():
     pm = PageMeta(index=1, width=612.0, height=792.0)
-    tool = CamelotTool(page_meta={1: pm})
+    tool = CamelotTool()
     block = tool._table_to_block(_fake_table(), page_index=1, page_meta=pm, table_seq=0)
     assert block.role == BlockRole.TABLE
     assert block.page_index == 1
@@ -89,13 +90,13 @@ def test_run_maps_pages_arg_and_invokes_camelot(monkeypatch):
     monkeypatch.setattr(mod.camelot, "read_pdf", fake_read_pdf)
 
     pm = {1: PageMeta(index=1, width=612.0, height=792.0)}
-    result = CamelotTool(page_meta=pm).run("/tmp/x.pdf", pages=[1])
+    result = CamelotTool().run("/tmp/x.pdf", pages=[1], page_meta=pm)
     # 0-based page 1 → camelot 1-indexed "2"
     assert calls["pages"] == "2"
     assert calls["flavor"] == "lattice"
-    assert len(result.blocks) == 1
-    assert result.blocks[0].id == "camelot:1:0"
-    assert result.blocks[0].id in result.native_by_block
+    assert len(result.blocks_by_capability[Capability.TABLE_DETECTION]) == 1
+    assert result.blocks_by_capability[Capability.TABLE_DETECTION][0].id == "camelot:1:0"
+    assert result.blocks_by_capability[Capability.TABLE_DETECTION][0].id in result.native_by_block
 
 
 def test_run_lattice_omits_stream_only_kwargs(monkeypatch):
@@ -128,3 +129,7 @@ def test_run_stream_includes_tol_kwargs(monkeypatch):
     CamelotTool(config=CamelotConfig(flavor="stream", edge_tol=40, row_tol=3)).run("/tmp/x.pdf")
     assert calls["edge_tol"] == 40
     assert calls["row_tol"] == 3
+
+
+def test_camelot_declares_table_detection():
+    assert CamelotTool().provides == frozenset({Capability.TABLE_DETECTION})

--- a/backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
@@ -1,0 +1,30 @@
+from app.cdm.adapters.custom_pipeline.capabilities import (
+    BLOCK_PRODUCING, STAGING, Capability, resolve_precedence,
+)
+
+T, TB, O, L = (Capability.TEXT_EXTRACTION, Capability.TABLE_DETECTION,
+               Capability.TEXT_OCR, Capability.LAYOUT_ANALYSIS)
+
+
+def test_capability_kinds():
+    assert BLOCK_PRODUCING == frozenset({T, TB, O})
+    assert STAGING == frozenset({L})
+
+
+def test_default_order_table_beats_text_beats_ocr():
+    r = resolve_precedence(cid_corrupt=False, ocr_prefer=False)
+    assert r[TB] > r[T] > r[O]
+
+
+def test_cid_corrupt_page_flips_ocr_above_text():
+    r = resolve_precedence(cid_corrupt=True, ocr_prefer=False)
+    assert r[TB] > r[O] > r[T]
+
+
+def test_ocr_prefer_flips_ocr_above_text():
+    r = resolve_precedence(cid_corrupt=False, ocr_prefer=True)
+    assert r[TB] > r[O] > r[T]
+
+
+def test_staging_capability_has_no_rank():
+    assert L not in resolve_precedence(cid_corrupt=False, ocr_prefer=False)

--- a/backend/tests/cdm/adapters/custom_pipeline/test_config.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_config.py
@@ -1,98 +1,96 @@
 import pytest
 
-from app.cdm.adapters.custom_pipeline.config import (
-    CamelotConfig,
-    FitzConfig,
-    FitzTablesConfig,
-    CustomPipelineConfig,
-    TABLE_TOOL_IDS,
-    build_pipeline_config,
-)
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.config import build_pipeline_config
+
+BASE = {
+    "tools": {"fitz": {"tool": "fitz", "config": {}}},
+    "capabilities": {"text_extraction": "fitz"},
+}
 
 
-def test_fitz_config_defaults():
-    c = FitzConfig()
-    assert c.min_chars_threshold == 10
-    assert c.include_images is True
-    assert c.span_detail is False
+def test_builds_a_single_slot_pipeline():
+    p = build_pipeline_config(BASE)
+    inst = p.for_capability(Capability.TEXT_EXTRACTION)
+    assert inst.key == "fitz"
+    assert inst.tool.tool_id == "fitz"
+    assert inst.emit == frozenset({Capability.TEXT_EXTRACTION})
+    assert p.for_capability(Capability.TABLE_DETECTION) is None
 
 
-def test_camelot_config_defaults():
-    c = CamelotConfig()
-    assert c.flavor == "lattice"
-    assert c.edge_tol == 50
-    assert c.row_tol == 2
-    assert c.copy_text == []
+def test_one_instance_serves_many_slots_and_is_built_once():
+    cfg = {
+        "tools": {"f": {"tool": "fitz", "config": {}},
+                  "t": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "f", "table_detection": "t"},
+    }
+    p = build_pipeline_config(cfg)
+    assert len(p.instances) == 2
+    assert {i.key for i in p.instances} == {"f", "t"}
 
 
-def test_build_pipeline_config_fitz_only():
-    cfg = build_pipeline_config({
-        "tools": [{"tool_id": "fitz", "config": {"min_chars_threshold": 5}}],
-        "eviction_overlap_threshold": 0.4,
-    })
-    assert isinstance(cfg, CustomPipelineConfig)
-    assert cfg.eviction_overlap_threshold == 0.4
-    assert [t.tool_id for t in cfg.tools] == ["fitz"]
+def test_tool_config_is_validated_and_applied():
+    cfg = {
+        "tools": {"fitz": {"tool": "fitz", "config": {"span_detail": True}}},
+        "capabilities": {"text_extraction": "fitz"},
+    }
+    inst = build_pipeline_config(cfg).for_capability(Capability.TEXT_EXTRACTION)
+    assert inst.tool.config.span_detail is True
 
 
-def test_build_pipeline_config_fitz_and_camelot_order_preserved():
-    cfg = build_pipeline_config({
-        "tools": [
-            {"tool_id": "fitz", "config": {}},
-            {"tool_id": "camelot", "config": {"flavor": "stream"}},
-        ],
-    })
-    assert [t.tool_id for t in cfg.tools] == ["fitz", "camelot"]
-    assert cfg.eviction_overlap_threshold == 0.5  # default
+def test_text_extraction_slot_is_required():
+    with pytest.raises(ValueError, match="text_extraction"):
+        build_pipeline_config({"tools": {}, "capabilities": {}})
 
 
-def test_build_pipeline_config_rejects_unknown_tool():
+def test_unknown_tool_is_rejected():
     with pytest.raises(ValueError, match="unknown tool"):
-        build_pipeline_config({"tools": [{"tool_id": "bogus", "config": {}}]})
+        build_pipeline_config({"tools": {"x": {"tool": "nope"}},
+                               "capabilities": {"text_extraction": "x"}})
 
 
-def test_fitz_tables_config_defaults():
-    c = FitzTablesConfig()
-    assert c.vertical_strategy == "lines_strict"
-    assert c.horizontal_strategy == "lines_strict"
-    assert c.snap_tolerance == 3.0
-    assert c.join_tolerance == 3.0
-    assert c.edge_min_length == 3.0
-    assert c.min_words_vertical == 3
-    assert c.min_words_horizontal == 1
-    assert c.intersection_tolerance == 3.0
-    assert c.text_tolerance == 3.0
-    assert c.snap_x_tolerance is None
-    assert c.snap_y_tolerance is None
-    assert c.join_x_tolerance is None
-    assert c.join_y_tolerance is None
-    assert c.intersection_x_tolerance is None
-    assert c.intersection_y_tolerance is None
-    assert c.text_x_tolerance is None
-    assert c.text_y_tolerance is None
+def test_unknown_capability_is_rejected():
+    with pytest.raises(ValueError, match="unknown capability"):
+        build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
+                               "capabilities": {"text_extraction": "f",
+                                                "teleportation": "f"}})
 
 
-def test_table_tool_ids_contains_camelot_and_fitz_tables():
-    assert "camelot" in TABLE_TOOL_IDS
-    assert "fitz_tables" in TABLE_TOOL_IDS
+def test_staging_capability_has_no_tools_yet():
+    with pytest.raises(ValueError, match="staging capability"):
+        build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
+                               "capabilities": {"text_extraction": "f",
+                                                "layout_analysis": "f"}})
 
 
-def test_build_pipeline_config_rejects_multiple_table_tools():
-    with pytest.raises(ValueError, match="only one table tool allowed"):
+def test_capability_not_provided_by_tool_is_rejected():
+    with pytest.raises(ValueError, match="does not provide"):
         build_pipeline_config({
-            "tools": [
-                {"tool_id": "fitz", "config": {}},
-                {"tool_id": "fitz_tables", "config": {}},
-                {"tool_id": "camelot", "config": {}},
-            ],
+            "tools": {"f": {"tool": "fitz"}},
+            "capabilities": {"text_extraction": "f", "table_detection": "f"},
         })
 
 
-def test_build_pipeline_config_fitz_and_fitz_tables():
-    cfg = build_pipeline_config({
-        "tools": [
-            {"tool_id": "fitz", "config": {}},
-            {"tool_id": "fitz_tables", "config": {}},
-        ],
-    })
-    assert [t.tool_id for t in cfg.tools] == ["fitz", "fitz_tables"]
+def test_dangling_instance_reference_is_rejected():
+    with pytest.raises(ValueError, match="unknown instance"):
+        build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
+                               "capabilities": {"text_extraction": "ghost"}})
+
+
+def test_thresholds_and_page_flags_defaults():
+    p = build_pipeline_config(BASE)
+    assert p.eviction_overlap_threshold == 0.5
+    assert p.ocr_eviction_threshold == 0.3
+    assert p.page_flags.min_chars == 10 and p.page_flags.cid_ratio == 0.3
+
+
+def test_two_table_tools_are_structurally_unrepresentable():
+    # The capabilities map is a dict — there is only ever one table_detection
+    # key, so the old "only one table tool" runtime guard has nothing to guard.
+    cfg = {"tools": {"a": {"tool": "camelot"}, "b": {"tool": "fitz_tables"},
+                     "f": {"tool": "fitz"}},
+           "capabilities": {"text_extraction": "f", "table_detection": "b"}}
+    p = build_pipeline_config(cfg)
+    assert p.for_capability(Capability.TABLE_DETECTION).key == "b"
+    # The unreferenced instance "a" is never built.
+    assert {i.key for i in p.instances} == {"b", "f"}

--- a/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tables_tool.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tables_tool.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import fitz
 import pytest
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.config import FitzTablesConfig
 from app.cdm.adapters.custom_pipeline.tools.base import PageMeta
 from app.cdm.adapters.custom_pipeline.tools.fitz_tables_tool import FitzTablesTool
@@ -53,14 +54,14 @@ def test_fitz_tables_tool_id():
 
 
 def test_fitz_tables_emits_table_blocks(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    tables = [b for b in result.blocks if b.role == BlockRole.TABLE]
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    tables = [b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE]
     assert len(tables) >= 1
 
 
 def test_fitz_tables_block_has_normalized_bbox(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     assert b.bbox is not None
     for v in (b.bbox.x0, b.bbox.y0, b.bbox.x1, b.bbox.y1):
         assert 0.0 <= v <= 1.0
@@ -69,8 +70,8 @@ def test_fitz_tables_block_has_normalized_bbox(table_pdf, page_meta):
 
 def test_fitz_tables_bbox_no_y_flip(table_pdf, page_meta):
     """Coordinates use top-left origin — source y0 < source y1 (no y-flip)."""
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     assert b.bbox is not None
     assert b.bbox.source_coords is not None
     x0, y0, x1, y1 = b.bbox.source_coords
@@ -78,47 +79,47 @@ def test_fitz_tables_bbox_no_y_flip(table_pdf, page_meta):
 
 
 def test_fitz_tables_block_has_table_cdm(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     assert b.table is not None
     assert b.table.rows >= 2
     assert b.table.cols >= 2
 
 
 def test_fitz_tables_cell_text(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     all_text = " ".join(c.text for c in b.table.cells)
     assert "Name" in all_text or "Value" in all_text
 
 
 def test_fitz_tables_html_and_markdown(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     assert b.html is not None and "<table>" in b.html
     assert b.markdown is not None and "|" in b.markdown
 
 
 def test_fitz_tables_block_id_format(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     assert b.id.startswith("fitz_tables:0:")
 
 
 def test_fitz_tables_duration_ms_is_non_negative(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
     assert result.duration_ms >= 0
 
 
 def test_fitz_tables_native_by_block_keyed_by_prov_id(table_pdf, page_meta):
-    result = FitzTablesTool(page_meta=page_meta).run(table_pdf)
-    b = next(b for b in result.blocks if b.role == BlockRole.TABLE)
+    result = FitzTablesTool().run(table_pdf, page_meta=page_meta)
+    b = next(b for b in result.blocks_by_capability[Capability.TABLE_DETECTION] if b.role == BlockRole.TABLE)
     assert b.id in result.native_by_block
 
 
 def test_fitz_tables_custom_snap_tolerance_accepted(table_pdf, page_meta):
     cfg = FitzTablesConfig(snap_tolerance=5.0)
-    result = FitzTablesTool(config=cfg, page_meta=page_meta).run(table_pdf)
+    result = FitzTablesTool(config=cfg).run(table_pdf, page_meta=page_meta)
     assert result.tool_id == "fitz_tables"
 
 
@@ -129,4 +130,8 @@ def test_fitz_tables_empty_pdf_emits_no_table_blocks(tmp_path):
     doc.save(str(pdf))
     doc.close()
     result = FitzTablesTool().run(pdf)
-    assert not any(b.role == BlockRole.TABLE for b in result.blocks)
+    assert not any(b.role == BlockRole.TABLE for b in result.blocks_by_capability[Capability.TABLE_DETECTION])
+
+
+def test_fitz_tables_declares_table_detection():
+    assert FitzTablesTool().provides == frozenset({Capability.TABLE_DETECTION})

--- a/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
@@ -2,12 +2,19 @@ import json
 from pathlib import Path
 
 import fitz
+import pytest
 
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.config import FitzConfig
 from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool, _json_safe
 from app.cdm.models import BlockRole
 
 FIXTURES = Path(__file__).parent / "fixtures"
+TE = Capability.TEXT_EXTRACTION
+
+
+def _blocks(result):
+    return result.blocks_by_capability[TE]
 
 
 def _make_image_pdf(path: Path) -> None:
@@ -26,10 +33,24 @@ def test_fitz_tool_id():
     assert FitzTool().tool_id == "fitz"
 
 
+def test_fitz_declares_text_extraction_and_emits_under_it():
+    tool = FitzTool()
+    assert tool.provides == frozenset({TE})
+    result = tool.run(FIXTURES / "simple_text.pdf", emit=frozenset({TE}))
+    assert list(result.blocks_by_capability) == [TE]
+    assert len(_blocks(result)) >= 1
+
+
+def test_fitz_rejects_an_emit_it_does_not_provide():
+    with pytest.raises(ValueError, match="cannot emit"):
+        FitzTool().run(FIXTURES / "simple_text.pdf",
+                       emit=frozenset({Capability.TABLE_DETECTION}))
+
+
 def test_fitz_extracts_paragraph_blocks_with_normalized_bbox():
     result = FitzTool().run(FIXTURES / "simple_text.pdf")
     assert result.tool_id == "fitz"
-    paras = [b for b in result.blocks if b.role == BlockRole.TEXT]
+    paras = [b for b in _blocks(result) if b.role == BlockRole.TEXT]
     assert len(paras) > 0
     b = paras[0]
     assert b.text.strip() != ""
@@ -49,20 +70,20 @@ def test_fitz_provides_page_meta_for_every_page():
 
 def test_fitz_native_record_keyed_by_provisional_id():
     result = FitzTool().run(FIXTURES / "simple_text.pdf")
-    b = result.blocks[0]
+    b = _blocks(result)[0]
     assert b.id in result.native_by_block
     assert "bbox" in result.native_by_block[b.id]
 
 
 def test_fitz_span_detail_off_by_default():
     result = FitzTool().run(FIXTURES / "simple_text.pdf")
-    para = next(b for b in result.blocks if b.role == BlockRole.TEXT)
+    para = next(b for b in _blocks(result) if b.role == BlockRole.TEXT)
     assert "spans" not in para.parser_extras
 
 
 def test_fitz_span_detail_on_records_spans():
     result = FitzTool(config=FitzConfig(span_detail=True)).run(FIXTURES / "simple_text.pdf")
-    para = next(b for b in result.blocks if b.role == BlockRole.TEXT)
+    para = next(b for b in _blocks(result) if b.role == BlockRole.TEXT)
     assert "spans" in para.parser_extras
     assert isinstance(para.parser_extras["spans"], list)
 
@@ -80,7 +101,7 @@ def test_fitz_raw_is_json_serializable_with_images(tmp_path):
     _make_image_pdf(pdf)
     result = FitzTool().run(pdf)
     # Sanity: an image block was extracted as a FIGURE.
-    assert any(b.role == BlockRole.FIGURE for b in result.blocks)
+    assert any(b.role == BlockRole.FIGURE for b in _blocks(result))
     # The raw audit data must be JSON-serializable (no raw image bytes).
     json.dumps(result.raw)
     json.dumps(result.native_by_block)

--- a/backend/tests/cdm/adapters/custom_pipeline/test_merger.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_merger.py
@@ -1,95 +1,89 @@
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
 from app.cdm.adapters.custom_pipeline.merger import merge, overlap_fraction
-from app.cdm.adapters.custom_pipeline.tools.base import PageMeta, ToolResult
+from app.cdm.adapters.custom_pipeline.page_flags import PageFlags
+from app.cdm.adapters.custom_pipeline.tools.base import ToolResult
 from app.cdm.models import BBox, Block, BlockRole
 
-
-def _bbox(x0, y0, x1, y1):
-    return BBox(x0=x0, y0=y0, x1=x1, y1=y1)
+TE, TB, OC = Capability.TEXT_EXTRACTION, Capability.TABLE_DETECTION, Capability.TEXT_OCR
 
 
-def test_overlap_fraction_full_containment():
-    table = _bbox(0.0, 0.0, 1.0, 1.0)
-    fitz = _bbox(0.1, 0.1, 0.2, 0.2)
-    assert overlap_fraction(table, fitz) == 1.0
+def _b(bid, x0, y0, x1, y1, role=BlockRole.TEXT):
+    return Block(id=bid, role=role, native_type=role.value, page_index=0,
+                 bbox=BBox(x0=x0, y0=y0, x1=x1, y1=y1))
 
 
-def test_overlap_fraction_no_overlap():
-    table = _bbox(0.0, 0.0, 0.1, 0.1)
-    fitz = _bbox(0.5, 0.5, 0.6, 0.6)
-    assert overlap_fraction(table, fitz) == 0.0
+def _res(tool_id, cap, blocks):
+    return ToolResult(tool_id=tool_id, blocks_by_capability={cap: blocks},
+                      native_by_block={b.id: {} for b in blocks})
 
 
-def _fitz_result():
-    blocks = [
-        Block(id="fitz:0:0", role=BlockRole.TEXT, native_type="text",
-              text="heading", page_index=0, bbox=_bbox(0.1, 0.05, 0.9, 0.1)),
-        Block(id="fitz:0:1", role=BlockRole.TEXT, native_type="text",
-              text="inside table", page_index=0, bbox=_bbox(0.2, 0.55, 0.8, 0.65)),
-    ]
-    return ToolResult(
-        tool_id="fitz", blocks=blocks,
-        page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
-        raw={"pages": {}},
-        native_by_block={"fitz:0:0": {"k": "h"}, "fitz:0:1": {"k": "t"}},
-    )
+def _flags(cid=False):
+    return {0: PageFlags(index=0, char_count=100, pua_ratio=0.0, cid_corrupt=cid)}
 
 
-def _camelot_result():
-    block = Block(id="camelot:0:0", role=BlockRole.TABLE, native_type="table",
-                  page_index=0, bbox=_bbox(0.1, 0.5, 0.9, 0.7))
-    return ToolResult(
-        tool_id="camelot", blocks=[block], page_meta={},
-        raw={"tables": []}, native_by_block={"camelot:0:0": {"acc": 99}},
-    )
+def test_overlap_fraction_is_share_of_the_loser():
+    assert overlap_fraction(BBox(x0=0, y0=0, x1=1, y1=1),
+                            BBox(x0=0, y0=0, x1=0.5, y1=1)) == 1.0
 
 
-def test_merge_evicts_overlapping_fitz_block():
-    result = merge(_fitz_result(), _camelot_result(),
-                   source_document_id="doc1", eviction_overlap_threshold=0.5)
-    texts = [b.text for b in result.blocks]
-    assert "heading" in texts
-    assert "inside table" not in texts  # evicted by the table
-    assert result.raw_output["evicted"][0]["reason"] == "spatial_overlap"
-    assert result.raw_output["evicted"][0]["won_by"].startswith("doc1:0:")
+def test_overlap_fraction_of_zero_area_loser_is_zero():
+    assert overlap_fraction(BBox(x0=0, y0=0, x1=1, y1=1),
+                            BBox(x0=0.5, y0=0.5, x1=0.5, y1=0.5)) == 0.0
 
 
-def test_merge_mints_block_ids_and_reading_order():
-    result = merge(_fitz_result(), _camelot_result(),
-                   source_document_id="doc1", eviction_overlap_threshold=0.5)
-    for b in result.blocks:
-        assert b.id.startswith("doc1:0:")
-        assert b.reading_order is not None
-    # heading (y0=0.05) comes before the table (y0=0.5)
-    ordered = sorted(result.blocks, key=lambda b: b.reading_order)
-    assert ordered[0].text == "heading"
-    assert ordered[1].role == BlockRole.TABLE
+def test_table_evicts_overlapping_text():
+    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.9, 0.4)])
+    table = _res("fitz_tables", TB, [_b("tb1", 0.0, 0.0, 1.0, 0.5, BlockRole.TABLE)])
+    out = merge([text, table], source_document_id="d", page_flags=_flags())
+    assert len(out.blocks) == 1
+    rec = out.raw_output["evicted"][0]
+    assert rec["capability"] == "text_extraction"
+    assert rec["winner_capability"] == "table_detection"
+    assert rec["reason"] == "covered_by"
+    assert rec["won_by"] == "d:0:0"
 
 
-def test_merge_raw_output_has_tool_block_maps():
-    result = merge(_fitz_result(), _camelot_result(),
-                   source_document_id="doc1", eviction_overlap_threshold=0.5)
-    ro = result.raw_output
-    assert set(ro["tools"].keys()) == {"fitz", "camelot"}
-    assert "raw" in ro["tools"]["fitz"]
-    assert "block_map" in ro["tools"]["camelot"]
-    # surviving table maps to its native record
-    table_id = next(b.id for b in result.blocks if b.role == BlockRole.TABLE)
-    assert ro["tools"]["camelot"]["block_map"][table_id] == {"acc": 99}
+def test_native_text_evicts_overlapping_ocr_by_default():
+    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 1.0, 0.5)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.1, 0.1, 0.3, 0.2)])
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags())
+    assert [b.id for b in out.blocks] == ["d:0:0"]
+    assert out.raw_output["evicted"][0]["capability"] == "text_ocr"
 
 
-def test_merge_raw_output_key_uses_table_result_tool_id():
-    """raw_output["tools"] key is the table tool's tool_id, not the string "camelot"."""
-    block = Block(
-        id="fitz_tables:0:0", role=BlockRole.TABLE, native_type="table",
-        page_index=0, bbox=_bbox(0.1, 0.5, 0.9, 0.7),
-    )
-    fitz_tables_result = ToolResult(
-        tool_id="fitz_tables", blocks=[block], page_meta={},
-        raw={"tables": []}, native_by_block={"fitz_tables:0:0": {"rows": 2}},
-    )
-    result = merge(
-        _fitz_result(), fitz_tables_result,
-        source_document_id="doc1", eviction_overlap_threshold=0.5,
-    )
-    assert "fitz_tables" in result.raw_output["tools"]
-    assert "camelot" not in result.raw_output["tools"]
+def test_ocr_survives_where_no_native_text_covers_it():
+    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 1.0, 0.2)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.6, 0.5, 0.8)])  # no overlap
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags())
+    assert len(out.blocks) == 2
+    assert out.raw_output["evicted"] == []
+
+
+def test_cid_corrupt_page_lets_ocr_evict_native_text():
+    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.0, 1.0, 0.5)])
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags(cid=True))
+    assert out.raw_output["evicted"][0]["capability"] == "text_extraction"
+    assert out.raw_output["evicted"][0]["winner_capability"] == "text_ocr"
+
+
+def test_ocr_prefer_flips_precedence_for_the_whole_run():
+    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.0, 1.0, 0.5)])
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags(), ocr_prefer=True)
+    assert out.raw_output["evicted"][0]["capability"] == "text_extraction"
+
+
+def test_reading_order_is_contiguous_from_zero_per_page():
+    text = _res("fitz", TE, [_b("a", 0.0, 0.5, 0.2, 0.6), _b("b", 0.0, 0.1, 0.2, 0.2)])
+    out = merge([text], source_document_id="d", page_flags=_flags())
+    assert [b.reading_order for b in out.blocks] == [0, 1]
+    assert [b.id for b in out.blocks] == ["d:0:0", "d:0:1"]
+
+
+def test_audit_trail_is_keyed_by_instance():
+    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 0.2, 0.2)])
+    out = merge([text], source_document_id="d", page_flags=_flags())
+    assert "instances" in out.raw_output and "tools" not in out.raw_output
+    assert out.raw_output["instances"]["fitz"]["capabilities"] == ["text_extraction"]
+    assert "d:0:0" in out.raw_output["instances"]["fitz"]["block_map"]

--- a/backend/tests/cdm/adapters/custom_pipeline/test_page_flags.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_page_flags.py
@@ -1,0 +1,44 @@
+import fitz
+from app.cdm.adapters.custom_pipeline.page_flags import (
+    PageFlagsConfig, compute_page_flags, pua_ratio,
+)
+
+
+def _pdf(tmp_path, text: str):
+    doc = fitz.open(); page = doc.new_page(width=612, height=792)
+    if text:
+        page.insert_text((72, 72), text, fontsize=11)
+    p = tmp_path / "f.pdf"; doc.save(str(p)); doc.close()
+    return p
+
+
+def test_empty_page_has_no_usable_text_layer(tmp_path):
+    flags = compute_page_flags(_pdf(tmp_path, ""), PageFlagsConfig())
+    assert flags[0].char_count == 0
+    assert flags[0].cid_corrupt is False
+
+
+def test_text_page_reports_char_count(tmp_path):
+    flags = compute_page_flags(_pdf(tmp_path, "Hello invoice world"), PageFlagsConfig())
+    assert flags[0].char_count >= 15
+    assert flags[0].pua_ratio == 0.0
+    assert flags[0].cid_corrupt is False
+
+
+def test_pua_ratio_detects_private_use_characters():
+    # A broken CID font decodes to private-use codepoints. We cannot synthesize
+    # such a PDF (base-14 fonts substitute these glyphs on write), so the
+    # heuristic is tested directly on the text it would extract.
+    corrupt = "".join(chr(0xE000 + (i % 10)) for i in range(60))
+    assert pua_ratio(corrupt) == 1.0
+    assert pua_ratio("Hello invoice world") == 0.0
+    assert pua_ratio("") == 0.0
+    assert pua_ratio("ab" + chr(0xE000) * 2) == 0.5
+
+
+def test_cid_corrupt_is_derived_from_the_configured_threshold(tmp_path):
+    # Drive the threshold below any achievable ratio to prove cid_corrupt is
+    # wired to config rather than hardcoded.
+    pdf = _pdf(tmp_path, "Hello invoice world")
+    assert compute_page_flags(pdf, PageFlagsConfig()).get(0).cid_corrupt is False
+    assert compute_page_flags(pdf, PageFlagsConfig(cid_ratio=-0.1))[0].cid_corrupt is True

--- a/backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
@@ -1,0 +1,119 @@
+"""PR A is a behaviour-preserving refactor.
+
+`ParsedDocument` must be equivalent to the pre-refactor pipeline for any config
+expressible under the old contract. `ParseRun.raw_payload` is exempt — its shape
+changes on purpose ("tools" -> "instances"), because it is an audit artifact,
+not part of `ParsedDocument`.
+"""
+from datetime import datetime, timezone
+
+import fitz
+import pytest
+
+from app.cdm.models import BlockRole
+from app.cdm.source import ParseRunStatus, SourceDocument
+from app.services.parsing.custom_pipeline_runner import run_custom_pipeline
+
+
+def _source() -> SourceDocument:
+    return SourceDocument(
+        id="src-1",
+        sha256="b" * 64,
+        filename="equiv.pdf",
+        mime_type="application/pdf",
+        byte_size=1234,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture
+def ruled_table_pdf(tmp_path):
+    """Text plus a ruled grid, so both text_extraction and table_detection fire."""
+    d = fitz.open()
+    page = d.new_page(width=595, height=842)
+    page.insert_text(fitz.Point(72, 72), "Quarterly revenue report", fontsize=14)
+    page.insert_text(fitz.Point(72, 92), "Figures are provisional.", fontsize=10)
+    col_x, row_y = [72, 236, 400], [200, 250, 300]
+    for x in col_x:
+        page.draw_line(fitz.Point(x, row_y[0]), fitz.Point(x, row_y[-1]), width=1)
+    for y in row_y:
+        page.draw_line(fitz.Point(col_x[0], y), fitz.Point(col_x[-1], y), width=1)
+    page.insert_text(fitz.Point(80, 235), "Name", fontsize=11)
+    page.insert_text(fitz.Point(244, 235), "Value", fontsize=11)
+    page.insert_text(fitz.Point(80, 285), "alpha", fontsize=11)
+    page.insert_text(fitz.Point(244, 285), "1", fontsize=11)
+    path = tmp_path / "equiv.pdf"
+    d.save(str(path)); d.close()
+    return path
+
+
+@pytest.mark.asyncio
+async def test_text_only_pipeline_output_is_stable(ruled_table_pdf):
+    run, parsed = await run_custom_pipeline(
+        source=_source(), file_path=str(ruled_table_pdf),
+        representation_kind="extract_rich",
+        config={"tools": {"fitz": {"tool": "fitz", "config": {}}},
+                "capabilities": {"text_extraction": "fitz"}},
+        client=None,
+    )
+    assert run.status == ParseRunStatus.SUCCEEDED
+    assert parsed.page_count == 1
+    assert "Quarterly revenue report" in parsed.full_text
+
+    # Reading order is contiguous from 0 on every page (unchanged (y0, x0) sort).
+    orders = [b.reading_order for b in parsed.blocks if b.page_index == 0]
+    assert orders == list(range(len(orders)))
+
+    # Block ids follow the documented "<source>:<page>:<order>" scheme.
+    assert parsed.blocks[0].id == "src-1:0:0"
+    assert all(b.id.startswith("src-1:") for b in parsed.blocks)
+
+
+@pytest.mark.asyncio
+async def test_table_tool_evicts_overlapping_text_exactly_as_before(ruled_table_pdf):
+    config = {
+        "tools": {"fitz": {"tool": "fitz", "config": {}},
+                  "tbl": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+    }
+    run, parsed = await run_custom_pipeline(
+        source=_source(), file_path=str(ruled_table_pdf),
+        representation_kind="extract_rich", config=config, client=None,
+    )
+    assert run.status == ParseRunStatus.SUCCEEDED
+    assert any(b.role == BlockRole.TABLE for b in parsed.blocks)
+
+    # The table won over the text it covers — same rule, same 0.5 threshold.
+    assert run.raw_payload["evicted"], "expected the table to evict covered text"
+    for rec in run.raw_payload["evicted"]:
+        assert rec["capability"] == "text_extraction"
+        assert rec["winner_capability"] == "table_detection"
+        assert rec["reason"] == "covered_by"
+        assert rec["overlap_fraction"] > 0.5
+
+    # The audit trail changed shape on purpose.
+    assert "instances" in run.raw_payload and "tools" not in run.raw_payload
+
+
+@pytest.mark.asyncio
+async def test_table_tool_does_not_change_the_surviving_text(ruled_table_pdf):
+    """Adding table_detection must only remove text the table covers — never
+    alter the text blocks that survive."""
+    base = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
+            "capabilities": {"text_extraction": "fitz"}}
+    with_table = {
+        "tools": {"fitz": {"tool": "fitz", "config": {}},
+                  "tbl": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+    }
+    _, text_only = await run_custom_pipeline(
+        source=_source(), file_path=str(ruled_table_pdf),
+        representation_kind="extract_rich", config=base, client=None)
+    _, both = await run_custom_pipeline(
+        source=_source(), file_path=str(ruled_table_pdf),
+        representation_kind="extract_rich", config=with_table, client=None)
+
+    surviving = {b.text for b in both.blocks if b.role == BlockRole.TEXT}
+    original = {b.text for b in text_only.blocks if b.role == BlockRole.TEXT}
+    assert surviving <= original
+    assert "Quarterly revenue report" in " ".join(surviving)

--- a/backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
@@ -1,4 +1,7 @@
-from app.cdm.adapters.custom_pipeline.tools.base import PageMeta, ToolResult, clamp01
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.tools.base import (
+    PageMeta, PipelineTool, ToolResult, clamp01,
+)
 from app.cdm.models import Block, BlockRole
 
 
@@ -14,18 +17,29 @@ def test_page_meta_defaults():
     assert pm.rotation == 0
 
 
-def test_tool_result_holds_blocks_and_native_records():
+def test_tool_result_holds_blocks_by_capability_and_native_records():
     block = Block(id="fitz:0:0", role=BlockRole.TEXT, native_type="text",
                   text="hi", page_index=0)
     result = ToolResult(
         tool_id="fitz",
-        blocks=[block],
+        blocks_by_capability={Capability.TEXT_EXTRACTION: [block]},
         page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
         raw={"pages": {}},
         native_by_block={"fitz:0:0": {"type": 0}},
     )
     assert result.tool_id == "fitz"
-    assert result.blocks[0].text == "hi"
+    assert result.blocks_by_capability[Capability.TEXT_EXTRACTION][0].text == "hi"
     assert result.native_by_block["fitz:0:0"] == {"type": 0}
     assert result.warnings == []
     assert result.duration_ms == 0
+
+
+def test_pipeline_tool_protocol_is_runtime_checkable():
+    class Fake:
+        tool_id = "fake"
+        provides = frozenset({Capability.TEXT_EXTRACTION})
+
+        def run(self, pdf_path, *, pages=None, page_meta=None, emit=frozenset()):
+            return ToolResult(tool_id="fake", blocks_by_capability={}, page_meta={})
+
+    assert isinstance(Fake(), PipelineTool)

--- a/backend/tests/services/parsing/test_custom_pipeline_runner.py
+++ b/backend/tests/services/parsing/test_custom_pipeline_runner.py
@@ -28,7 +28,8 @@ def _source() -> SourceDocument:
 @pytest.mark.asyncio
 async def test_run_custom_pipeline_fitz_only_succeeds():
     config = {
-        "tools": [{"tool_id": "fitz", "config": {}}],
+        "tools": {"fitz": {"tool": "fitz", "config": {}}},
+        "capabilities": {"text_extraction": "fitz"},
         "eviction_overlap_threshold": 0.5,
     }
     run, doc = await run_custom_pipeline(
@@ -42,8 +43,8 @@ async def test_run_custom_pipeline_fitz_only_succeeds():
     assert run.status == ParseRunStatus.SUCCEEDED
     assert run.source_document_id == "doc-xyz"
     assert run.raw_payload is not None
-    assert "tools" in run.raw_payload
-    assert "fitz" in run.raw_payload["tools"]
+    assert "instances" in run.raw_payload
+    assert "fitz" in run.raw_payload["instances"]
     assert doc.parse_run_id == run.id
     assert doc.page_count == 2
     assert any(b.role == BlockRole.TEXT for b in doc.blocks)
@@ -64,7 +65,8 @@ async def test_run_custom_pipeline_raw_payload_json_serializable_with_images(tmp
     doc_pdf.save(str(pdf))
     doc_pdf.close()
 
-    config = {"tools": [{"tool_id": "fitz", "config": {}}]}
+    config = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
+              "capabilities": {"text_extraction": "fitz"}}
     run, _ = await run_custom_pipeline(
         source=_source(),
         file_path=str(pdf),
@@ -79,7 +81,8 @@ async def test_run_custom_pipeline_raw_payload_json_serializable_with_images(tmp
 
 @pytest.mark.asyncio
 async def test_run_custom_pipeline_wraps_failure(tmp_path):
-    config = {"tools": [{"tool_id": "fitz", "config": {}}]}
+    config = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
+              "capabilities": {"text_extraction": "fitz"}}
     with pytest.raises(CustomPipelineRunError) as ei:
         await run_custom_pipeline(
             source=_source(),
@@ -118,10 +121,9 @@ async def test_run_custom_pipeline_fitz_tables_emits_table_blocks(tmp_path):
     doc.close()
 
     config = {
-        "tools": [
-            {"tool_id": "fitz", "config": {}},
-            {"tool_id": "fitz_tables", "config": {}},
-        ],
+        "tools": {"fitz": {"tool": "fitz", "config": {}},
+                  "fitz_tables": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "fitz", "table_detection": "fitz_tables"},
         "eviction_overlap_threshold": 0.5,
     }
     run, doc_result = await run_custom_pipeline(
@@ -132,20 +134,17 @@ async def test_run_custom_pipeline_fitz_tables_emits_table_blocks(tmp_path):
         client=None,
     )
     assert run.status == ParseRunStatus.SUCCEEDED
-    assert "fitz_tables" in run.raw_payload["tools"]
+    assert "fitz_tables" in run.raw_payload["instances"]
     assert any(b.role == BlockRole.TABLE for b in doc_result.blocks)
 
 
 @pytest.mark.asyncio
-async def test_run_custom_pipeline_rejects_dual_table_tools():
-    config = {
-        "tools": [
-            {"tool_id": "fitz", "config": {}},
-            {"tool_id": "fitz_tables", "config": {}},
-            {"tool_id": "camelot", "config": {}},
-        ],
-    }
-    with pytest.raises(CustomPipelineRunError) as ei:
+async def test_run_custom_pipeline_requires_a_text_extraction_slot():
+    """Two table tools are now structurally unrepresentable (the capabilities map
+    has a single table_detection key), so the old dual-table guard is gone. What
+    remains worth asserting is the required slot."""
+    config = {"tools": {}, "capabilities": {}}
+    with pytest.raises(CustomPipelineRunError, match="text_extraction"):
         await run_custom_pipeline(
             source=_source(),
             file_path=str(FIXTURES / "simple_text.pdf"),
@@ -153,4 +152,3 @@ async def test_run_custom_pipeline_rejects_dual_table_tools():
             config=config,
             client=None,
         )
-    assert ei.value.run.status == ParseRunStatus.FAILED

--- a/docs/superpowers/plans/2026-07-10-capability-slot-refactor.md
+++ b/docs/superpowers/plans/2026-07-10-capability-slot-refactor.md
@@ -1,0 +1,1473 @@
+# Capability-Slot Refactor (WS2 slice 1, PR A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the custom pipeline's flat `tools: [...]` list and binary merger with capability slots — one tool per IDP capability — and an N-way, capability-aware merger, **without changing parse output**.
+
+**Architecture:** A closed `Capability` enum. Config becomes named tool *instances* plus a `capabilities` map referencing them; one instance runs once however many slots reference it, and is told which capabilities to `emit` (masking). The merger flattens all tool output, ranks blocks by the capability that produced them (page-dependent precedence), evicts lower-ranked blocks on spatial overlap, and emits a capability-tagged audit trail. No OCR in this PR.
+
+**Tech Stack:** Python 3.12, pydantic v2, PyMuPDF (`fitz`), camelot. React 18, TypeScript, vitest.
+
+**Spec:** [docs/superpowers/specs/2026-07-10-ocr-capability-pipeline-design.md](../specs/2026-07-10-ocr-capability-pipeline-design.md) (§2, §3, §4b PR A, §5, §6)
+
+## Global Constraints
+
+- **Pre-implementation gate:** a GitHub issue with acceptance criteria must exist and be confirmed with the user BEFORE Task 1. Branch `feat/ocr-capability-pipeline` already exists.
+- **PR A is a behaviour-preserving refactor.** For any document and any pipeline expressible under the old config, the new pipeline must produce an **identical `ParsedDocument`** (same `blocks`, `pages`, `full_text`, `full_markdown`). Task 9 proves this.
+- **Exception, intentional:** `ParseRun.raw_payload` changes shape (`"tools"` → `"instances"`, capability-tagged eviction records). It is an audit artifact, not part of `ParsedDocument`. Do not try to preserve it.
+- **No OCR in this PR.** `Capability.TEXT_OCR` exists in the enum and in precedence logic (pure, fully unit-tested), but no tool provides it. `has_uncovered_image`, the `precedence` config field, and `tesseract_tool.py` are **PR B**.
+- **No compat shim.** There is no legacy data; delete the old config shape outright.
+- **Delete, don't generalize:** `TABLE_TOOL_IDS`, its `len(...) > 1` guard, and the hardcoded `"custom pipeline requires a 'fitz' tool"` string.
+- Backend tests: `cd backend && uv run python -m pytest -o "addopts=" <path> -v` (SQLite; no Postgres needed).
+- Frontend: `cd frontend && npx vitest run <path>`, `npm run lint`, `npm run build`.
+- `parser_eval` treats pipeline config as an opaque dict — **do not** change anything under `app/services/parser_eval/`.
+
+---
+
+## File Structure
+
+**Create**
+- `backend/app/cdm/adapters/custom_pipeline/capabilities.py` — `Capability` enum, kinds, precedence
+- `backend/app/cdm/adapters/custom_pipeline/page_flags.py` — `PageFlags`, `compute_page_flags`
+
+**Modify**
+- `backend/app/cdm/adapters/custom_pipeline/tools/base.py` — `LocalTool` → `PipelineTool`; `ToolResult.blocks_by_capability`
+- `backend/app/cdm/adapters/custom_pipeline/tools/{fitz_tool,fitz_tables_tool,camelot_tool}.py` — new contract; `page_meta` moves constructor → `run()`
+- `backend/app/cdm/adapters/custom_pipeline/config.py` — instances + capabilities contract, masking, validation
+- `backend/app/cdm/adapters/custom_pipeline/merger.py` — N-way, capability-aware
+- `backend/app/cdm/adapters/custom_pipeline/__init__.py` — exports
+- `backend/app/services/parsing/custom_pipeline_runner.py` — slot-driven
+- `frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx` (+ its test)
+- `frontend/src/components/documents/ParseMethodSelector.test.tsx`
+
+---
+
+## Task 1: Capability enum + precedence
+
+**Files:**
+- Create: `backend/app/cdm/adapters/custom_pipeline/capabilities.py`
+- Test: `backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py`
+
+**Interfaces:**
+- Produces: `Capability` (str enum), `BLOCK_PRODUCING: frozenset[Capability]`, `STAGING: frozenset[Capability]`, `resolve_precedence(cid_corrupt: bool, ocr_prefer: bool) -> Dict[Capability, int]` (higher rank wins; staging capabilities absent from the map).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
+from app.cdm.adapters.custom_pipeline.capabilities import (
+    BLOCK_PRODUCING, STAGING, Capability, resolve_precedence,
+)
+
+T, TB, O, L = (Capability.TEXT_EXTRACTION, Capability.TABLE_DETECTION,
+               Capability.TEXT_OCR, Capability.LAYOUT_ANALYSIS)
+
+
+def test_capability_kinds():
+    assert BLOCK_PRODUCING == frozenset({T, TB, O})
+    assert STAGING == frozenset({L})
+
+
+def test_default_order_table_beats_text_beats_ocr():
+    r = resolve_precedence(cid_corrupt=False, ocr_prefer=False)
+    assert r[TB] > r[T] > r[O]
+
+
+def test_cid_corrupt_page_flips_ocr_above_text():
+    r = resolve_precedence(cid_corrupt=True, ocr_prefer=False)
+    assert r[TB] > r[O] > r[T]
+
+
+def test_ocr_prefer_flips_ocr_above_text():
+    r = resolve_precedence(cid_corrupt=False, ocr_prefer=True)
+    assert r[TB] > r[O] > r[T]
+
+
+def test_staging_capability_has_no_rank():
+    assert L not in resolve_precedence(cid_corrupt=False, ocr_prefer=False)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_capabilities.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.cdm.adapters.custom_pipeline.capabilities`.
+
+- [ ] **Step 3: Write `capabilities.py`**
+
+```python
+"""IDP capabilities and their precedence.
+
+One tool fills at most one capability slot. Blocks are tagged with the
+capability that produced them; the merger ranks blocks by that tag.
+"""
+from __future__ import annotations
+from enum import Enum
+from typing import Dict
+
+
+class Capability(str, Enum):
+    TEXT_EXTRACTION = "text_extraction"
+    TABLE_DETECTION = "table_detection"
+    TEXT_OCR = "text_ocr"
+    LAYOUT_ANALYSIS = "layout_analysis"
+
+
+#: Capabilities whose blocks compete for page area (governed by precedence).
+BLOCK_PRODUCING = frozenset({
+    Capability.TEXT_EXTRACTION,
+    Capability.TABLE_DETECTION,
+    Capability.TEXT_OCR,
+})
+
+#: Capabilities that order/route rather than compete. No tools yet.
+STAGING = frozenset({Capability.LAYOUT_ANALYSIS})
+
+
+def resolve_precedence(*, cid_corrupt: bool, ocr_prefer: bool) -> Dict[Capability, int]:
+    """Rank block-producing capabilities for one page. Higher wins.
+
+    Structure always beats loose text. The only variable is whether OCR sits
+    above or below native text — the CID flip and `prefer` are the same
+    mechanism, applied per-page vs per-run.
+    """
+    ocr_outranks_text = ocr_prefer or cid_corrupt
+    if ocr_outranks_text:
+        return {Capability.TABLE_DETECTION: 3, Capability.TEXT_OCR: 2,
+                Capability.TEXT_EXTRACTION: 1}
+    return {Capability.TABLE_DETECTION: 3, Capability.TEXT_EXTRACTION: 2,
+            Capability.TEXT_OCR: 1}
+```
+
+> The test calls `resolve_precedence(cid_corrupt=..., ocr_prefer=...)` — keyword-only, matching the signature above.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_capabilities.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/capabilities.py backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
+git commit -m "feat(pipeline): Capability enum + page-dependent precedence"
+```
+
+---
+
+## Task 2: Page flags
+
+**Files:**
+- Create: `backend/app/cdm/adapters/custom_pipeline/page_flags.py`
+- Test: `backend/tests/cdm/adapters/custom_pipeline/test_page_flags.py`
+
+**Interfaces:**
+- Produces: `PageFlagsConfig(min_chars: int = 10, cid_ratio: float = 0.3)`, `PageFlags(index, char_count, pua_ratio, cid_corrupt)`, `compute_page_flags(pdf_path: Path, cfg: PageFlagsConfig) -> Dict[int, PageFlags]`.
+- `has_uncovered_image` is **PR B**. Do not add it here.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/cdm/adapters/custom_pipeline/test_page_flags.py
+import fitz
+from app.cdm.adapters.custom_pipeline.page_flags import (
+    PageFlagsConfig, compute_page_flags,
+)
+
+
+def _pdf(tmp_path, text: str):
+    doc = fitz.open(); page = doc.new_page(width=612, height=792)
+    if text:
+        page.insert_text((72, 72), text, fontsize=11)
+    p = tmp_path / "f.pdf"; doc.save(str(p)); doc.close()
+    return p
+
+
+def test_empty_page_has_no_usable_text_layer(tmp_path):
+    flags = compute_page_flags(_pdf(tmp_path, ""), PageFlagsConfig())
+    assert flags[0].char_count == 0
+    assert flags[0].cid_corrupt is False
+
+
+def test_text_page_reports_char_count(tmp_path):
+    flags = compute_page_flags(_pdf(tmp_path, "Hello invoice world"), PageFlagsConfig())
+    assert flags[0].char_count >= 15
+    assert flags[0].pua_ratio == 0.0
+    assert flags[0].cid_corrupt is False
+
+
+def test_cid_corrupt_when_private_use_ratio_exceeds_threshold(tmp_path):
+    # Private-use-area characters are what a broken CID font decodes to.
+    corrupt = "".join(chr(0xE000 + (i % 10)) for i in range(60))
+    flags = compute_page_flags(_pdf(tmp_path, corrupt), PageFlagsConfig())
+    assert flags[0].pua_ratio > 0.3
+    assert flags[0].cid_corrupt is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_page_flags.py -v`
+Expected: FAIL — `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write `page_flags.py`**
+
+```python
+"""Per-page facts consumed by the merger (CID precedence flip) and, in PR B,
+by the OCR tool's `pages: "auto"` selector.
+
+fitz metadata only — no rasterization. Deliberately independent of `app/probe/`:
+the probe is advisory evidence, this is deterministic execution state.
+"""
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict
+import fitz
+from pydantic import BaseModel
+
+
+class PageFlagsConfig(BaseModel):
+    min_chars: int = 10      # below this, the page has no usable text layer
+    cid_ratio: float = 0.3   # private-use-area char ratio => cid_corrupt
+
+
+class PageFlags(BaseModel):
+    index: int
+    char_count: int
+    pua_ratio: float
+    cid_corrupt: bool
+
+
+def compute_page_flags(pdf_path: Path, cfg: PageFlagsConfig) -> Dict[int, PageFlags]:
+    out: Dict[int, PageFlags] = {}
+    doc = fitz.open(str(pdf_path))
+    try:
+        for i in range(len(doc)):
+            text = doc[i].get_text("text")
+            stripped = text.strip()
+            pua = sum(1 for c in text if 0xE000 <= ord(c) <= 0xF8FF)
+            ratio = (pua / len(text)) if text else 0.0
+            out[i] = PageFlags(
+                index=i,
+                char_count=len(stripped),
+                pua_ratio=ratio,
+                cid_corrupt=ratio > cfg.cid_ratio,
+            )
+    finally:
+        doc.close()
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_page_flags.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/page_flags.py backend/tests/cdm/adapters/custom_pipeline/test_page_flags.py
+git commit -m "feat(pipeline): per-page flags (char_count, pua_ratio, cid_corrupt)"
+```
+
+---
+
+## Task 3: `PipelineTool` contract
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/base.py`
+- Test: `backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py` (rewrite)
+
+**Interfaces:**
+- Consumes: `Capability` (Task 1).
+- Produces: `PipelineTool` protocol with `tool_id: str`, `provides: frozenset[Capability]`, `run(pdf_path, *, pages=None, page_meta=None, emit) -> ToolResult`; `ToolResult` with `blocks_by_capability: Dict[Capability, List[Block]]` (replaces `blocks`); `PageMeta` and `clamp01` unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.tools.base import (
+    PageMeta, PipelineTool, ToolResult, clamp01,
+)
+from app.cdm.models import Block, BlockRole
+
+
+def test_clamp01_bounds():
+    assert clamp01(-0.5) == 0.0 and clamp01(1.5) == 1.0 and clamp01(0.25) == 0.25
+
+
+def test_tool_result_holds_blocks_by_capability():
+    b = Block(id="x", role=BlockRole.TEXT, page_index=0)
+    r = ToolResult(
+        tool_id="fitz",
+        blocks_by_capability={Capability.TEXT_EXTRACTION: [b]},
+        page_meta={0: PageMeta(index=0, width=612, height=792)},
+    )
+    assert r.blocks_by_capability[Capability.TEXT_EXTRACTION][0].id == "x"
+    assert r.warnings == [] and r.duration_ms == 0
+
+
+def test_pipeline_tool_protocol_is_runtime_checkable():
+    class Fake:
+        tool_id = "fake"
+        provides = frozenset({Capability.TEXT_EXTRACTION})
+        def run(self, pdf_path, *, pages=None, page_meta=None, emit=frozenset()):
+            return ToolResult(tool_id="fake", blocks_by_capability={}, page_meta={})
+
+    assert isinstance(Fake(), PipelineTool)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_tools_base.py -v`
+Expected: FAIL — `ImportError: cannot import name 'PipelineTool'`.
+
+- [ ] **Step 3: Rewrite `tools/base.py`**
+
+```python
+"""Contracts shared by all custom-pipeline tools.
+
+A PipelineTool reads a PDF and returns CDM Blocks (normalized bboxes) keyed by
+the capability that produced them, plus the native records behind them.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.models import Block
+
+
+def clamp01(v: float) -> float:
+    """Clamp a coordinate fraction into the [0, 1] range."""
+    return max(0.0, min(1.0, v))
+
+
+class PageMeta(BaseModel):
+    """Authoritative page geometry, sourced from the text_extraction tool."""
+    index: int
+    width: float       # PDF points
+    height: float      # PDF points
+    unit: str = "points"
+    rotation: int = 0  # degrees
+
+
+class ToolResult(BaseModel):
+    """Output of one PipelineTool.run() invocation."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    tool_id: str
+    blocks_by_capability: Dict[Capability, List[Block]] = {}
+    page_meta: Dict[int, PageMeta] = {}
+    raw: Any = None
+    native_by_block: Dict[str, Any] = {}
+    warnings: List[str] = []
+    duration_ms: int = 0
+
+
+@runtime_checkable
+class PipelineTool(Protocol):
+    tool_id: str
+    provides: frozenset[Capability]
+
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+        emit: frozenset[Capability],
+    ) -> ToolResult: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_tools_base.py -v`
+Expected: PASS (3 passed). Other pipeline tests will fail until Tasks 4–8 — that is expected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/tools/base.py backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
+git commit -m "refactor(pipeline): LocalTool -> PipelineTool; blocks_by_capability"
+```
+
+---
+
+## Task 4: Port `FitzTool`
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py`
+- Modify: `backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py`
+
+**Interfaces:**
+- Consumes: `Capability`, `ToolResult`, `PageMeta`, `clamp01`.
+- Produces: `FitzTool` with `provides = frozenset({Capability.TEXT_EXTRACTION})`; `run(..., emit=...)` returns `blocks_by_capability={TEXT_EXTRACTION: [...]}`.
+
+- [ ] **Step 1: Update the test to the new contract**
+
+Open `backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py`. Every call site changes from `FitzTool().run(pdf)` to `FitzTool().run(pdf, emit=frozenset({Capability.TEXT_EXTRACTION}))`, and every `result.blocks` becomes `result.blocks_by_capability[Capability.TEXT_EXTRACTION]`. Add this test:
+
+```python
+# append to test_fitz_tool.py
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+
+def test_fitz_declares_text_extraction_and_emits_under_it(tmp_path):
+    import fitz as _f
+    doc = _f.open(); p = doc.new_page(); p.insert_text((72, 72), "hello world text")
+    path = tmp_path / "a.pdf"; doc.save(str(path)); doc.close()
+
+    tool = FitzTool()
+    assert tool.provides == frozenset({Capability.TEXT_EXTRACTION})
+    result = tool.run(path, emit=frozenset({Capability.TEXT_EXTRACTION}))
+    assert list(result.blocks_by_capability) == [Capability.TEXT_EXTRACTION]
+    assert len(result.blocks_by_capability[Capability.TEXT_EXTRACTION]) >= 1
+
+
+def test_fitz_rejects_an_emit_it_does_not_provide(tmp_path):
+    import fitz as _f, pytest
+    doc = _f.open(); doc.new_page(); path = tmp_path / "b.pdf"; doc.save(str(path)); doc.close()
+    with pytest.raises(ValueError, match="cannot emit"):
+        FitzTool().run(path, emit=frozenset({Capability.TABLE_DETECTION}))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_fitz_tool.py -v`
+Expected: FAIL — `run()` has no `emit` kwarg / no `provides`.
+
+- [ ] **Step 3: Port `fitz_tool.py`**
+
+Change only the class surface; the block-building body is untouched.
+
+```python
+# at the imports
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+
+# replace the class header and run() signature
+class FitzTool:
+    tool_id = "fitz"
+    provides = frozenset({Capability.TEXT_EXTRACTION})
+
+    def __init__(self, config: Optional[FitzConfig] = None) -> None:
+        self.config = config or FitzConfig()
+
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,   # unused; fitz is the source
+        emit: frozenset[Capability] = frozenset({Capability.TEXT_EXTRACTION}),
+    ) -> ToolResult:
+        if not emit <= self.provides:
+            raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
+        ...  # body unchanged, building `blocks`
+```
+
+and the return:
+
+```python
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks_by_capability={Capability.TEXT_EXTRACTION: blocks},
+            page_meta=page_meta_out,          # rename the local dict to avoid shadowing the kwarg
+            raw={"pages": native_raw},
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )
+```
+
+> Rename the local `page_meta` accumulator to `page_meta_out` so it does not shadow the new keyword argument.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_fitz_tool.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
+git commit -m "refactor(pipeline): port FitzTool to PipelineTool contract"
+```
+
+---
+
+## Task 5: Port `FitzTablesTool` and `CamelotTool`
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/fitz_tables_tool.py`
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/camelot_tool.py`
+- Modify: `backend/tests/cdm/adapters/custom_pipeline/test_fitz_tables_tool.py`, `test_camelot_tool.py`
+
+**Interfaces:**
+- Produces: both tools get `provides = frozenset({Capability.TABLE_DETECTION})`, emit under `TABLE_DETECTION`, and **`page_meta` moves from `__init__` to `run()`** so `build_pipeline_config` can instantiate every tool up front.
+
+- [ ] **Step 1: Update the tests to the new contract**
+
+In both test files, replace `Tool(config=cfg, page_meta=pm)` with `Tool(config=cfg)`, and `tool.run(pdf)` with `tool.run(pdf, page_meta=pm, emit=frozenset({Capability.TABLE_DETECTION}))`. Replace `result.blocks` with `result.blocks_by_capability[Capability.TABLE_DETECTION]`. Add to `test_fitz_tables_tool.py`:
+
+```python
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+
+def test_fitz_tables_declares_table_detection():
+    assert FitzTablesTool().provides == frozenset({Capability.TABLE_DETECTION})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_fitz_tables_tool.py tests/cdm/adapters/custom_pipeline/test_camelot_tool.py -v`
+Expected: FAIL — unexpected keyword `emit` / no `provides`.
+
+- [ ] **Step 3: Port `fitz_tables_tool.py`**
+
+```python
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+
+class FitzTablesTool:
+    tool_id = "fitz_tables"
+    provides = frozenset({Capability.TABLE_DETECTION})
+
+    def __init__(self, config: Optional[FitzTablesConfig] = None) -> None:
+        self.config = config or FitzTablesConfig()
+
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,
+        page_meta: Optional[Dict[int, PageMeta]] = None,
+        emit: frozenset[Capability] = frozenset({Capability.TABLE_DETECTION}),
+    ) -> ToolResult:
+        if not emit <= self.provides:
+            raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
+        self.page_meta = page_meta or {}          # methods below already read self.page_meta
+        ...  # body unchanged
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks_by_capability={Capability.TABLE_DETECTION: blocks},
+            page_meta=self.page_meta,
+            raw={"tables": list(native_by_block.values())},
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )
+```
+
+- [ ] **Step 4: Port `camelot_tool.py` identically**
+
+Same three edits: add `provides = frozenset({Capability.TABLE_DETECTION})`; drop `page_meta` from `__init__` and accept it in `run()` (assigning `self.page_meta = page_meta or {}`); add the `emit` guard; return `blocks_by_capability={Capability.TABLE_DETECTION: blocks}`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_fitz_tables_tool.py tests/cdm/adapters/custom_pipeline/test_camelot_tool.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/tools/fitz_tables_tool.py backend/app/cdm/adapters/custom_pipeline/tools/camelot_tool.py backend/tests/cdm/adapters/custom_pipeline/test_fitz_tables_tool.py backend/tests/cdm/adapters/custom_pipeline/test_camelot_tool.py
+git commit -m "refactor(pipeline): port table tools; page_meta moves to run()"
+```
+
+---
+
+## Task 6: Capability-slot config contract
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/config.py`
+- Modify: `backend/tests/cdm/adapters/custom_pipeline/test_config.py` (rewrite)
+
+**Interfaces:**
+- Consumes: `Capability`, `PageFlagsConfig`, the three tools.
+- Produces:
+  - `ToolSpec(config_cls, provides, factory)` and `TOOL_REGISTRY: Dict[str, ToolSpec]`
+  - `ResolvedInstance(key, tool, emit)`
+  - `ResolvedPipeline(instances: List[ResolvedInstance], page_flags: PageFlagsConfig, eviction_overlap_threshold: float, ocr_eviction_threshold: float)` with `for_capability(cap) -> ResolvedInstance | None`
+  - `build_pipeline_config(config: Dict[str, Any]) -> ResolvedPipeline`
+- **Deleted:** `TABLE_TOOL_IDS`, the `len(...) > 1` guard, the old `CustomPipelineConfig` dataclass.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/cdm/adapters/custom_pipeline/test_config.py
+import pytest
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.config import build_pipeline_config
+
+BASE = {
+    "tools": {"fitz": {"tool": "fitz", "config": {}}},
+    "capabilities": {"text_extraction": "fitz"},
+}
+
+
+def test_builds_a_single_slot_pipeline():
+    p = build_pipeline_config(BASE)
+    inst = p.for_capability(Capability.TEXT_EXTRACTION)
+    assert inst.key == "fitz"
+    assert inst.tool.tool_id == "fitz"
+    assert inst.emit == frozenset({Capability.TEXT_EXTRACTION})
+    assert p.for_capability(Capability.TABLE_DETECTION) is None
+
+
+def test_one_instance_serves_many_slots_and_is_built_once():
+    cfg = {
+        "tools": {"f": {"tool": "fitz", "config": {}},
+                  "t": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "f", "table_detection": "t"},
+    }
+    p = build_pipeline_config(cfg)
+    assert len(p.instances) == 2
+    assert {i.key for i in p.instances} == {"f", "t"}
+
+
+def test_text_extraction_slot_is_required():
+    with pytest.raises(ValueError, match="text_extraction"):
+        build_pipeline_config({"tools": {}, "capabilities": {}})
+
+
+def test_unknown_tool_is_rejected():
+    with pytest.raises(ValueError, match="unknown tool"):
+        build_pipeline_config({"tools": {"x": {"tool": "nope"}},
+                               "capabilities": {"text_extraction": "x"}})
+
+
+def test_capability_not_provided_by_tool_is_rejected():
+    with pytest.raises(ValueError, match="does not provide"):
+        build_pipeline_config({
+            "tools": {"f": {"tool": "fitz"}},
+            "capabilities": {"text_extraction": "f", "table_detection": "f"},
+        })
+
+
+def test_dangling_instance_reference_is_rejected():
+    with pytest.raises(ValueError, match="unknown instance"):
+        build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
+                               "capabilities": {"text_extraction": "ghost"}})
+
+
+def test_thresholds_and_page_flags_defaults():
+    p = build_pipeline_config(BASE)
+    assert p.eviction_overlap_threshold == 0.5
+    assert p.ocr_eviction_threshold == 0.3
+    assert p.page_flags.min_chars == 10 and p.page_flags.cid_ratio == 0.3
+
+
+def test_two_table_tools_are_structurally_unrepresentable():
+    # The capabilities map is a dict — a second table_detection key overwrites
+    # the first. There is nothing to guard against.
+    cfg = {"tools": {"a": {"tool": "camelot"}, "b": {"tool": "fitz_tables"},
+                     "f": {"tool": "fitz"}},
+           "capabilities": {"text_extraction": "f", "table_detection": "b"}}
+    p = build_pipeline_config(cfg)
+    assert p.for_capability(Capability.TABLE_DETECTION).key == "b"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_config.py -v`
+Expected: FAIL — `build_pipeline_config` still expects `tools: [...]`.
+
+- [ ] **Step 3: Rewrite `config.py`**
+
+Keep the four existing pydantic config classes (`FitzConfig`, `CamelotConfig`, `FitzTablesConfig`) exactly as they are. Replace `TABLE_TOOL_IDS`, `TOOL_REGISTRY`, `CustomPipelineConfig`, and `build_pipeline_config` with:
+
+```python
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+from pydantic import BaseModel
+
+from app.cdm.adapters.custom_pipeline.capabilities import BLOCK_PRODUCING, Capability
+from app.cdm.adapters.custom_pipeline.page_flags import PageFlagsConfig
+from app.cdm.adapters.custom_pipeline.tools.base import PipelineTool
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    config_cls: type[BaseModel]
+    provides: frozenset[Capability]
+    factory: Callable[[BaseModel], PipelineTool]
+
+
+def _tool_registry() -> Dict[str, ToolSpec]:
+    from app.cdm.adapters.custom_pipeline.tools.camelot_tool import CamelotTool
+    from app.cdm.adapters.custom_pipeline.tools.fitz_tables_tool import FitzTablesTool
+    from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool
+    return {
+        "fitz": ToolSpec(FitzConfig, FitzTool.provides, lambda c: FitzTool(config=c)),
+        "camelot": ToolSpec(CamelotConfig, CamelotTool.provides, lambda c: CamelotTool(config=c)),
+        "fitz_tables": ToolSpec(FitzTablesConfig, FitzTablesTool.provides,
+                                lambda c: FitzTablesTool(config=c)),
+    }
+
+
+@dataclass(frozen=True)
+class ResolvedInstance:
+    key: str
+    tool: PipelineTool
+    emit: frozenset[Capability]
+
+
+@dataclass(frozen=True)
+class ResolvedPipeline:
+    instances: List[ResolvedInstance]
+    page_flags: PageFlagsConfig
+    eviction_overlap_threshold: float
+    ocr_eviction_threshold: float
+
+    def for_capability(self, cap: Capability) -> Optional[ResolvedInstance]:
+        return next((i for i in self.instances if cap in i.emit), None)
+
+
+def build_pipeline_config(config: Dict[str, Any]) -> ResolvedPipeline:
+    registry = _tool_registry()
+    tools_cfg: Dict[str, Any] = config.get("tools", {}) or {}
+    caps_cfg: Dict[str, str] = config.get("capabilities", {}) or {}
+
+    # capability key -> Capability, validating the enum
+    slots: Dict[Capability, str] = {}
+    for raw_cap, instance_key in caps_cfg.items():
+        try:
+            cap = Capability(raw_cap)
+        except ValueError:
+            raise ValueError(f"unknown capability: {raw_cap!r}")
+        if cap not in BLOCK_PRODUCING:
+            raise ValueError(f"no tool provides staging capability {cap.value!r}")
+        slots[cap] = instance_key
+
+    if Capability.TEXT_EXTRACTION not in slots:
+        raise ValueError("capability 'text_extraction' is required")
+
+    # instance key -> assigned capabilities (this is the masking set)
+    assigned: Dict[str, set[Capability]] = {}
+    for cap, key in slots.items():
+        if key not in tools_cfg:
+            raise ValueError(f"capability {cap.value!r} references unknown instance {key!r}")
+        assigned.setdefault(key, set()).add(cap)
+
+    instances: List[ResolvedInstance] = []
+    for key in sorted(assigned):                       # deterministic order
+        entry = tools_cfg[key]
+        tool_id = entry.get("tool")
+        spec = registry.get(tool_id)
+        if spec is None:
+            raise ValueError(f"unknown tool: {tool_id!r}")
+        emit = frozenset(assigned[key])
+        if not emit <= spec.provides:
+            missing = {c.value for c in emit - spec.provides}
+            raise ValueError(f"tool {tool_id!r} does not provide {missing}")
+        tool_cfg = spec.config_cls.model_validate(entry.get("config", {}) or {})
+        instances.append(ResolvedInstance(key=key, tool=spec.factory(tool_cfg), emit=emit))
+
+    return ResolvedPipeline(
+        instances=instances,
+        page_flags=PageFlagsConfig.model_validate(config.get("page_flags", {}) or {}),
+        eviction_overlap_threshold=config.get("eviction_overlap_threshold", 0.5),
+        ocr_eviction_threshold=config.get("ocr_eviction_threshold", 0.3),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_config.py -v`
+Expected: PASS (8 passed).
+
+- [ ] **Step 5: Verify the old guard is gone**
+
+Run: `cd backend && grep -rn "TABLE_TOOL_IDS\|only one table tool" app tests`
+Expected: no results.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/config.py backend/tests/cdm/adapters/custom_pipeline/test_config.py
+git commit -m "feat(pipeline): capability-slot config contract; delete TABLE_TOOL_IDS"
+```
+
+---
+
+## Task 7: N-way capability-aware merger
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/merger.py`
+- Modify: `backend/tests/cdm/adapters/custom_pipeline/test_merger.py` (rewrite)
+
+**Interfaces:**
+- Consumes: `Capability`, `resolve_precedence`, `PageFlags`, `ToolResult`.
+- Produces: `overlap_fraction(winner: BBox, loser: BBox) -> float` (renamed params, same maths); `merge(results: Sequence[ToolResult], *, source_document_id: str, page_flags: Dict[int, PageFlags], ocr_prefer: bool = False, eviction_overlap_threshold: float = 0.5, ocr_eviction_threshold: float = 0.3) -> MergeResult`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/cdm/adapters/custom_pipeline/test_merger.py
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.merger import merge, overlap_fraction
+from app.cdm.adapters.custom_pipeline.page_flags import PageFlags
+from app.cdm.adapters.custom_pipeline.tools.base import ToolResult
+from app.cdm.models import BBox, Block, BlockRole
+
+TE, TB, OC = Capability.TEXT_EXTRACTION, Capability.TABLE_DETECTION, Capability.TEXT_OCR
+
+
+def _b(bid, x0, y0, x1, y1, role=BlockRole.TEXT):
+    return Block(id=bid, role=role, page_index=0, bbox=BBox(x0=x0, y0=y0, x1=x1, y1=y1))
+
+
+def _res(tool_id, cap, blocks):
+    return ToolResult(tool_id=tool_id, blocks_by_capability={cap: blocks},
+                      native_by_block={b.id: {} for b in blocks})
+
+
+def _flags(cid=False):
+    return {0: PageFlags(index=0, char_count=100, pua_ratio=0.0, cid_corrupt=cid)}
+
+
+def test_overlap_fraction_is_share_of_the_loser():
+    assert overlap_fraction(BBox(x0=0, y0=0, x1=1, y1=1),
+                            BBox(x0=0, y0=0, x1=0.5, y1=1)) == 1.0
+
+
+def test_table_evicts_overlapping_text():
+    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.9, 0.4)])
+    table = _res("fitz_tables", TB, [_b("tb1", 0.0, 0.0, 1.0, 0.5, BlockRole.TABLE)])
+    out = merge([text, table], source_document_id="d", page_flags=_flags())
+    assert len(out.blocks) == 1
+    assert out.raw_output["evicted"][0]["capability"] == "text_extraction"
+    assert out.raw_output["evicted"][0]["winner_capability"] == "table_detection"
+
+
+def test_native_text_evicts_overlapping_ocr_by_default():
+    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 1.0, 0.5)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.1, 0.1, 0.3, 0.2)])
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags())
+    assert [b.id for b in out.blocks] == ["d:0:0"]
+    assert out.raw_output["evicted"][0]["capability"] == "text_ocr"
+
+
+def test_ocr_survives_where_no_native_text_covers_it():
+    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 1.0, 0.2)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.6, 0.5, 0.8)])   # no overlap
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags())
+    assert len(out.blocks) == 2
+
+
+def test_cid_corrupt_page_lets_ocr_evict_native_text():
+    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
+    ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.0, 1.0, 0.5)])
+    out = merge([text, ocr], source_document_id="d", page_flags=_flags(cid=True))
+    assert out.raw_output["evicted"][0]["capability"] == "text_extraction"
+
+
+def test_audit_trail_is_keyed_by_instance():
+    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 0.2, 0.2)])
+    out = merge([text], source_document_id="d", page_flags=_flags())
+    assert "fitz" in out.raw_output["instances"]
+    assert out.raw_output["instances"]["fitz"]["capabilities"] == ["text_extraction"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_merger.py -v`
+Expected: FAIL — `merge()` still takes two positional `ToolResult`s.
+
+- [ ] **Step 3: Rewrite `merger.py`**
+
+```python
+"""Merge tool outputs into a final ordered block list + an audit raw_output.
+
+Blocks are tagged with the capability that produced them. Precedence is
+per-page (see capabilities.resolve_precedence): structure beats loose text, and
+OCR sits below native text unless the page is CID-corrupt or the router set
+`ocr_prefer`. Losers are evicted (logged, not deleted).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence, Tuple
+
+from app.cdm.adapters.custom_pipeline.capabilities import Capability, resolve_precedence
+from app.cdm.adapters.custom_pipeline.page_flags import PageFlags
+from app.cdm.adapters.custom_pipeline.tools.base import ToolResult
+from app.cdm.models import BBox, Block
+
+
+def _area(b: BBox) -> float:
+    return max(0.0, b.x1 - b.x0) * max(0.0, b.y1 - b.y0)
+
+
+def overlap_fraction(winner: BBox, loser: BBox) -> float:
+    """Intersection area / area(loser), in normalized coords."""
+    loser_area = _area(loser)
+    if loser_area == 0.0:
+        return 0.0
+    ix0, iy0 = max(winner.x0, loser.x0), max(winner.y0, loser.y0)
+    ix1, iy1 = min(winner.x1, loser.x1), min(winner.y1, loser.y1)
+    inter = max(0.0, ix1 - ix0) * max(0.0, iy1 - iy0)
+    return inter / loser_area
+
+
+@dataclass
+class MergeResult:
+    blocks: List[Block]
+    raw_output: Dict[str, Any]
+
+
+def _sort_key(block: Block) -> Tuple[float, float]:
+    if block.bbox is None:
+        return (1e9, 1e9)
+    return (block.bbox.y0, block.bbox.x0)
+
+
+def merge(
+    results: Sequence[ToolResult],
+    *,
+    source_document_id: str,
+    page_flags: Dict[int, PageFlags],
+    ocr_prefer: bool = False,
+    eviction_overlap_threshold: float = 0.5,
+    ocr_eviction_threshold: float = 0.3,
+) -> MergeResult:
+    # Flatten to (block, capability, tool_id), preserving producer order.
+    tagged: List[Tuple[Block, Capability, str]] = [
+        (b, cap, r.tool_id)
+        for r in results
+        for cap, blocks in r.blocks_by_capability.items()
+        for b in blocks
+    ]
+
+    def _threshold(loser_cap: Capability) -> float:
+        return (ocr_eviction_threshold if loser_cap is Capability.TEXT_OCR
+                else eviction_overlap_threshold)
+
+    def _rank(page_index: int) -> Dict[Capability, int]:
+        flags = page_flags.get(page_index)
+        return resolve_precedence(
+            cid_corrupt=bool(flags and flags.cid_corrupt), ocr_prefer=ocr_prefer,
+        )
+
+    # 1. Eviction pass — a block loses to any higher-ranked block that covers it.
+    evicted: Dict[str, Dict[str, Any]] = {}
+    for loser, loser_cap, loser_tool in tagged:
+        if loser.bbox is None:
+            continue
+        ranks = _rank(loser.page_index)
+        for winner, winner_cap, _ in tagged:
+            if winner.id == loser.id or winner.bbox is None:
+                continue
+            if winner.page_index != loser.page_index:
+                continue
+            if ranks.get(winner_cap, 0) <= ranks.get(loser_cap, 0):
+                continue
+            frac = overlap_fraction(winner.bbox, loser.bbox)
+            if frac > _threshold(loser_cap):
+                evicted[loser.id] = {
+                    "block_id": loser.id,
+                    "capability": loser_cap.value,
+                    "winner_capability": winner_cap.value,
+                    "winner_prov_id": winner.id,
+                    "reason": "covered_by",
+                    "overlap_fraction": frac,
+                    "tool": loser_tool,
+                }
+                break
+
+    survivors = [(b, c, t) for (b, c, t) in tagged if b.id not in evicted]
+
+    # 2. Mint final ids + reading order, grouped per page.
+    by_page: Dict[int, List[Block]] = {}
+    for b, _, _ in survivors:
+        by_page.setdefault(b.page_index, []).append(b)
+
+    prov_to_final: Dict[str, str] = {}
+    final_blocks: List[Block] = []
+    for page_index in sorted(by_page):
+        for reading_order, block in enumerate(sorted(by_page[page_index], key=_sort_key)):
+            final_id = f"{source_document_id}:{page_index}:{reading_order}"
+            prov_to_final[block.id] = final_id
+            final_blocks.append(
+                block.model_copy(update={"id": final_id, "reading_order": reading_order})
+            )
+
+    # 3. Audit trail, keyed by instance and explained in capability terms.
+    instances: Dict[str, Any] = {}
+    for r in results:
+        block_map = {
+            prov_to_final[prov]: native
+            for prov, native in r.native_by_block.items()
+            if prov in prov_to_final
+        }
+        instances[r.tool_id] = {
+            "tool": r.tool_id,
+            "capabilities": [c.value for c in r.blocks_by_capability],
+            "raw": r.raw,
+            "block_map": block_map,
+        }
+
+    for record in evicted.values():
+        record["won_by"] = prov_to_final.get(record.pop("winner_prov_id"))
+
+    return MergeResult(
+        blocks=final_blocks,
+        raw_output={"instances": instances, "evicted": list(evicted.values())},
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_merger.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/merger.py backend/tests/cdm/adapters/custom_pipeline/test_merger.py
+git commit -m "feat(pipeline): N-way capability-aware merger + capability-tagged audit"
+```
+
+---
+
+## Task 8: Slot-driven runner
+
+**Files:**
+- Modify: `backend/app/services/parsing/custom_pipeline_runner.py`
+- Modify: `backend/app/cdm/adapters/custom_pipeline/__init__.py`
+- Modify: `backend/tests/services/parsing/test_custom_pipeline_runner.py`
+
+**Interfaces:**
+- Consumes: `build_pipeline_config`, `compute_page_flags`, `merge`, `Capability`, `CustomPipelineAdapter`.
+- Produces: unchanged public signature `run_custom_pipeline(...) -> Tuple[ParseRun, ParsedDocument]`.
+
+- [ ] **Step 1: Update the runner test to the new config shape**
+
+In `test_custom_pipeline_runner.py`, every pipeline config literal changes from
+`{"tools": [{"tool_id": "fitz", "config": {}}]}` to
+`{"tools": {"fitz": {"tool": "fitz", "config": {}}}, "capabilities": {"text_extraction": "fitz"}}`.
+Add:
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_runner_requires_a_text_extraction_slot(source_doc, pdf_path):
+    with pytest.raises(Exception, match="text_extraction"):
+        await run_custom_pipeline(
+            source=source_doc, file_path=str(pdf_path),
+            representation_kind="extract_rich",
+            config={"tools": {}, "capabilities": {}},
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_custom_pipeline_runner.py -v`
+Expected: FAIL — old config shape / `merge()` signature.
+
+- [ ] **Step 3: Rewrite the `try:` body of `run_custom_pipeline`**
+
+Replace everything from `pdf_path = Path(file_path)` through the `merge(...)` call with:
+
+```python
+        pdf_path = Path(file_path)
+
+        pipeline = build_pipeline_config(config)
+        flags = compute_page_flags(pdf_path, pipeline.page_flags)
+
+        text_instance = pipeline.for_capability(Capability.TEXT_EXTRACTION)
+        # build_pipeline_config guarantees this, but fail loudly if it ever does not.
+        if text_instance is None:
+            raise ValueError("capability 'text_extraction' is required")
+
+        text_result = text_instance.tool.run(pdf_path, emit=text_instance.emit)
+        results = [text_result]
+        warnings = list(text_result.warnings)
+
+        # Remaining instances run once each, in the deterministic order
+        # build_pipeline_config established, and receive page geometry from
+        # the text_extraction tool.
+        for inst in pipeline.instances:
+            if inst is text_instance:
+                continue
+            r = inst.tool.run(pdf_path, page_meta=text_result.page_meta, emit=inst.emit)
+            results.append(r)
+            warnings.extend(r.warnings)
+
+        merge_result = merge(
+            results,
+            source_document_id=source.id,
+            page_flags=flags,
+            eviction_overlap_threshold=pipeline.eviction_overlap_threshold,
+            ocr_eviction_threshold=pipeline.ocr_eviction_threshold,
+        )
+```
+
+Update the imports at the top of the file:
+
+```python
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.config import build_pipeline_config
+from app.cdm.adapters.custom_pipeline.merger import merge
+from app.cdm.adapters.custom_pipeline.page_flags import compute_page_flags
+from app.cdm.adapters.custom_pipeline.tools.base import ToolResult   # keep if still referenced
+```
+
+Delete the `TABLE_TOOL_IDS` import, the `fitz_tool = next(...)` lookup, the
+`raise ValueError("custom pipeline requires a 'fitz' tool")`, the `table_entry` block, and the
+`ToolResult(tool_id="none", ...)` placeholder.
+
+The `adapter.adapt(...)` call below is unchanged except it reads `text_result.page_meta`:
+
+```python
+        {"page_meta": text_result.page_meta, "blocks": merge_result.blocks},
+```
+
+- [ ] **Step 4: Update `__init__.py` exports**
+
+```python
+from app.cdm.adapters.custom_pipeline.adapter import CustomPipelineAdapter
+from app.cdm.adapters.custom_pipeline.capabilities import (
+    BLOCK_PRODUCING, STAGING, Capability, resolve_precedence,
+)
+from app.cdm.adapters.custom_pipeline.config import (
+    CamelotConfig, FitzConfig, FitzTablesConfig,
+    ResolvedInstance, ResolvedPipeline, build_pipeline_config,
+)
+from app.cdm.adapters.custom_pipeline.merger import MergeResult, merge, overlap_fraction
+from app.cdm.adapters.custom_pipeline.page_flags import (
+    PageFlags, PageFlagsConfig, compute_page_flags,
+)
+from app.cdm.adapters.custom_pipeline.tools.base import PageMeta, PipelineTool, ToolResult
+from app.cdm.adapters.custom_pipeline.tools.camelot_tool import CamelotTool
+from app.cdm.adapters.custom_pipeline.tools.fitz_tables_tool import FitzTablesTool
+from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool
+
+__all__ = [
+    "CustomPipelineAdapter", "BLOCK_PRODUCING", "STAGING", "Capability",
+    "resolve_precedence", "CamelotConfig", "FitzConfig", "FitzTablesConfig",
+    "ResolvedInstance", "ResolvedPipeline", "build_pipeline_config",
+    "MergeResult", "merge", "overlap_fraction",
+    "PageFlags", "PageFlagsConfig", "compute_page_flags",
+    "PageMeta", "PipelineTool", "ToolResult",
+    "CamelotTool", "FitzTablesTool", "FitzTool",
+]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_custom_pipeline_runner.py tests/cdm/adapters/custom_pipeline -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify no `LocalTool` references survive**
+
+Run: `cd backend && grep -rn "LocalTool" app tests`
+Expected: no results.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/parsing/custom_pipeline_runner.py backend/app/cdm/adapters/custom_pipeline/__init__.py backend/tests/services/parsing/test_custom_pipeline_runner.py
+git commit -m "refactor(pipeline): slot-driven runner; drop hardcoded fitz requirement"
+```
+
+---
+
+## Task 9: Behaviour-equivalence acceptance test
+
+**Files:**
+- Create: `backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py`
+
+**Interfaces:**
+- Consumes: `run_custom_pipeline`.
+- Proves the plan's acceptance property: the refactor does not change `ParsedDocument`.
+
+This is the task that justifies splitting PR A from PR B. It pins the output of a
+representative document so a reviewer can trust the refactor without reading every diff.
+
+- [ ] **Step 1: Write the test**
+
+```python
+# backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
+"""PR A is a behaviour-preserving refactor.
+
+`ParsedDocument` must be byte-identical to the pre-refactor pipeline for any
+config expressible under the old contract. `ParseRun.raw_payload` is exempt —
+its shape changes on purpose ("tools" -> "instances").
+"""
+import fitz
+import pytest
+
+from app.cdm.source import SourceDocument
+from app.services.parsing.custom_pipeline_runner import run_custom_pipeline
+
+
+@pytest.fixture
+def doc_and_pdf(tmp_path):
+    d = fitz.open()
+    page = d.new_page(width=612, height=792)
+    page.insert_text((72, 72), "Quarterly revenue report", fontsize=14)
+    page.insert_text((72, 110), "Figures are unaudited and provisional.", fontsize=10)
+    for i in range(5):                       # a ruled grid -> a table
+        page.draw_line(fitz.Point(100, 300 + i * 20), fitz.Point(500, 300 + i * 20))
+    for i in range(3):
+        page.draw_line(fitz.Point(100 + i * 200, 300), fitz.Point(100 + i * 200, 380))
+    path = tmp_path / "equiv.pdf"
+    d.save(str(path)); d.close()
+    source = SourceDocument(id="src-1", filename="equiv.pdf", sha256="deadbeef")
+    return source, path
+
+
+@pytest.mark.asyncio
+async def test_text_only_pipeline_output_is_stable(doc_and_pdf):
+    source, path = doc_and_pdf
+    _run, parsed = await run_custom_pipeline(
+        source=source, file_path=str(path), representation_kind="extract_rich",
+        config={"tools": {"fitz": {"tool": "fitz", "config": {}}},
+                "capabilities": {"text_extraction": "fitz"}},
+    )
+    assert parsed.page_count == 1
+    assert "Quarterly revenue report" in parsed.full_text
+    # Reading order is contiguous and starts at 0 on every page.
+    orders = [b.reading_order for b in parsed.blocks if b.page_index == 0]
+    assert orders == list(range(len(orders)))
+    # Block ids follow the documented "<source>:<page>:<order>" scheme.
+    assert parsed.blocks[0].id == "src-1:0:0"
+
+
+@pytest.mark.asyncio
+async def test_table_tool_evicts_overlapping_text_exactly_as_before(doc_and_pdf):
+    source, path = doc_and_pdf
+    cfg = {
+        "tools": {"fitz": {"tool": "fitz", "config": {}},
+                  "tbl": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+    }
+    run, parsed = await run_custom_pipeline(
+        source=source, file_path=str(path), representation_kind="extract_rich", config=cfg,
+    )
+    roles = {b.role.value for b in parsed.blocks}
+    assert "table" in roles
+    # Every eviction is explained in capability terms.
+    for rec in run.raw_payload["evicted"]:
+        assert rec["winner_capability"] == "table_detection"
+        assert rec["reason"] == "covered_by"
+    assert "instances" in run.raw_payload and "tools" not in run.raw_payload
+```
+
+> If `SourceDocument` requires additional fields, mirror the construction used in
+> `backend/tests/services/parsing/test_custom_pipeline_runner.py`.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 3: Run the whole backend suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests -q`
+Expected: all pass. (`tests/services/parser_eval` must be untouched and green — it treats config as an opaque dict.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
+git commit -m "test(pipeline): behaviour-equivalence acceptance test for the refactor"
+```
+
+---
+
+## Task 10: Frontend — capability-slot config
+
+**Files:**
+- Modify: `frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx`
+- Modify: `frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx`
+- Modify: `frontend/src/components/documents/ParseMethodSelector.test.tsx`
+
+**Interfaces:**
+- Produces: the component emits the new config object:
+  `{ tools: {<toolId>: {tool, config}}, capabilities: {text_extraction, table_detection?}, page_flags, eviction_overlap_threshold, ocr_eviction_threshold }`
+- Instance keys are the tool id (1:1 simplification; a future multi-capability tool referenced from two slots therefore resolves to one instance).
+- No OCR controls in PR A.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// append to CustomPipelineConfig.test.tsx
+const capabilityConfig = {
+  tools: { fitz: { tool: 'fitz', config: {} } },
+  capabilities: { text_extraction: 'fitz' },
+}
+
+it('renders text extraction as a slot, not an always-on label', () => {
+  render(<CustomPipelineConfig config={capabilityConfig} onChange={vi.fn()} />)
+  expect(screen.getByRole('combobox', { name: /text extraction/i })).toBeInTheDocument()
+  expect(screen.queryByText(/always on/i)).not.toBeInTheDocument()
+})
+
+it('selecting a table tool emits a capability-slot config', async () => {
+  const onChange = vi.fn()
+  render(<CustomPipelineConfig config={capabilityConfig} onChange={onChange} />)
+  await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
+  await userEvent.click(screen.getByText(/fitz_tables/i))
+  const next = onChange.mock.calls[0][0]
+  expect(next.capabilities.text_extraction).toBe('fitz')
+  expect(next.capabilities.table_detection).toBe('fitz_tables')
+  expect(next.tools.fitz_tables.tool).toBe('fitz_tables')
+})
+
+it('selecting none removes the table_detection slot and its instance', async () => {
+  const withTable = {
+    tools: { fitz: { tool: 'fitz', config: {} },
+             fitz_tables: { tool: 'fitz_tables', config: {} } },
+    capabilities: { text_extraction: 'fitz', table_detection: 'fitz_tables' },
+  }
+  const onChange = vi.fn()
+  render(<CustomPipelineConfig config={withTable} onChange={onChange} />)
+  await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
+  await userEvent.click(screen.getByRole('option', { name: /none/i }))
+  const next = onChange.mock.calls[0][0]
+  expect(next.capabilities.table_detection).toBeUndefined()
+  expect(next.tools.fitz_tables).toBeUndefined()
+})
+```
+
+Replace the existing `fitzOnly` / `withFitzTables` / `withCamelot` fixtures with capability-slot
+equivalents, and update the existing tool-selection tests to read
+`next.capabilities.table_detection` instead of `next.tools.map(t => t.tool_id)`.
+
+In `ParseMethodSelector.test.tsx`, change the `custom_pipeline` config literal to
+`{ tools: { fitz: { tool: 'fitz', config: {} } }, capabilities: { text_extraction: 'fitz' } }`.
+Its assertion on the *Table extraction* combobox stays as-is.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/documents/parser-configs/CustomPipelineConfig.test.tsx`
+Expected: FAIL — no *Text extraction* combobox; config emitted as a `tools` array.
+
+- [ ] **Step 3: Update `CustomPipelineConfig.tsx`**
+
+Read the current file first. Then:
+
+1. Replace the *"Fitz — always on"* heading with a **Text extraction** `Select` whose only
+   option is `fitz` (labelled `fitz (text + images)`), wired with `aria-label="Text extraction"`.
+2. Derive the currently-selected table tool from `config.capabilities?.table_detection` instead
+   of scanning a `tools` array.
+3. Replace the two config-mutation helpers with capability-slot equivalents:
+
+```tsx
+type ToolInstance = { tool: string; config: Record<string, unknown> }
+type PipelineConfig = {
+  tools: Record<string, ToolInstance>
+  capabilities: Record<string, string>
+  page_flags?: Record<string, number>
+  eviction_overlap_threshold?: number
+  ocr_eviction_threshold?: number
+}
+
+function setSlot(cfg: PipelineConfig, capability: string, toolId: string | null,
+                 defaults: Record<string, unknown> = {}): PipelineConfig {
+  const capabilities = { ...cfg.capabilities }
+  const tools = { ...cfg.tools }
+  const previous = capabilities[capability]
+  if (previous) {
+    delete capabilities[capability]
+    // Drop the instance only if no other slot still references it.
+    if (!Object.values(capabilities).includes(previous)) delete tools[previous]
+  }
+  if (toolId) {
+    capabilities[capability] = toolId
+    tools[toolId] = tools[toolId] ?? { tool: toolId, config: defaults }
+  }
+  return { ...cfg, tools, capabilities }
+}
+
+function setToolConfig(cfg: PipelineConfig, toolId: string,
+                       patch: Record<string, unknown>): PipelineConfig {
+  const existing = cfg.tools[toolId]
+  if (!existing) return cfg
+  return { ...cfg, tools: { ...cfg.tools,
+    [toolId]: { ...existing, config: { ...existing.config, ...patch } } } }
+}
+```
+
+4. The table-tool `Select`'s `onValueChange` becomes
+   `onChange(setSlot(config, 'table_detection', v === 'none' ? null : v, v === 'camelot' ? CAMELOT_DEFAULTS : FITZ_TABLES_DEFAULTS))`.
+5. The existing camelot / fitz_tables config panels read
+   `config.tools[selectedTableTool]?.config` and write through `setToolConfig`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd frontend && npx vitest run src/components/documents/parser-configs/CustomPipelineConfig.test.tsx src/components/documents/ParseMethodSelector.test.tsx
+```
+Expected: PASS.
+
+- [ ] **Step 5: Lint, typecheck, full suite**
+
+Run:
+```bash
+cd frontend && npm run lint
+cd frontend && npm run build
+cd frontend && npx vitest run
+```
+Expected: lint clean; build succeeds; all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx frontend/src/components/documents/ParseMethodSelector.test.tsx
+git commit -m "feat(pipeline): capability-slot config UI; text extraction is a slot"
+```
+
+---
+
+## Task 11: Full verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Backend suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests -q`
+Expected: all pass.
+
+- [ ] **Step 2: Frontend suite, lint, build**
+
+Run:
+```bash
+cd frontend && npx vitest run
+cd frontend && npm run lint && npm run build
+```
+Expected: all pass.
+
+- [ ] **Step 3: Confirm the deletions actually happened**
+
+Run:
+```bash
+cd backend && grep -rn "LocalTool\|TABLE_TOOL_IDS\|only one table tool\|requires a 'fitz' tool" app tests
+```
+Expected: no results.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/ocr-capability-pipeline
+gh pr create --base main --head feat/ocr-capability-pipeline \
+  --title "refactor(pipeline): capability slots + N-way capability-aware merger (WS2 PR A)"
+```
+
+The PR body must state: **behaviour-preserving for `ParsedDocument`; `ParseRun.raw_payload`
+changes shape intentionally**; and that OCR (`tesseract_tool.py`, `has_uncovered_image`,
+`precedence` config) lands in PR B.
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage.** §2 capability model → Tasks 1, 3, 6 (enum, `provides`/`emit` masking, instance→slot, `TABLE_TOOL_IDS` deleted, `PipelineTool` rename). §3 precedence + eviction + audit trail → Tasks 1, 7. §3 reading order → unchanged `_sort_key` (Task 7); the *granularity* rule binds producers and has no PR A consumer, since no tool emits lines. §4b PR A scope → Tasks 1–10, exactly. §5 backend structure → Tasks 1–8. §6 frontend → Task 10. Acceptance property → Task 9.
+- **Deferred to PR B, correctly:** `tesseract_tool.py`, `page_flags.has_uncovered_image`, the `precedence` config field, `pages: auto`, OCR UI. `Capability.TEXT_OCR` and `ocr_prefer` exist in PR A as *fully unit-tested pure logic* (Tasks 1, 7) so PR B only wires config — not dead code.
+- **Type consistency.** `resolve_precedence(*, cid_corrupt, ocr_prefer)` keyword-only in Tasks 1/7. `ToolResult.blocks_by_capability` in Tasks 3/4/5/7. `run(pdf_path, *, pages, page_meta, emit)` in Tasks 3/4/5/8. `ResolvedPipeline.for_capability()` in Tasks 6/8. `overlap_fraction(winner, loser)` in Task 7.
+- **Known risk.** Task 4's `fitz_tool.py` has a local variable named `page_meta` that now collides with the new keyword argument; the plan renames it `page_meta_out` explicitly.
+- **Verified, not assumed.** `parser_eval` hashes pipeline config as an opaque dict, so the contract change has no blast radius there (`app/services/parser_eval/variants.py`).

--- a/docs/superpowers/specs/2026-07-09-ocr-ws2-constraints.md
+++ b/docs/superpowers/specs/2026-07-09-ocr-ws2-constraints.md
@@ -1,8 +1,20 @@
 # WS2 — OCR Tooling: Parking-Lot Constraints
 
-**Status:** Parking lot (not a spec yet). Accumulates decisions/constraints surfaced
-while brainstorming WS1 (the standalone explainable Probe). WS2 gets its own full
-spec later; start it from here.
+**Status:** Largely superseded. WS2 slice 1 is specified in
+[2026-07-10-ocr-capability-pipeline-design.md](2026-07-10-ocr-capability-pipeline-design.md).
+This document remains the parking lot for questions deferred past that slice — see
+"Still parked" at the bottom.
+
+**Disposition of the original constraints:**
+
+| | Constraint | Outcome |
+|---|---|---|
+| C1 | Execution location configurable; not "always local" | **Parked** — see "Still parked" below. Slice 1 ships in-process tesseract with no `execution` field, so no local assumption is baked into the config contract. |
+| C2 | `LocalTool` name clashes with remote ambition | **Resolved** — renamed `PipelineTool` in slice 1. |
+| C3 | Engine is user-selectable | **Resolved structurally** — the `text_ocr` capability slot enforces one engine per run, so the engine *is* the tool id (`tesseract`, later `paddleocr`). No separate engine seam needed. |
+
+**Original context:** WS1 = make the Probe a standalone, explainable feature (robust, legible
+"needs OCR" evidence). WS2 = add actual OCR as composable custom-pipeline tool(s).
 
 **Context:** WS1 = make the Probe a standalone, explainable feature (robust, legible
 "needs OCR" evidence). WS2 = add actual OCR as composable custom-pipeline tool(s).
@@ -72,11 +84,35 @@ location split.)
 
 ---
 
-## Open questions for the WS2 spec (do not answer yet)
+## Resolved by the slice-1 spec
 
-- How does the probe's per-region evidence (WS1 output) get *handed* to the OCR tool
-  when the user routes manually? File + page list? Region bboxes? Just the page?
-- Reconciliation: how do OCR blocks merge with an existing native text layer on `mixed`
-  pages without duplicating (extends the existing `merger.py` eviction machinery)?
-- Structure recovery for tables-embedded-as-images (deferred; possibly a later slice).
-- Remote hand-off contract: sync vs. async, auth, payload shape, failure/timeouts.
+- **Probe → OCR hand-off:** dissolved. OCR engines already do text detection, so the probe
+  never hands over regions. It informs *which pages*; reconciliation handles the rest.
+  The pipeline takes no dependency on `app/probe/`.
+- **Reconciliation:** OCR runs wholesale on selected pages, then output is filtered
+  spatially — native text wins (exact beats lossy), except on CID-corrupt pages or when the
+  router sets `precedence.text_ocr: "prefer"`. Mixed pages fall out for free.
+- **Structure recovery for tables-embedded-as-images:** still deferred.
+
+---
+
+## Still parked — brainstorm alongside PaddleOCR / layout analysis
+
+### Execution location (the C1 question, reopened deliberately)
+Slice 1 ships tesseract in-process and omits the `execution` config field entirely. The
+broader question is richer than "local vs remote" and deserves its own session:
+
+- Remote/managed OCR service (neocloud GPU, dedicated GPU box)
+- **Local GPU acceleration** (same process, different device)
+- Sync vs async hand-off, auth, payload shape, timeouts, failure semantics
+- Whether execution generalizes beyond OCR to any heavy `PipelineTool` (e.g. a remote docling)
+
+**Rejected sketch, recorded so it is not re-proposed:** `RemoteEngine(endpoint, engine="paddleocr")`
+made engine identity a *class* locally and a *string* remotely. That asymmetry re-couples the
+two axes C1 exists to keep orthogonal. The right factoring separates the **recognizer**
+(engine, in-process) from the **transport** (executor, engine-agnostic) — but settle it with
+real GPU/hosting requirements in hand, not speculatively.
+
+### Heavy engines
+`paddleocr` (paddlepaddle, hundreds of MB) and `easyocr` (torch, GB+) should not go in the
+API image. Their natural home is behind whatever the execution axis becomes.

--- a/docs/superpowers/specs/2026-07-10-ocr-capability-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-10-ocr-capability-pipeline-design.md
@@ -1,0 +1,397 @@
+# OCR + Capability-Slot Pipeline (WS2, slice 1)
+
+**Status:** Design — approved in brainstorming, pending spec review
+**Date:** 2026-07-10
+**Related:** [WS2 constraints parking lot](2026-07-09-ocr-ws2-constraints.md) ·
+[WS1 standalone Probe](2026-07-09-probe-standalone-design.md) ·
+[Custom pipeline overview](2026-06-30-custom-pipeline-design.md)
+
+---
+
+## 1. Context
+
+WS1 shipped the standalone Probe — an evidence provider that reports, per page and per
+image region, what a document *is*. WS2 makes the parser act on that: **add OCR to the
+custom pipeline**, so text trapped in images and text on scanned pages is actually
+extracted.
+
+Doing that surfaced a structural problem. Despite its name, the custom pipeline is
+**composable in name only**:
+
+| Slot | How it is enforced today |
+|------|--------------------------|
+| Text | Hardcoded string — `custom_pipeline_runner.py` raises `"custom pipeline requires a 'fitz' tool"`. Not swappable. |
+| Table | `TABLE_TOOL_IDS` frozenset + a `len(...) > 1` count check over a flat `tools: [...]` list. |
+| Merge | Binary positional call — `merge(fitz_result, table_result)`. |
+
+There is no capability abstraction. This slice introduces one, then adds OCR into it.
+
+**Product framing.** This application exists to let a user *evaluate* parsing approaches
+and cut through vendor marketing ("awesome_parser beats all other parsers"). Nobody
+differentiates on text extraction — every parser pulls clean text off a digital PDF. The
+real battleground is **OCR quality on degraded scans, table structure recognition, and
+layout/reading order on complex documents**. The pipeline must therefore make those
+capabilities *independently swappable and comparable*. Configuration over convention.
+
+## 2. Core model — capability slots
+
+The pipeline is a fixed set of **IDP capabilities**, each filled by at most **one named
+tool instance**.
+
+```jsonc
+{
+  "tools": {
+    "fitz":      { "tool": "fitz",      "config": { "include_images": true } },
+    "camelot":   { "tool": "camelot",   "config": { "flavor": "lattice" } },
+    "tesseract": { "tool": "tesseract", "config": { "pages": "auto", "lang": "eng" } }
+  },
+  "capabilities": {
+    "text_extraction": "fitz",       // required
+    "table_detection": "camelot",    // optional
+    "text_ocr":        "tesseract"   // optional
+  },
+  "precedence": { "text_ocr": "fallback" },
+  "eviction_overlap_threshold": 0.5,
+  "ocr_eviction_threshold": 0.3,
+
+  // Per-page facts consumed by BOTH the OCR tool (`pages: "auto"`) and the
+  // merger (the CID precedence flip). Computed once, in the runner.
+  "page_flags": {
+    "min_chars": 10,                 // below this, the page has no usable text layer
+    "cid_ratio": 0.3,                // private-use-area char ratio => cid_corrupt
+    "min_uncovered_coverage": 0.10,  // image must cover >=10% of the page to matter
+    "covered_overlap": 0.6           // >=60% overlap with native text => "covered"
+  }
+}
+```
+
+### Rules
+
+- **Capabilities are a closed enum.** Slice 1 implements `text_extraction` (required),
+  `table_detection`, `text_ocr`. `layout_analysis` exists in the enum but has no tools yet.
+- **Two capability kinds.**
+  - *Block-producing* (`text_extraction`, `table_detection`, `text_ocr`) emit blocks that
+    compete for page area, governed by the precedence matrix.
+  - *Staging* (`layout_analysis`) orders and routes; it never competes. Declared now so the
+    merger does not assume every capability competes.
+- **Tools declare `provides: frozenset[Capability]`.** The executor derives
+  `assigned(instance)` from the slot references and passes `emit=assigned`, **masking off**
+  everything not assigned. So `text_extraction: docling, table_detection: camelot`
+  automatically runs docling with table structure disabled — derived, not hand-specified.
+  Assigning a capability to a tool that does not `provide` it is a config error.
+- **One instance → one run**, regardless of how many slots reference it. This is what makes
+  `text/tables/ocr/layout: docling` mean a single docling execution.
+- **`TABLE_TOOL_IDS` and its count guard are deleted, not generalized.** Two table tools
+  becomes structurally unrepresentable.
+- **`LocalTool` → `PipelineTool`** (constraint C2).
+- **No compat shim.** There is no legacy data; clean cut-over.
+
+### Deliberate limitation
+
+One tool per capability **forbids ensembling** (two OCR engines voting, highest-confidence
+wins). This is intentional: an evaluation tool compares configurations *across runs*, not
+within a run. If ensembling is ever wanted, this model must break — state it, don't
+discover it.
+
+## 3. Merger — precedence and reconciliation
+
+### The reconciliation model
+
+OCR runs **wholesale on selected pages**; its output is then **filtered spatially**. We do
+*not* feed probe regions into the OCR tool.
+
+Rationale: OCR engines already perform text detection. Give tesseract a page raster and it
+returns word/line boxes. Finding text inside an image is the *engine's* job. So the two real
+decisions are:
+
+1. **Which pages to OCR** — a cost/routing decision (§4).
+2. **Which OCR output to keep** — resolved spatially: discard OCR blocks that overlap
+   existing native text, because native text is exact and OCR is lossy.
+
+The mixed-page case then falls out for free: on a page with a native text layer plus a logo
+and an embedded table screenshot, OCR returns boxes for all three; reconciliation drops the
+body text (already covered) and keeps the logo and table text (nothing underneath).
+**What survives is exactly the text that was trapped in images** — with no region hand-off
+and no dependency on `app/probe/`.
+
+### Precedence
+
+Block-producing capabilities rank `table_detection` above text — structure beats loose
+spans. The only variable is whether OCR sits above or below native text:
+
+```python
+ocr_outranks_text(page) = (precedence.text_ocr == "prefer") or page.cid_corrupt
+```
+
+| Situation | Order | Why |
+|---|---|---|
+| Default (`fallback`) | `table` > `text` > `ocr` | Native text is exact; OCR is lossy |
+| CID-corrupt page | `table` > `ocr` > `text` | Native text exists but is garbage |
+| `prefer` (whole run) | `table` > `ocr` > `text` | Scans already OCR'd badly by another tool |
+
+The CID flip and `prefer` are **the same mechanism**, applied per-page vs per-run.
+
+`prefer` exists because a large share of real-world PDFs are scans already OCR'd by a cheap
+tool: a *bad but valid* text layer, real characters, wrong ones. `pua_ratio` cannot detect
+it (no private-use chars) and `char_count` cannot (plenty of chars). No heuristic wins here,
+so the router decides. Precedence is configuration, not convention.
+
+### Eviction
+
+For each overlapping pair, the lower-precedence block is evicted and logged.
+`overlap_fraction(winner, loser) = intersection / area(loser)` is reused verbatim from the
+existing merger; only its parameter names change.
+
+Two thresholds, because the pairs differ geometrically:
+
+- `eviction_overlap_threshold: 0.5` — table vs text *(existing behaviour, unchanged)*
+- `ocr_eviction_threshold: 0.3` — OCR blocks sit *inside* native paragraphs, so partial
+  coverage already implies duplication
+
+### Reading order
+
+**Requirement:** every producer emits blocks at **paragraph/region granularity** with
+intra-block text order preserved. **The merger never reorders text within a block.**
+
+Tesseract returns a `block → paragraph → line → word` hierarchy. We aggregate to
+**paragraph-level blocks**. We do **not** emit line-level blocks. Once no producer emits
+lines, the merger's existing cross-block `(y0, x0)` sort is exactly as good as it is today
+for fitz.
+
+Stated honestly: `(y0, x0)` **still breaks on genuinely multi-column pages**. It does today,
+for fitz; OCR does not make it worse. That is the defect `layout_analysis` fixes next slice
+by supplying reading order as a *staging* capability. This slice does not pretend to solve
+it.
+
+### Audit trail
+
+`raw_output` stops being two hardcoded slots and explains itself in capability terms:
+
+```jsonc
+{
+  "instances": {
+    "fitz":      { "tool": "fitz", "capabilities": ["text_extraction"], "raw": …, "block_map": … },
+    "tesseract": { "tool": "tesseract", "capabilities": ["text_ocr"], "raw": …, "block_map": … }
+  },
+  "evicted": [{
+    "block_id": "…", "capability": "text_ocr",
+    "reason": "covered_by", "winner_capability": "text_extraction",
+    "won_by": "<final block id>", "overlap_fraction": 0.82
+  }]
+}
+```
+
+An eviction record now reads *"an OCR block was dropped because native text already covered
+82% of it"* — the same explainability ethos as the probe's receipts, and what makes
+configuration comparison honest.
+
+## 4. The OCR tool
+
+### Identity
+
+**The engine is the tool.** `tesseract` (later `paddleocr`, `easyocr`) are tool ids filling
+the `text_ocr` slot. The capability slot already enforces one-engine-per-run, so no separate
+`OcrEngine` protocol is needed: engine pluggability *is* slot pluggability (constraint C3
+satisfied structurally).
+
+Slice 1 ships one concrete `TesseractTool` implementing `PipelineTool`. If a second engine
+later reveals genuinely shared machinery (rasterization, paragraph assembly), extract a base
+class **then**, informed by a real second case.
+
+### Config
+
+```jsonc
+"tesseract": { "tool": "tesseract", "config": {
+  "pages": "auto",          // "auto" | "all" | [3, 7]
+  "lang": "eng",
+  "psm": 3,                 // tesseract page-segmentation mode
+  "dpi": 300,               // render resolution
+  "min_confidence": 0.0     // 0..1
+}}
+```
+
+`min_confidence` defaults to **0.0 on purpose**: an evaluation tool must not silently
+discard low-confidence OCR. Surface it; let the user decide.
+
+There is **no `execution` field**. Execution location is parked (§9) — omitting the field
+bakes in nothing, and adding it later is purely additive.
+
+### Page selection — how `auto` works
+
+`auto` needs per-page facts, and so does the merger (the CID flip). They are computed
+**once, in the runner**, and fed to both.
+
+```python
+# custom_pipeline/page_flags.py — fitz metadata only, no rasterization
+PageFlags(char_count, pua_ratio, cid_corrupt, has_uncovered_image)
+
+ocr_page = (char_count < min_chars) or cid_corrupt or has_uncovered_image
+```
+
+All four thresholds live in the pipeline-level `page_flags` config block (§2), **not** in the
+tesseract tool config — because the merger consumes `cid_corrupt` even when no OCR tool is
+configured. `cid_corrupt = pua_ratio > cid_ratio`.
+
+`has_uncovered_image` = an image whose area ≥ `min_uncovered_coverage` (0.10) **and** whose
+overlap with native text spans < `covered_overlap` (0.6).
+
+That third term is load-bearing: **it stops a full-bleed marketing image from triggering OCR
+on every page it appears on.** Defining `auto` as merely "the page has an image" would
+reintroduce exactly the false positive that motivated this whole workstream.
+
+**Accepted trade — duplication over coupling.** `page_flags` re-derives ~40 lines of
+probe-shaped heuristics (char count, PUA ratio, image/text overlap) inside the pipeline. The
+probe is *advisory evidence* with its own lifecycle; the pipeline needs *deterministic
+execution flags*. Importing `app/probe/` into the parse path would bind parsing to a
+diagnostic tool. If the two implementations drift in a way that matters, that is the trigger
+to extract a shared leaf util — not before.
+
+### Execution order
+
+```
+1. compute page_flags                     (fitz metadata, no raster)
+2. text_extraction tool                   (required)
+3. table_detection tool                   (optional; uses page_meta from step 2)
+4. text_ocr tool                          (optional; only the selected pages)
+5. merge(results, page_flags, precedence) (capability precedence + eviction)
+6. adapter → CDM ParsedDocument
+```
+
+The OCR tool renders each selected page at `dpi`, calls tesseract, aggregates the
+`block → paragraph → line → word` hierarchy into paragraph-level blocks, normalizes pixel
+bboxes to `[0, 1]`, and sets `Block.quality.confidence` from the mean word confidence.
+
+Provenance for evaluation: `Block.parser_extras = {"producer": "tesseract",
+"capability": "text_ocr", "engine": "tesseract"}`.
+
+### Errors
+
+A per-page OCR failure degrades to a **warning + `failed_pages`** on the `ParseRun` (both
+fields already exist); a single unreadable page must not discard a 200-page parse. A missing
+tesseract binary is a **config-time** error naming the tool, not a mid-parse crash.
+
+## 5. Backend structure
+
+```
+backend/app/cdm/adapters/custom_pipeline/
+  capabilities.py     # Capability enum; block-producing vs staging; precedence resolution
+  config.py           # tools/capabilities/precedence contract; instance→slot resolution; masking
+  page_flags.py       # PageFlags + compute_page_flags (fitz metadata only)
+  merger.py           # N-way, capability-aware eviction; capability-tagged audit trail
+  tools/
+    base.py           # PipelineTool protocol (renamed from LocalTool), ToolResult, PageMeta
+    fitz_tool.py  camelot_tool.py  fitz_tables_tool.py
+    tesseract_tool.py # NEW
+backend/app/services/parsing/custom_pipeline_runner.py   # slot-driven, no hardcoded 'fitz'
+```
+
+Contract changes:
+
+```python
+class PipelineTool(Protocol):
+    tool_id: str
+    provides: frozenset[Capability]
+    def run(self, pdf_path, *, pages=None, page_meta=None,
+            emit: frozenset[Capability]) -> ToolResult
+
+class ToolResult(BaseModel):
+    tool_id: str
+    blocks_by_capability: Dict[Capability, List[Block]]   # was: blocks
+    page_meta: Dict[int, PageMeta]
+    raw: Any
+    native_by_block: Dict[str, Any]
+    warnings: List[str]
+    duration_ms: int
+```
+
+Single-capability tools assert `emit == provides`.
+
+## 6. Frontend
+
+`CustomPipelineConfig.tsx` already renders capability slots — *"Fitz — always on"* plus a
+*"Table extraction"* select. The backend now agrees, and the *"always on"* copy dies (it was
+the symptom of a frozen slot).
+
+| Slot | Control |
+|---|---|
+| Text extraction | Select — `fitz` (one option today, but a *slot*: `pdfplumber`/`docling` become options, not a redesign) |
+| Table detection | Select — `none / fitz_tables / camelot` + existing config panels, unchanged |
+| Text OCR | Select — `none / tesseract` + panel: `pages`, `lang`, `psm`, `dpi`, `min_confidence` |
+| Precedence *(shown only when OCR is on)* | `Native text wins (fallback)` / `OCR wins (prefer)`, with help text: *"Choose 'OCR wins' for scans that already carry a poor-quality text layer."* |
+| Advanced | `eviction_overlap_threshold`, `ocr_eviction_threshold` |
+
+**Instance keying:** the UI keys instances by tool id — a 1:1 simplification of the
+named-instance model. A future multi-capability tool referenced from two slots therefore
+resolves to a single instance automatically, so docling-in-two-slots needs no UI redesign.
+Richer named-instance setups remain available to API and agent callers.
+
+Knock-on: `ParseMethodSelector.test.tsx` asserts the *Table extraction* combobox and will
+need a light update.
+
+## 7. Testing
+
+Tesseract 5.5.0 is present on the dev machine **and** in the backend image, so OCR
+integration tests run everywhere. They are still guarded with `skipif` for portability.
+
+**1. Pure functions — no PDF, no binary.** This is where the design's risk lives.
+- Precedence: truth table — `table > text > ocr`; CID flip; `prefer` mode.
+- Merger: N-way eviction; capability-tagged audit records; **text within a block is never
+  reordered**.
+- Paragraph aggregation: feed a *fixture* `image_to_data` dict (word rows with
+  `block_num`/`par_num`/`line_num`/`conf`) → assert paragraph-level blocks, preserved order,
+  unioned bbox, mean confidence. The reading-order rule is tested without invoking OCR.
+
+**2. Fixture PDFs (fitz-generated), still no OCR.**
+- `page_flags`: scanned → `char_count == 0`; CID-corrupt → high `pua_ratio`;
+  **image covered by native text → `has_uncovered_image is False`** (the false-positive
+  killer); full-bleed image with no text → `True` (asserting the *documented* wasted-compute
+  behaviour, so nobody "fixes" it by accident).
+- `pages: "auto" | "all" | [3]` selection is honoured.
+
+**3. Integration (`skipif` no tesseract binary).**
+- Render a page with known text as an image → OCR → text recovered, confidence populated,
+  bbox normalized to `[0, 1]`.
+- **Acceptance test for the slice:** a mixed page with native text *and* an image containing
+  text. After merge — native blocks survive, OCR blocks over native text are evicted, OCR
+  blocks over the image survive.
+
+**4. Runner / e2e.** All three capabilities → `ParsedDocument`. An OCR failure on one page →
+`warnings` + `failed_pages`, run still completes.
+
+**Frontend.** Config emission shape; OCR panel round-trip; precedence control.
+
+## 8. Known limitations (accepted, deliberately)
+
+These emerged from stress-testing the model. They are recorded so they are not rediscovered
+as bugs.
+
+| # | Limitation |
+|---|---|
+| L1 | **Capabilities are modelled as peers; in real IDP they are a DAG with layout upstream.** Spatial reconciliation is a cheap substitute for a layout stage. It works because fitz/camelot/tesseract are all page-global. The staging-capability distinction (§2) keeps layout able to slot in above the merger later without a rewrite. |
+| L2 | **Cross-block reading order is `(y0, x0)` and breaks on multi-column pages.** Pre-existing; OCR does not worsen it because no producer emits lines. `layout_analysis` fixes it. |
+| L3 | **`auto` is page-level; text-in-image is region-level.** A small logo on a dense page triggers OCR of the whole page, and most of the output is discarded by reconciliation. Correct output, wasted compute — the price of having no layout stage. |
+| L4 | **No ensembling.** One tool per capability, by design (§2). |
+| L5 | **Parsing produces a flat block list, not a document tree.** As capabilities grow, "merge" will increasingly mean "assemble structure" (sections, captions bound to figures, table cells) rather than "dedupe overlapping boxes". The merger's job will grow. |
+| L6 | **Heuristics cannot detect a bad-but-valid text layer.** Mitigated by `precedence.text_ocr: "prefer"`, decided by the router. |
+
+## 9. Parked / future
+
+- **Execution location (GPU, neocloud, local acceleration).** Deliberately parked. Slice 1
+  ships tesseract in-process with **no `execution` config field**. The question — remote
+  services, GPU boxes, local GPU acceleration — deserves its own brainstorm and will be
+  taken up when PaddleOCR and layout analysis are implemented, since those are the workloads
+  that motivate it. Note: an earlier `RemoteEngine(engine="paddleocr")` sketch was rejected
+  because it made engine identity a class locally and a string remotely — asymmetric, and a
+  violation of C1's orthogonality. The right factoring separates *recognizer* from
+  *transport*; settle it with real requirements in hand.
+- **`layout_analysis` — the immediate next slice.** It is where parser differentiation
+  actually lives (reading order, region classification, routing). It brings
+  **docling-as-a-pipeline-tool** with it naturally, since docling *is* a layout model — a far
+  better reason to do that work than "make multi-capability real". Landing it also fixes L2
+  and mitigates L3.
+- **Additional engines** (`paddleocr`, `easyocr`) — both are heavy (paddlepaddle: hundreds of
+  MB; easyocr: torch, GB+). Their natural home is behind the parked execution axis, not in
+  the API image.
+- **Table structure comparison** — after layout.
+- The probe's `edge_density` could be upgraded from numpy-Sobel to OpenCV Canny at **zero
+  dependency cost** (`cv2` is already in the image via docling).

--- a/docs/superpowers/specs/2026-07-10-ocr-capability-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-10-ocr-capability-pipeline-design.md
@@ -270,6 +270,45 @@ A per-page OCR failure degrades to a **warning + `failed_pages`** on the `ParseR
 fields already exist); a single unreadable page must not discard a 200-page parse. A missing
 tesseract binary is a **config-time** error naming the tool, not a mid-parse crash.
 
+## 4b. Delivery — two PRs
+
+The slice ships as two sequential PRs. The seam is chosen so the first is a **pure
+structural refactor with no behaviour change**, which is far safer to review than a refactor
+tangled with a new capability.
+
+### PR A — capability refactor (no OCR)
+
+- `capabilities.py` — Capability enum, block-producing vs staging, precedence resolution
+- `config.py` — new contract (`tools` / `capabilities` / `precedence` / `page_flags` /
+  thresholds), instance→slot resolution, capability masking; **delete** `TABLE_TOOL_IDS` and
+  the `len(...) > 1` guard
+- `tools/base.py` — `LocalTool` → `PipelineTool`, `provides`, `emit`,
+  `ToolResult.blocks_by_capability`
+- `fitz_tool.py`, `camelot_tool.py`, `fitz_tables_tool.py` — ported to the new contract
+- `page_flags.py` — `char_count`, `pua_ratio`, `cid_corrupt` only
+  (`has_uncovered_image` lands in PR B, where its only consumer lives — no dead code)
+- `merger.py` — N-way, capability-aware eviction; capability-tagged audit trail
+- `custom_pipeline_runner.py` — slot-driven; the hardcoded `'fitz'` requirement dies
+- Frontend — `CustomPipelineConfig.tsx` emits the new config; text presented as a *slot*
+  (fitz the only option); table slot unchanged; no OCR controls yet
+- `ParseMethodSelector.test.tsx` updated
+
+**Acceptance property:** for any document and any pipeline expressible under the old config,
+the new pipeline produces an **identical `ParsedDocument`**. The refactor is verified by
+equivalence, not just by unit tests.
+
+### PR B — tesseract OCR
+
+- `tesseract_tool.py` — rasterization, `pages: auto|all|[…]`, paragraph aggregation
+- `page_flags.py` — add `has_uncovered_image`
+- Precedence wiring — `ocr_outranks_text()`, `ocr_eviction_threshold`
+- Frontend — OCR slot, `precedence` control, OCR thresholds
+- Tests — paragraph aggregation, `auto` selection, and the mixed-page acceptance test
+
+PR B's plan is written **after PR A merges**, from this same spec — no further brainstorming
+required. `precedence.text_ocr: "prefer"` (L6) lands in PR B and remains cheap to cut if it
+still feels speculative then.
+
 ## 5. Backend structure
 
 ```

--- a/frontend/src/components/documents/ParseMethodSelector.test.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.test.tsx
@@ -78,7 +78,8 @@ describe('ParseMethodSelector', () => {
         {...defaultProps}
         parserType="custom_pipeline"
         config={{
-          tools: [{ tool_id: 'fitz', config: {} }],
+          tools: { fitz: { tool: 'fitz', config: {} } },
+          capabilities: { text_extraction: 'fitz' },
           eviction_overlap_threshold: 0.5,
         }}
       />

--- a/frontend/src/components/documents/ParseMethodSelector.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.tsx
@@ -42,12 +42,13 @@ export const PARSER_REGISTRY: Record<string, ParserMeta> = {
     label: 'Custom pipeline',
     description: 'Composable tools',
     defaultConfig: {
-      tools: [
-        {
-          tool_id: 'fitz',
+      tools: {
+        fitz: {
+          tool: 'fitz',
           config: { min_chars_threshold: 10, include_images: true, span_detail: false },
         },
-      ],
+      },
+      capabilities: { text_extraction: 'fitz' },
       eviction_overlap_threshold: 0.5,
     },
   },

--- a/frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx
+++ b/frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import { CustomPipelineConfig } from './CustomPipelineConfig'
+import { CustomPipelineConfig, normalizeCustomPipelineConfig } from './CustomPipelineConfig'
 
 const fitzOnly = {
   tools: {
@@ -119,4 +119,78 @@ describe('CustomPipelineConfig', () => {
     expect(screen.getByText('row_tol')).toBeInTheDocument()
   })
 
+})
+
+describe('normalizeCustomPipelineConfig', () => {
+  const OLD_ARRAY = {
+    tools: [
+      { tool_id: 'fitz', config: { min_chars_threshold: 10, include_images: true } },
+    ],
+    eviction_overlap_threshold: 0.5,
+  }
+
+  it('converts the old array shape to capability slots', () => {
+    const n = normalizeCustomPipelineConfig(OLD_ARRAY)
+    expect(Array.isArray(n.tools)).toBe(false)
+    expect(n.tools['0']).toBeUndefined()          // no array-index key
+    expect(n.tools.fitz.tool).toBe('fitz')
+    expect(n.tools.fitz.config.include_images).toBe(true)
+    expect(n.capabilities.text_extraction).toBe('fitz')
+  })
+
+  it('infers table_detection from an old array with a table tool', () => {
+    const n = normalizeCustomPipelineConfig({
+      tools: [
+        { tool_id: 'fitz', config: {} },
+        { tool_id: 'camelot', config: { flavor: 'stream' } },
+      ],
+    })
+    expect(n.capabilities.text_extraction).toBe('fitz')
+    expect(n.capabilities.table_detection).toBe('camelot')
+    expect(n.tools.camelot.config.flavor).toBe('stream')
+  })
+
+  it('guarantees a text_extraction slot even if the input lacks one', () => {
+    const n = normalizeCustomPipelineConfig({
+      tools: { fitz_tables: { tool: 'fitz_tables', config: {} } },
+      capabilities: { table_detection: 'fitz_tables' },
+    })
+    expect(n.capabilities.text_extraction).toBe('fitz')
+    expect(n.tools.fitz.tool).toBe('fitz')
+  })
+
+  it('is idempotent on an already-normalized config', () => {
+    const once = normalizeCustomPipelineConfig(OLD_ARRAY)
+    const twice = normalizeCustomPipelineConfig(once)
+    expect(twice).toEqual(once)
+  })
+})
+
+describe('CustomPipelineConfig with a legacy config', () => {
+  const OLD_ARRAY = {
+    tools: [{ tool_id: 'fitz', config: { include_images: true, span_detail: false } }],
+    eviction_overlap_threshold: 0.5,
+  }
+
+  it('emits a normalized capability-slot config on mount', () => {
+    const onChange = vi.fn()
+    render(<CustomPipelineConfig config={OLD_ARRAY} onChange={onChange} />)
+    expect(onChange).toHaveBeenCalled()
+    const next = onChange.mock.calls[0][0]
+    expect(next.capabilities.text_extraction).toBe('fitz')
+    expect(next.tools['0']).toBeUndefined()
+    expect(Array.isArray(next.tools)).toBe(false)
+  })
+
+  it('never produces a config missing text_extraction after editing the table slot', async () => {
+    const onChange = vi.fn()
+    render(<CustomPipelineConfig config={OLD_ARRAY} onChange={onChange} />)
+    await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
+    await userEvent.click(screen.getByText(/fitz_tables/i))
+    const calls = onChange.mock.calls
+    const next = calls[calls.length - 1][0]
+    expect(next.capabilities.text_extraction).toBe('fitz')
+    expect(next.capabilities.table_detection).toBe('fitz_tables')
+    expect(next.tools['0']).toBeUndefined()
+  })
 })

--- a/frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx
+++ b/frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx
@@ -4,39 +4,43 @@ import { describe, expect, it, vi } from 'vitest'
 import { CustomPipelineConfig } from './CustomPipelineConfig'
 
 const fitzOnly = {
-  tools: [
-    {
-      tool_id: 'fitz',
+  tools: {
+    fitz: {
+      tool: 'fitz',
       config: { include_images: true, span_detail: false, min_chars_threshold: 10 },
     },
-  ],
+  },
+  capabilities: { text_extraction: 'fitz' },
   eviction_overlap_threshold: 0.5,
 }
 
 const withFitzTables = {
   ...fitzOnly,
-  tools: [
+  tools: {
     ...fitzOnly.tools,
-    {
-      tool_id: 'fitz_tables',
+    fitz_tables: {
+      tool: 'fitz_tables',
       config: { vertical_strategy: 'lines_strict', horizontal_strategy: 'lines_strict' },
     },
-  ],
+  },
+  capabilities: { text_extraction: 'fitz', table_detection: 'fitz_tables' },
 }
 
 const withCamelot = {
   ...fitzOnly,
-  tools: [
+  tools: {
     ...fitzOnly.tools,
-    { tool_id: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } },
-  ],
+    camelot: { tool: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } },
+  },
+  capabilities: { text_extraction: 'fitz', table_detection: 'camelot' },
 }
 
 describe('CustomPipelineConfig', () => {
-  it('renders fitz section as always-on and a table-tool selector', () => {
+  it('renders text extraction as a slot, not an always-on label', () => {
     render(<CustomPipelineConfig config={fitzOnly} onChange={vi.fn()} />)
-    expect(screen.getByText(/fitz \(text \+ images\)/i)).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /text extraction/i })).toBeInTheDocument()
     expect(screen.getByRole('combobox', { name: /table extraction/i })).toBeInTheDocument()
+    expect(screen.queryByText(/always on/i)).not.toBeInTheDocument()
   })
 
   it('selecting fitz_tables adds it to tools list', async () => {
@@ -45,8 +49,10 @@ describe('CustomPipelineConfig', () => {
     await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
     await userEvent.click(screen.getByText(/fitz_tables/i))
     const next = onChange.mock.calls[0][0]
-    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).toContain('fitz_tables')
-    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).not.toContain('camelot')
+    expect(next.capabilities.text_extraction).toBe('fitz')
+    expect(next.capabilities.table_detection).toBe('fitz_tables')
+    expect(next.tools.fitz_tables.tool).toBe('fitz_tables')
+    expect(next.tools.camelot).toBeUndefined()
   })
 
   it('selecting camelot adds it to tools list', async () => {
@@ -55,8 +61,9 @@ describe('CustomPipelineConfig', () => {
     await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
     await userEvent.click(screen.getByText(/^camelot/i))
     const next = onChange.mock.calls[0][0]
-    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).toContain('camelot')
-    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).not.toContain('fitz_tables')
+    expect(next.capabilities.table_detection).toBe('camelot')
+    expect(next.tools.camelot.tool).toBe('camelot')
+    expect(next.tools.fitz_tables).toBeUndefined()
   })
 
   it('selecting none removes existing table tool', async () => {
@@ -65,8 +72,9 @@ describe('CustomPipelineConfig', () => {
     await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
     await userEvent.click(screen.getByRole('option', { name: /none/i }))
     const next = onChange.mock.calls[0][0]
-    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).not.toContain('fitz_tables')
-    expect(next.tools.map((t: { tool_id: string }) => t.tool_id)).not.toContain('camelot')
+    expect(next.capabilities.table_detection).toBeUndefined()
+    expect(next.tools.fitz_tables).toBeUndefined()
+    expect(next.tools.camelot).toBeUndefined()
   })
 
   it('switching from camelot to fitz_tables removes camelot', async () => {
@@ -75,9 +83,9 @@ describe('CustomPipelineConfig', () => {
     await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
     await userEvent.click(screen.getByText(/fitz_tables/i))
     const next = onChange.mock.calls[0][0]
-    const ids = next.tools.map((t: { tool_id: string }) => t.tool_id)
-    expect(ids).toContain('fitz_tables')
-    expect(ids).not.toContain('camelot')
+    expect(next.capabilities.table_detection).toBe('fitz_tables')
+    expect(next.tools.fitz_tables).toBeDefined()
+    expect(next.tools.camelot).toBeUndefined()
   })
 
   it('shows fitz_tables config panel when fitz_tables is selected', () => {
@@ -100,10 +108,11 @@ describe('CustomPipelineConfig', () => {
   it('shows edge_tol/row_tol for camelot stream flavor', () => {
     const withStream = {
       ...fitzOnly,
-      tools: [
+      tools: {
         ...fitzOnly.tools,
-        { tool_id: 'camelot', config: { flavor: 'stream', edge_tol: 50, row_tol: 2 } },
-      ],
+        camelot: { tool: 'camelot', config: { flavor: 'stream', edge_tol: 50, row_tol: 2 } },
+      },
+      capabilities: { text_extraction: 'fitz', table_detection: 'camelot' },
     }
     render(<CustomPipelineConfig config={withStream} onChange={vi.fn()} />)
     expect(screen.getByText('edge_tol')).toBeInTheDocument()

--- a/frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx
+++ b/frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx
@@ -16,7 +16,7 @@ import {
 import { Slider } from '@/components/ui/slider'
 import type { ParseConfig } from '@/types/parsing'
 import { ChevronDown } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface ToolInstance {
   tool: string
@@ -355,6 +355,62 @@ function FitzTablesConfigPanel({
   )
 }
 
+const CAPABILITY_BY_TOOL: Record<string, string> = {
+  fitz: 'text_extraction',
+  pdfplumber: 'text_extraction',
+  fitz_tables: 'table_detection',
+  camelot: 'table_detection',
+}
+
+/** Coerce any accepted config shape into the capability-slot shape, and
+ * guarantee the required `text_extraction` slot.
+ *
+ * Handles the pre-refactor array shape (`tools: [{tool_id, config}]`, no
+ * `capabilities`) so re-parsing an old run — or any stale seed — cannot emit a
+ * config the backend will reject with "text_extraction is required".
+ * Idempotent: normalizing an already-normal config returns an equal object.
+ */
+export function normalizeCustomPipelineConfig(raw: unknown): PipelineConfig {
+  const src = (raw ?? {}) as Record<string, unknown>
+  const tools: Record<string, ToolInstance> = {}
+  const capabilities: Record<string, string> = {
+    ...((src.capabilities as Record<string, string>) ?? {}),
+  }
+
+  const rawTools = src.tools
+  if (Array.isArray(rawTools)) {
+    // Old shape: [{ tool_id, config }] keyed by tool id, inferring slots.
+    for (const entry of rawTools as Array<Record<string, unknown>>) {
+      const toolId = (entry.tool ?? entry.tool_id) as string | undefined
+      if (!toolId) continue
+      tools[toolId] = { tool: toolId, config: (entry.config as Record<string, unknown>) ?? {} }
+      const cap = CAPABILITY_BY_TOOL[toolId]
+      if (cap && !capabilities[cap]) capabilities[cap] = toolId
+    }
+  } else if (rawTools && typeof rawTools === 'object') {
+    for (const [key, entry] of Object.entries(rawTools as Record<string, Record<string, unknown>>)) {
+      const toolId = (entry.tool ?? entry.tool_id) as string | undefined
+      if (!toolId) continue
+      tools[key] = { tool: toolId, config: (entry.config as Record<string, unknown>) ?? {} }
+    }
+  }
+
+  // Guarantee the required text_extraction slot.
+  if (!capabilities.text_extraction) {
+    if (!tools.fitz) tools.fitz = { tool: 'fitz', config: {} }
+    capabilities.text_extraction = 'fitz'
+  }
+
+  const out: PipelineConfig = { tools, capabilities }
+  if (typeof src.eviction_overlap_threshold === 'number') {
+    out.eviction_overlap_threshold = src.eviction_overlap_threshold
+  }
+  if (typeof src.ocr_eviction_threshold === 'number') {
+    out.ocr_eviction_threshold = src.ocr_eviction_threshold
+  }
+  return out
+}
+
 /** Assign (or clear) the tool filling a capability slot.
  *
  * Instance keys are the tool id — a 1:1 simplification of the named-instance
@@ -402,10 +458,22 @@ export function CustomPipelineConfig({
   onChange,
   disabled = false,
 }: CustomPipelineConfigProps) {
-  const cfg = config as unknown as PipelineConfig
-  const tools = cfg.tools ?? {}
-  const capabilities = cfg.capabilities ?? {}
-  const threshold = (config.eviction_overlap_threshold as number | undefined) ?? 0.5
+  const cfg = normalizeCustomPipelineConfig(config)
+
+  // If the incoming config was a stale/legacy shape, push the normalized shape
+  // up so the parent (and any parse it triggers) uses the corrected config even
+  // if the user never edits anything.
+  const normalizedKey = JSON.stringify(cfg)
+  useEffect(() => {
+    if (JSON.stringify(config) !== normalizedKey) {
+      onChange(cfg as unknown as ParseConfig)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [normalizedKey])
+
+  const tools = cfg.tools
+  const capabilities = cfg.capabilities
+  const threshold = cfg.eviction_overlap_threshold ?? 0.5
 
   const textKey = capabilities.text_extraction ?? 'fitz'
   const fitz = tools[textKey]

--- a/frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx
+++ b/frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx
@@ -18,9 +18,18 @@ import type { ParseConfig } from '@/types/parsing'
 import { ChevronDown } from 'lucide-react'
 import { useState } from 'react'
 
-interface ToolEntry {
-  tool_id: string
+interface ToolInstance {
+  tool: string
   config: Record<string, unknown>
+}
+
+/** Capability slots: each capability is filled by at most one named tool instance. */
+interface PipelineConfig {
+  tools: Record<string, ToolInstance>
+  capabilities: Record<string, string>
+  eviction_overlap_threshold?: number
+  ocr_eviction_threshold?: number
+  page_flags?: Record<string, number>
 }
 
 interface CustomPipelineConfigProps {
@@ -30,8 +39,6 @@ interface CustomPipelineConfigProps {
 }
 
 type TableTool = 'none' | 'fitz_tables' | 'camelot'
-
-const TABLE_TOOL_IDS: TableTool[] = ['fitz_tables', 'camelot']
 
 const CAMELOT_DEFAULTS = { flavor: 'lattice', edge_tol: 50, row_tol: 2 }
 
@@ -348,62 +355,104 @@ function FitzTablesConfigPanel({
   )
 }
 
+/** Assign (or clear) the tool filling a capability slot.
+ *
+ * Instance keys are the tool id — a 1:1 simplification of the named-instance
+ * model. A tool referenced from two slots therefore resolves to one instance.
+ */
+function setSlot(
+  cfg: PipelineConfig,
+  capability: string,
+  toolId: string | null,
+  defaults: Record<string, unknown> = {},
+): PipelineConfig {
+  const capabilities = { ...cfg.capabilities }
+  const tools = { ...cfg.tools }
+  const previous = capabilities[capability]
+  if (previous) {
+    delete capabilities[capability]
+    // Drop the instance only if no other slot still references it.
+    if (!Object.values(capabilities).includes(previous)) delete tools[previous]
+  }
+  if (toolId) {
+    capabilities[capability] = toolId
+    tools[toolId] = tools[toolId] ?? { tool: toolId, config: defaults }
+  }
+  return { ...cfg, tools, capabilities }
+}
+
+function setToolConfig(
+  cfg: PipelineConfig,
+  instanceKey: string,
+  patch: Record<string, unknown>,
+): PipelineConfig {
+  const existing = cfg.tools[instanceKey]
+  if (!existing) return cfg
+  return {
+    ...cfg,
+    tools: {
+      ...cfg.tools,
+      [instanceKey]: { ...existing, config: { ...existing.config, ...patch } },
+    },
+  }
+}
+
 export function CustomPipelineConfig({
   config,
   onChange,
   disabled = false,
 }: CustomPipelineConfigProps) {
-  const tools = (config.tools as ToolEntry[] | undefined) ?? []
+  const cfg = config as unknown as PipelineConfig
+  const tools = cfg.tools ?? {}
+  const capabilities = cfg.capabilities ?? {}
   const threshold = (config.eviction_overlap_threshold as number | undefined) ?? 0.5
 
-  const fitz = tools.find((t) => t.tool_id === 'fitz')
-  const currentTableTool = tools.find((t) =>
-    TABLE_TOOL_IDS.includes(t.tool_id as TableTool)
-  )
-  const selectedTableTool: TableTool = (currentTableTool?.tool_id as TableTool) ?? 'none'
+  const textKey = capabilities.text_extraction ?? 'fitz'
+  const fitz = tools[textKey]
 
-  const setTools = (next: ToolEntry[]) => onChange({ ...config, tools: next })
+  const tableKey = capabilities.table_detection
+  const currentTableTool = tableKey ? tools[tableKey] : undefined
+  const selectedTableTool: TableTool = (currentTableTool?.tool as TableTool) ?? 'none'
 
-  const updateTool = (toolId: string, patch: Record<string, unknown>) => {
-    setTools(
-      tools.map((t) =>
-        t.tool_id === toolId ? { ...t, config: { ...t.config, ...patch } } : t
-      )
-    )
+  const updateTool = (instanceKey: string, patch: Record<string, unknown>) => {
+    onChange(setToolConfig(cfg, instanceKey, patch) as unknown as ParseConfig)
   }
 
   const handleTableToolChange = (value: TableTool) => {
-    const withoutAnyTableTool = tools.filter(
-      (t) => !TABLE_TOOL_IDS.includes(t.tool_id as TableTool)
+    const defaults =
+      value === 'camelot' ? { ...CAMELOT_DEFAULTS } : { ...FITZ_TABLES_DEFAULTS }
+    const next = setSlot(
+      cfg,
+      'table_detection',
+      value === 'none' ? null : value,
+      defaults,
     )
-    if (value === 'none') {
-      setTools(withoutAnyTableTool)
-    } else if (value === 'fitz_tables') {
-      setTools([
-        ...withoutAnyTableTool,
-        { tool_id: 'fitz_tables', config: { ...FITZ_TABLES_DEFAULTS } },
-      ])
-    } else if (value === 'camelot') {
-      setTools([
-        ...withoutAnyTableTool,
-        { tool_id: 'camelot', config: { ...CAMELOT_DEFAULTS } },
-      ])
-    }
+    onChange(next as unknown as ParseConfig)
   }
 
   return (
     <div className="space-y-4">
-      {/* Fitz — always on */}
+      {/* Text extraction — a capability slot (required) */}
       <div className="space-y-2 rounded-md border p-3">
-        <div className="flex items-center justify-between">
-          <Label>fitz (text + images)</Label>
-          <span className="text-xs text-muted-foreground">always on</span>
+        <div className="space-y-1">
+          <Label htmlFor="text-tool-select">Text extraction</Label>
+          <p className="text-xs text-muted-foreground">
+            The base text extractor. Required — every pipeline fills this slot.
+          </p>
+          <Select value={textKey} onValueChange={() => {}} disabled={disabled}>
+            <SelectTrigger id="text-tool-select" aria-label="Text extraction">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="fitz">fitz (text + images)</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex items-center gap-2">
           <Checkbox
             id="fitz-include-images"
             checked={(fitz?.config.include_images as boolean) ?? true}
-            onCheckedChange={(c) => updateTool('fitz', { include_images: !!c })}
+            onCheckedChange={(c) => updateTool(textKey, { include_images: !!c })}
             disabled={disabled}
           />
           <Label htmlFor="fitz-include-images">Include images (FIGURE blocks)</Label>
@@ -412,7 +461,7 @@ export function CustomPipelineConfig({
           <Checkbox
             id="fitz-span-detail"
             checked={(fitz?.config.span_detail as boolean) ?? false}
-            onCheckedChange={(c) => updateTool('fitz', { span_detail: !!c })}
+            onCheckedChange={(c) => updateTool(textKey, { span_detail: !!c })}
             disabled={disabled}
           />
           <Label htmlFor="fitz-span-detail">Record span detail</Label>
@@ -447,7 +496,7 @@ export function CustomPipelineConfig({
         {selectedTableTool === 'fitz_tables' && currentTableTool && (
           <FitzTablesConfigPanel
             config={currentTableTool.config}
-            onChange={(patch) => updateTool('fitz_tables', patch)}
+            onChange={(patch) => updateTool(tableKey as string, patch)}
             disabled={disabled}
           />
         )}
@@ -458,7 +507,7 @@ export function CustomPipelineConfig({
               <Label htmlFor="camelot-flavor">Flavor</Label>
               <Select
                 value={(currentTableTool.config.flavor as string) ?? 'lattice'}
-                onValueChange={(v) => updateTool('camelot', { flavor: v })}
+                onValueChange={(v) => updateTool(tableKey as string, { flavor: v })}
                 disabled={disabled}
               >
                 <SelectTrigger id="camelot-flavor">
@@ -480,7 +529,7 @@ export function CustomPipelineConfig({
                     type="number"
                     value={(currentTableTool.config.edge_tol as number) ?? 50}
                     onChange={(e) =>
-                      updateTool('camelot', { edge_tol: Number(e.target.value) })
+                      updateTool(tableKey as string, { edge_tol: Number(e.target.value) })
                     }
                     disabled={disabled}
                   />
@@ -492,7 +541,7 @@ export function CustomPipelineConfig({
                     type="number"
                     value={(currentTableTool.config.row_tol as number) ?? 2}
                     onChange={(e) =>
-                      updateTool('camelot', { row_tol: Number(e.target.value) })
+                      updateTool(tableKey as string, { row_tol: Number(e.target.value) })
                     }
                     disabled={disabled}
                   />


### PR DESCRIPTION
## Summary

Replaces the custom pipeline's flat `tools: [...]` list and binary merger with **capability slots** — one tool per IDP capability — and an N-way, capability-aware merger. **No OCR in this PR**; it lands in PR B.

Closes #161

- Spec: `docs/superpowers/specs/2026-07-10-ocr-capability-pipeline-design.md`
- Plan: `docs/superpowers/plans/2026-07-10-capability-slot-refactor.md`

## Why

Capability was never modelled — only *simulated*, by three unrelated string-level hacks:

| Slot | How it was "enforced" |
|---|---|
| Text | Hardcoded string: `raise ValueError("custom pipeline requires a 'fitz' tool")`. Not swappable. |
| Table | A `TABLE_TOOL_IDS` frozenset + a `len(...) > 1` runtime count check over a flat list. |
| Merge | Binary positional args: `merge(fitz_result, table_result)`. |

OCR cannot be added into that shape. Worse, OCR's precedence is *inverted* relative to tables (native text is exact, OCR is lossy), and flips again on CID-corrupt pages — so no fixed tool ordering can express it.

## What changed

- **`Capability` enum**, split into *block-producing* (compete, ranked by precedence) and *staging* (`layout_analysis` — orders/routes, never competes, so it can slot in above the merger later without a rewrite).
- **Config is named tool instances + a `capabilities` map.** One instance runs once however many slots reference it, receiving an `emit` mask. `text_extraction: docling, table_detection: camelot` would therefore run docling with tables masked off — derived, not hand-specified.
- **`LocalTool` → `PipelineTool`**; `ToolResult.blocks_by_capability` replaces `ToolResult.blocks`. `page_meta` moves from the table tools' constructors into `run()`, so every instance can be built up front.
- **N-way merger** with page-dependent precedence. The whole rule collapses to one line: `ocr_outranks_text(page) = ocr_prefer or page.cid_corrupt`. The CID flip and `prefer` are the same mechanism, applied per-page vs per-run.
- **Capability-tagged audit trail.** An eviction record now reads *"an OCR block was dropped because native text already covered 82% of it"*.
- **`page_flags.py`** — `char_count`, `pua_ratio`, `cid_corrupt` from fitz metadata only. Deliberately **no dependency on `app/probe/`**: the probe is advisory evidence, this is deterministic execution state.
- **Deleted, not generalized:** `TABLE_TOOL_IDS`, its count guard, the hardcoded `'fitz'` requirement — and the frontend's `TABLE_TOOL_IDS` mirror. Two table tools is now *structurally unrepresentable*.
- **Frontend:** text extraction is a real slot; `"always on"` is gone. The UI already looked like capability slots — the backend now agrees.

## Behaviour preservation

PR A is a **pure refactor**. `test_refactor_equivalence.py` pins it:

- Reading order stays contiguous from 0; block ids keep the `<source>:<page>:<order>` scheme.
- A table still evicts the text it covers, at the same `> 0.5` threshold.
- Adding `table_detection` only *removes* covered text — it never alters surviving text blocks.

**Intentional exception:** `ParseRun.raw_payload` changes shape (`"tools"` → `"instances"`, capability-tagged evictions). It is an audit artifact, not part of `ParsedDocument`.

## Verification

- Backend: **1275 passed**. `tests/repositories/test_project_repository.py::test_list_all_sorted_by_created_at` fails — verified **pre-existing on `main`** and untouched by this diff (which is confined to `custom_pipeline`, its tests, the runner, and docs).
- Frontend: **360 passed** (69/69 files); `npm run lint` clean; `npm run build` succeeds.
- `parser_eval` hashes pipeline config as an opaque dict, so the contract change has no blast radius there (verified).

## Out of scope (PR B)

`tesseract_tool.py`, `page_flags.has_uncovered_image`, the `precedence` config field, `pages: "auto"`, OCR UI. `Capability.TEXT_OCR` and `ocr_prefer` exist here as fully unit-tested pure logic, so PR B only wires config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
