### PR TITLE
Unify parse capability model: collapse text_extraction into layout_analysis (PR A)

### DIFF
--- a/backend/app/cdm/adapters/custom_pipeline/capabilities.py
+++ b/backend/app/cdm/adapters/custom_pipeline/capabilities.py
@@ -10,28 +10,28 @@ from typing import Dict
 
 
 class Capability(str, Enum):
-    TEXT_EXTRACTION = "text_extraction"
+    LAYOUT_ANALYSIS = "layout_analysis"   # required structure slot (fitz tier-0, docling tier-1)
     TABLE_DETECTION = "table_detection"
     TEXT_OCR = "text_ocr"
-    LAYOUT_ANALYSIS = "layout_analysis"
 
 
 #: Capabilities whose blocks compete for page area (governed by precedence).
 BLOCK_PRODUCING = frozenset({
-    Capability.TEXT_EXTRACTION,
+    Capability.LAYOUT_ANALYSIS,
     Capability.TABLE_DETECTION,
     Capability.TEXT_OCR,
 })
 
-#: Capabilities that order/route rather than compete. No tools yet.
-STAGING = frozenset({Capability.LAYOUT_ANALYSIS})
+#: Capabilities that order/route rather than compete. Empty for now — the
+#: router slice refills this with bbox+label-only layout detectors.
+STAGING: frozenset[Capability] = frozenset()
 
 
 def resolve_precedence(*, cid_corrupt: bool, ocr_prefer: bool) -> Dict[Capability, int]:
     """Rank block-producing capabilities for one page. Higher wins.
 
     Structure always beats loose text. The only variable is whether OCR sits
-    above or below native text — the CID flip and `prefer` are the same
+    above or below the structure text — the CID flip and `prefer` are the same
     mechanism, applied per-page vs per-run.
     """
     ocr_outranks_text = ocr_prefer or cid_corrupt
@@ -39,10 +39,10 @@ def resolve_precedence(*, cid_corrupt: bool, ocr_prefer: bool) -> Dict[Capabilit
         return {
             Capability.TABLE_DETECTION: 3,
             Capability.TEXT_OCR: 2,
-            Capability.TEXT_EXTRACTION: 1,
+            Capability.LAYOUT_ANALYSIS: 1,
         }
     return {
         Capability.TABLE_DETECTION: 3,
-        Capability.TEXT_EXTRACTION: 2,
+        Capability.LAYOUT_ANALYSIS: 2,
         Capability.TEXT_OCR: 1,
     }

--- a/backend/app/cdm/adapters/custom_pipeline/config.py
+++ b/backend/app/cdm/adapters/custom_pipeline/config.py
@@ -117,8 +117,8 @@ def build_pipeline_config(config: Dict[str, Any]) -> ResolvedPipeline:
             raise ValueError(f"no tool provides staging capability {cap.value!r}")
         slots[cap] = instance_key
 
-    if Capability.TEXT_EXTRACTION not in slots:
-        raise ValueError("capability 'text_extraction' is required")
+    if Capability.LAYOUT_ANALYSIS not in slots:
+        raise ValueError("capability 'layout_analysis' is required")
 
     # instance key -> assigned capabilities (this is the masking set)
     assigned: Dict[str, Set[Capability]] = {}

--- a/backend/app/cdm/adapters/custom_pipeline/tools/base.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/base.py
@@ -20,7 +20,7 @@ def clamp01(v: float) -> float:
 
 
 class PageMeta(BaseModel):
-    """Authoritative page geometry, sourced from the text_extraction tool."""
+    """Authoritative page geometry, sourced from the structure (layout_analysis) tool."""
     index: int
     width: float       # PDF points
     height: float      # PDF points

--- a/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py
+++ b/backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py
@@ -58,7 +58,7 @@ def _spans(native_block: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 class FitzTool:
     tool_id = "fitz"
-    provides = frozenset({Capability.TEXT_EXTRACTION})
+    provides = frozenset({Capability.LAYOUT_ANALYSIS})
 
     def __init__(self, config: Optional[FitzConfig] = None) -> None:
         self.config = config or FitzConfig()
@@ -69,7 +69,7 @@ class FitzTool:
         *,
         pages: Optional[List[int]] = None,
         page_meta: Optional[Dict[int, PageMeta]] = None,  # unused; fitz is the source
-        emit: frozenset[Capability] = frozenset({Capability.TEXT_EXTRACTION}),
+        emit: frozenset[Capability] = frozenset({Capability.LAYOUT_ANALYSIS}),
     ) -> ToolResult:
         if not emit <= self.provides:
             raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
@@ -148,7 +148,7 @@ class FitzTool:
 
         return ToolResult(
             tool_id=self.tool_id,
-            blocks_by_capability={Capability.TEXT_EXTRACTION: blocks},
+            blocks_by_capability={Capability.LAYOUT_ANALYSIS: blocks},
             page_meta=page_meta_out,
             raw={"pages": native_raw},
             native_by_block=native_by_block,

--- a/backend/app/services/parsing/custom_pipeline_runner.py
+++ b/backend/app/services/parsing/custom_pipeline_runner.py
@@ -54,20 +54,20 @@ async def run_custom_pipeline(
         pipeline = build_pipeline_config(config)
         flags = compute_page_flags(pdf_path, pipeline.page_flags)
 
-        text_instance = pipeline.for_capability(Capability.TEXT_EXTRACTION)
+        structure_instance = pipeline.for_capability(Capability.LAYOUT_ANALYSIS)
         # build_pipeline_config guarantees this, but fail loudly if it ever does not.
-        if text_instance is None:
-            raise ValueError("capability 'text_extraction' is required")
+        if structure_instance is None:
+            raise ValueError("capability 'layout_analysis' is required")
 
-        text_result = text_instance.tool.run(pdf_path, emit=text_instance.emit)
-        results = [text_result]
-        warnings = list(text_result.warnings)
+        structure_result = structure_instance.tool.run(pdf_path, emit=structure_instance.emit)
+        results = [structure_result]
+        warnings = list(structure_result.warnings)
 
         # Remaining instances run once each, in the deterministic order
         # build_pipeline_config established, and receive page geometry from the
         # text_extraction tool.
         for inst in pipeline.instances:
-            if inst is text_instance:
+            if inst is structure_instance:
                 continue
             pages = None
             if Capability.TEXT_OCR in inst.emit:
@@ -75,7 +75,7 @@ async def run_custom_pipeline(
                 # per-page facts; every other tool runs over the whole document.
                 pages = inst.tool.select_pages(flags)
             r = inst.tool.run(
-                pdf_path, pages=pages, page_meta=text_result.page_meta, emit=inst.emit)
+                pdf_path, pages=pages, page_meta=structure_result.page_meta, emit=inst.emit)
             results.append(r)
             warnings.extend(r.warnings)
 
@@ -109,7 +109,7 @@ async def run_custom_pipeline(
 
     adapter = CustomPipelineAdapter()
     doc = adapter.adapt(
-        {"page_meta": text_result.page_meta, "blocks": merge_result.blocks},
+        {"page_meta": structure_result.page_meta, "blocks": merge_result.blocks},
         SourceMeta(
             source_document_id=source.id,
             parse_run_id=run.id,

--- a/backend/app/services/parsing/custom_pipeline_runner.py
+++ b/backend/app/services/parsing/custom_pipeline_runner.py
@@ -65,7 +65,7 @@ async def run_custom_pipeline(
 
         # Remaining instances run once each, in the deterministic order
         # build_pipeline_config established, and receive page geometry from the
-        # text_extraction tool.
+        # structure (layout_analysis) tool.
         for inst in pipeline.instances:
             if inst is structure_instance:
                 continue

--- a/backend/scripts/capture_equivalence_golden.py
+++ b/backend/scripts/capture_equivalence_golden.py
@@ -1,0 +1,51 @@
+"""Run ONCE on the pre-refactor branch to snapshot current pipeline output.
+
+    cd backend && uv run python scripts/capture_equivalence_golden.py
+
+Writes tests/.../fixtures/equivalence/<name>.json. Commit the results; Task A5's
+test compares the post-refactor pipeline against them.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.cdm.source import SourceDocument
+from app.services.parsing.custom_pipeline_runner import run_custom_pipeline
+from tests.cdm.adapters.custom_pipeline.fixtures.equivalence_fixtures import (
+    EQUIV_CONFIGS, build_for, content_projection,
+)
+
+GOLDEN_DIR = (Path(__file__).resolve().parents[1]
+              / "tests/cdm/adapters/custom_pipeline/fixtures/equivalence")
+
+
+def _source() -> SourceDocument:
+    return SourceDocument(
+        id="src-1", sha256="b" * 64, filename="equiv.pdf",
+        mime_type="application/pdf", byte_size=1234,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+async def main() -> None:
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    for name, config in EQUIV_CONFIGS.items():
+        pdf = GOLDEN_DIR / f"{name}.pdf"
+        build_for(name, pdf)
+        _, parsed = await run_custom_pipeline(
+            source=_source(), file_path=str(pdf),
+            representation_kind="extract_rich", config=config, client=None)
+        (GOLDEN_DIR / f"{name}.json").write_text(
+            json.dumps(content_projection(parsed), indent=2, sort_keys=True))
+        pdf.unlink(missing_ok=True)
+        print(f"captured {name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence/text_only.json
+++ b/backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence/text_only.json
@@ -1,0 +1,100 @@
+{
+  "blocks": [
+    {
+      "bbox": {
+        "source_coords": [
+          72.0,
+          56.94999694824219,
+          224.5019989013672,
+          76.18599700927734
+        ],
+        "source_space": "pdf_points",
+        "space": "normalized",
+        "x0": 0.12100840336134454,
+        "x1": 0.377314283867844,
+        "y0": 0.0676365759480311,
+        "y1": 0.090482181721232
+      },
+      "children_ids": [],
+      "depth": null,
+      "html": null,
+      "id": "src-1:0:0",
+      "image_ref": null,
+      "is_continuation": false,
+      "language": null,
+      "markdown": null,
+      "native_label": null,
+      "native_type": "text",
+      "page_index": 0,
+      "parent_id": null,
+      "parser_extras": {
+        "fitz_block_type": 0
+      },
+      "quality": null,
+      "reading_order": 0,
+      "role": "text",
+      "spans": [],
+      "style": null,
+      "table": null,
+      "text": "Quarterly revenue report"
+    },
+    {
+      "bbox": {
+        "source_coords": [
+          72.0,
+          99.25,
+          175.91998291015625,
+          112.98999786376953
+        ],
+        "source_space": "pdf_points",
+        "space": "normalized",
+        "x0": 0.12100840336134454,
+        "x1": 0.295663836823792,
+        "y0": 0.11787410926365796,
+        "y1": 0.1341923965127904
+      },
+      "children_ids": [],
+      "depth": null,
+      "html": null,
+      "id": "src-1:0:1",
+      "image_ref": null,
+      "is_continuation": false,
+      "language": null,
+      "markdown": null,
+      "native_label": null,
+      "native_type": "text",
+      "page_index": 0,
+      "parent_id": null,
+      "parser_extras": {
+        "fitz_block_type": 0
+      },
+      "quality": null,
+      "reading_order": 1,
+      "role": "text",
+      "spans": [],
+      "style": null,
+      "table": null,
+      "text": "Figures are provisional."
+    }
+  ],
+  "full_markdown": null,
+  "full_text": "Quarterly revenue report\n\nFigures are provisional.",
+  "page_count": 1,
+  "pages": [
+    {
+      "block_ids": [
+        "src-1:0:0",
+        "src-1:0:1"
+      ],
+      "end_char": null,
+      "height": 842.0,
+      "index": 0,
+      "parser_extras": {},
+      "quality": null,
+      "rotation": 0,
+      "start_char": null,
+      "unit": "points",
+      "width": 595.0
+    }
+  ]
+}

--- a/backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence/text_plus_table.json
+++ b/backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence/text_plus_table.json
@@ -1,0 +1,202 @@
+{
+  "blocks": [
+    {
+      "bbox": {
+        "source_coords": [
+          72.0,
+          56.94999694824219,
+          224.5019989013672,
+          76.18599700927734
+        ],
+        "source_space": "pdf_points",
+        "space": "normalized",
+        "x0": 0.12100840336134454,
+        "x1": 0.377314283867844,
+        "y0": 0.0676365759480311,
+        "y1": 0.090482181721232
+      },
+      "children_ids": [],
+      "depth": null,
+      "html": null,
+      "id": "src-1:0:0",
+      "image_ref": null,
+      "is_continuation": false,
+      "language": null,
+      "markdown": null,
+      "native_label": null,
+      "native_type": "text",
+      "page_index": 0,
+      "parent_id": null,
+      "parser_extras": {
+        "fitz_block_type": 0
+      },
+      "quality": null,
+      "reading_order": 0,
+      "role": "text",
+      "spans": [],
+      "style": null,
+      "table": null,
+      "text": "Quarterly revenue report"
+    },
+    {
+      "bbox": {
+        "source_coords": [
+          72.0,
+          200.0,
+          400.0,
+          300.0
+        ],
+        "source_space": "pdf_points",
+        "space": "normalized",
+        "x0": 0.12100840336134454,
+        "x1": 0.6722689075630253,
+        "y0": 0.2375296912114014,
+        "y1": 0.35629453681710216
+      },
+      "children_ids": [],
+      "depth": null,
+      "html": "<table><tr><td>Name</td><td>Value</td></tr><tr><td>alpha</td><td>1</td></tr></table>",
+      "id": "src-1:0:1",
+      "image_ref": null,
+      "is_continuation": false,
+      "language": null,
+      "markdown": "| Name | Value |\n| --- | --- |\n| alpha | 1 |",
+      "native_label": null,
+      "native_type": "table",
+      "page_index": 0,
+      "parent_id": null,
+      "parser_extras": {
+        "fitz_tables_col_count": 2,
+        "fitz_tables_row_count": 2,
+        "fitz_tables_strategy": "lines_strict/lines_strict"
+      },
+      "quality": null,
+      "reading_order": 1,
+      "role": "table",
+      "spans": [],
+      "style": null,
+      "table": {
+        "caption": null,
+        "cells": [
+          {
+            "bbox": {
+              "source_coords": [
+                72.0,
+                200.0,
+                236.0,
+                250.0
+              ],
+              "source_space": "pdf_points",
+              "space": "normalized",
+              "x0": 0.12100840336134454,
+              "x1": 0.39663865546218485,
+              "y0": 0.2375296912114014,
+              "y1": 0.29691211401425177
+            },
+            "col": 0,
+            "colspan": 1,
+            "is_header": false,
+            "quality": null,
+            "row": 0,
+            "rowspan": 1,
+            "text": "Name"
+          },
+          {
+            "bbox": {
+              "source_coords": [
+                72.0,
+                250.0,
+                236.0,
+                300.0
+              ],
+              "source_space": "pdf_points",
+              "space": "normalized",
+              "x0": 0.12100840336134454,
+              "x1": 0.39663865546218485,
+              "y0": 0.29691211401425177,
+              "y1": 0.35629453681710216
+            },
+            "col": 1,
+            "colspan": 1,
+            "is_header": false,
+            "quality": null,
+            "row": 0,
+            "rowspan": 1,
+            "text": "Value"
+          },
+          {
+            "bbox": {
+              "source_coords": [
+                236.0,
+                200.0,
+                400.0,
+                250.0
+              ],
+              "source_space": "pdf_points",
+              "space": "normalized",
+              "x0": 0.39663865546218485,
+              "x1": 0.6722689075630253,
+              "y0": 0.2375296912114014,
+              "y1": 0.29691211401425177
+            },
+            "col": 0,
+            "colspan": 1,
+            "is_header": false,
+            "quality": null,
+            "row": 1,
+            "rowspan": 1,
+            "text": "alpha"
+          },
+          {
+            "bbox": {
+              "source_coords": [
+                236.0,
+                250.0,
+                400.0,
+                300.0
+              ],
+              "source_space": "pdf_points",
+              "space": "normalized",
+              "x0": 0.39663865546218485,
+              "x1": 0.6722689075630253,
+              "y0": 0.29691211401425177,
+              "y1": 0.35629453681710216
+            },
+            "col": 1,
+            "colspan": 1,
+            "is_header": false,
+            "quality": null,
+            "row": 1,
+            "rowspan": 1,
+            "text": "1"
+          }
+        ],
+        "cols": 2,
+        "html": "<table><tr><td>Name</td><td>Value</td></tr><tr><td>alpha</td><td>1</td></tr></table>",
+        "markdown": "| Name | Value |\n| --- | --- |\n| alpha | 1 |",
+        "rows": 2
+      },
+      "text": "Name | Value\nalpha | 1"
+    }
+  ],
+  "full_markdown": "| Name | Value |\n| --- | --- |\n| alpha | 1 |",
+  "full_text": "Quarterly revenue report\n\nName | Value\nalpha | 1",
+  "page_count": 1,
+  "pages": [
+    {
+      "block_ids": [
+        "src-1:0:0",
+        "src-1:0:1"
+      ],
+      "end_char": null,
+      "height": 842.0,
+      "index": 0,
+      "parser_extras": {},
+      "quality": null,
+      "rotation": 0,
+      "start_char": null,
+      "unit": "points",
+      "width": 595.0
+    }
+  ]
+}

--- a/backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence_fixtures.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence_fixtures.py
@@ -1,0 +1,72 @@
+"""Shared fixtures for the PR A equivalence gate.
+
+Both the golden-capture script (run once, pre-refactor) and the post-refactor
+comparison test import these, so the two sides can never drift.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import fitz
+
+
+def build_text_pdf(path: Path) -> None:
+    """Two text blocks, no table — exercises plain text_extraction."""
+    d = fitz.open()
+    page = d.new_page(width=595, height=842)
+    page.insert_text(fitz.Point(72, 72), "Quarterly revenue report", fontsize=14)
+    page.insert_text(fitz.Point(72, 110), "Figures are provisional.", fontsize=10)
+    d.save(str(path)); d.close()
+
+
+def build_table_pdf(path: Path) -> None:
+    """Text plus a ruled grid — exercises text + table_detection + eviction."""
+    d = fitz.open()
+    page = d.new_page(width=595, height=842)
+    page.insert_text(fitz.Point(72, 72), "Quarterly revenue report", fontsize=14)
+    col_x, row_y = [72, 236, 400], [200, 250, 300]
+    for x in col_x:
+        page.draw_line(fitz.Point(x, row_y[0]), fitz.Point(x, row_y[-1]), width=1)
+    for y in row_y:
+        page.draw_line(fitz.Point(col_x[0], y), fitz.Point(col_x[-1], y), width=1)
+    page.insert_text(fitz.Point(80, 235), "Name", fontsize=11)
+    page.insert_text(fitz.Point(244, 235), "Value", fontsize=11)
+    page.insert_text(fitz.Point(80, 285), "alpha", fontsize=11)
+    page.insert_text(fitz.Point(244, 285), "1", fontsize=11)
+    d.save(str(path)); d.close()
+
+
+# Config keyed by golden name. NOTE: written in the *current* contract
+# (capabilities.text_extraction). Task A5's comparison test rewrites the key to
+# layout_analysis and asserts the produced content still matches these goldens —
+# proving the rename changed nothing.
+EQUIV_CONFIGS: dict[str, dict] = {
+    "text_only": {
+        "tools": {"fitz": {"tool": "fitz", "config": {}}},
+        "capabilities": {"text_extraction": "fitz"},
+    },
+    "text_plus_table": {
+        "tools": {"fitz": {"tool": "fitz", "config": {}},
+                  "tbl": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+    },
+}
+
+_BUILDERS = {"text_only": build_text_pdf, "text_plus_table": build_table_pdf}
+
+
+def build_for(name: str, path: Path) -> None:
+    _BUILDERS[name](path)
+
+
+def content_projection(doc) -> dict:
+    """Stable, volatile-field-free projection of a ParsedDocument.
+
+    Excludes `id` and `parse_run_id` (random/UUID per run); everything that
+    describes *content* — pages, blocks, text, markdown — is deterministic
+    because block ids derive from the fixed source_document_id.
+    """
+    return doc.model_dump(
+        mode="json",
+        include={"page_count", "pages", "blocks", "full_text", "full_markdown"},
+    )

--- a/backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
@@ -2,29 +2,34 @@ from app.cdm.adapters.custom_pipeline.capabilities import (
     BLOCK_PRODUCING, STAGING, Capability, resolve_precedence,
 )
 
-T, TB, O, L = (Capability.TEXT_EXTRACTION, Capability.TABLE_DETECTION,
-               Capability.TEXT_OCR, Capability.LAYOUT_ANALYSIS)
+TB, O, L = (Capability.TABLE_DETECTION, Capability.TEXT_OCR,
+            Capability.LAYOUT_ANALYSIS)
 
 
 def test_capability_kinds():
-    assert BLOCK_PRODUCING == frozenset({T, TB, O})
-    assert STAGING == frozenset({L})
+    assert BLOCK_PRODUCING == frozenset({L, TB, O})
+    assert STAGING == frozenset()
 
 
-def test_default_order_table_beats_text_beats_ocr():
+def test_layout_analysis_is_block_producing():
+    assert Capability.LAYOUT_ANALYSIS in BLOCK_PRODUCING
+    assert Capability.LAYOUT_ANALYSIS not in STAGING
+
+
+def test_text_extraction_is_gone():
+    assert not hasattr(Capability, "TEXT_EXTRACTION")
+
+
+def test_default_order_table_beats_layout_beats_ocr():
     r = resolve_precedence(cid_corrupt=False, ocr_prefer=False)
-    assert r[TB] > r[T] > r[O]
+    assert r[TB] > r[L] > r[O]
 
 
-def test_cid_corrupt_page_flips_ocr_above_text():
+def test_cid_corrupt_page_flips_ocr_above_layout():
     r = resolve_precedence(cid_corrupt=True, ocr_prefer=False)
-    assert r[TB] > r[O] > r[T]
+    assert r[TB] > r[O] > r[L]
 
 
-def test_ocr_prefer_flips_ocr_above_text():
+def test_ocr_prefer_flips_ocr_above_layout():
     r = resolve_precedence(cid_corrupt=False, ocr_prefer=True)
-    assert r[TB] > r[O] > r[T]
-
-
-def test_staging_capability_has_no_rank():
-    assert L not in resolve_precedence(cid_corrupt=False, ocr_prefer=False)
+    assert r[TB] > r[O] > r[L]

--- a/backend/tests/cdm/adapters/custom_pipeline/test_config.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_config.py
@@ -5,16 +5,16 @@ from app.cdm.adapters.custom_pipeline.config import build_pipeline_config
 
 BASE = {
     "tools": {"fitz": {"tool": "fitz", "config": {}}},
-    "capabilities": {"text_extraction": "fitz"},
+    "capabilities": {"layout_analysis": "fitz"},
 }
 
 
 def test_builds_a_single_slot_pipeline():
     p = build_pipeline_config(BASE)
-    inst = p.for_capability(Capability.TEXT_EXTRACTION)
+    inst = p.for_capability(Capability.LAYOUT_ANALYSIS)
     assert inst.key == "fitz"
     assert inst.tool.tool_id == "fitz"
-    assert inst.emit == frozenset({Capability.TEXT_EXTRACTION})
+    assert inst.emit == frozenset({Capability.LAYOUT_ANALYSIS})
     assert p.for_capability(Capability.TABLE_DETECTION) is None
 
 
@@ -22,7 +22,7 @@ def test_one_instance_serves_many_slots_and_is_built_once():
     cfg = {
         "tools": {"f": {"tool": "fitz", "config": {}},
                   "t": {"tool": "fitz_tables", "config": {}}},
-        "capabilities": {"text_extraction": "f", "table_detection": "t"},
+        "capabilities": {"layout_analysis": "f", "table_detection": "t"},
     }
     p = build_pipeline_config(cfg)
     assert len(p.instances) == 2
@@ -32,49 +32,50 @@ def test_one_instance_serves_many_slots_and_is_built_once():
 def test_tool_config_is_validated_and_applied():
     cfg = {
         "tools": {"fitz": {"tool": "fitz", "config": {"span_detail": True}}},
-        "capabilities": {"text_extraction": "fitz"},
+        "capabilities": {"layout_analysis": "fitz"},
     }
-    inst = build_pipeline_config(cfg).for_capability(Capability.TEXT_EXTRACTION)
+    inst = build_pipeline_config(cfg).for_capability(Capability.LAYOUT_ANALYSIS)
     assert inst.tool.config.span_detail is True
 
 
-def test_text_extraction_slot_is_required():
-    with pytest.raises(ValueError, match="text_extraction"):
+def test_layout_analysis_slot_is_required():
+    with pytest.raises(ValueError, match="layout_analysis"):
         build_pipeline_config({"tools": {}, "capabilities": {}})
 
 
 def test_unknown_tool_is_rejected():
     with pytest.raises(ValueError, match="unknown tool"):
         build_pipeline_config({"tools": {"x": {"tool": "nope"}},
-                               "capabilities": {"text_extraction": "x"}})
+                               "capabilities": {"layout_analysis": "x"}})
 
 
 def test_unknown_capability_is_rejected():
     with pytest.raises(ValueError, match="unknown capability"):
         build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
-                               "capabilities": {"text_extraction": "f",
+                               "capabilities": {"layout_analysis": "f",
                                                 "teleportation": "f"}})
 
 
-def test_staging_capability_has_no_tools_yet():
-    with pytest.raises(ValueError, match="staging capability"):
-        build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
-                               "capabilities": {"text_extraction": "f",
-                                                "layout_analysis": "f"}})
+def test_layout_analysis_is_fillable_now():
+    # Was test_staging_capability_has_no_tools_yet — layout is block-producing now.
+    cfg = {"tools": {"f": {"tool": "fitz"}},
+           "capabilities": {"layout_analysis": "f"}}
+    p = build_pipeline_config(cfg)
+    assert p.for_capability(Capability.LAYOUT_ANALYSIS).key == "f"
 
 
 def test_capability_not_provided_by_tool_is_rejected():
     with pytest.raises(ValueError, match="does not provide"):
         build_pipeline_config({
             "tools": {"f": {"tool": "fitz"}},
-            "capabilities": {"text_extraction": "f", "table_detection": "f"},
+            "capabilities": {"layout_analysis": "f", "table_detection": "f"},
         })
 
 
 def test_dangling_instance_reference_is_rejected():
     with pytest.raises(ValueError, match="unknown instance"):
         build_pipeline_config({"tools": {"f": {"tool": "fitz"}},
-                               "capabilities": {"text_extraction": "ghost"}})
+                               "capabilities": {"layout_analysis": "ghost"}})
 
 
 def test_thresholds_and_page_flags_defaults():
@@ -89,7 +90,7 @@ def test_two_table_tools_are_structurally_unrepresentable():
     # key, so the old "only one table tool" runtime guard has nothing to guard.
     cfg = {"tools": {"a": {"tool": "camelot"}, "b": {"tool": "fitz_tables"},
                      "f": {"tool": "fitz"}},
-           "capabilities": {"text_extraction": "f", "table_detection": "b"}}
+           "capabilities": {"layout_analysis": "f", "table_detection": "b"}}
     p = build_pipeline_config(cfg)
     assert p.for_capability(Capability.TABLE_DETECTION).key == "b"
     # The unreferenced instance "a" is never built.
@@ -100,7 +101,7 @@ def test_tesseract_fills_the_text_ocr_slot():
     cfg = {
         "tools": {"fitz": {"tool": "fitz", "config": {}},
                   "ocr": {"tool": "tesseract", "config": {"pages": "auto", "lang": "eng"}}},
-        "capabilities": {"text_extraction": "fitz", "text_ocr": "ocr"},
+        "capabilities": {"layout_analysis": "fitz", "text_ocr": "ocr"},
     }
     p = build_pipeline_config(cfg)
     inst = p.for_capability(Capability.TEXT_OCR)
@@ -111,7 +112,7 @@ def test_tesseract_fills_the_text_ocr_slot():
 
 def test_ocr_prefer_defaults_false_and_reads_precedence():
     base = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
-            "capabilities": {"text_extraction": "fitz"}}
+            "capabilities": {"layout_analysis": "fitz"}}
     assert build_pipeline_config(base).ocr_prefer is False
     prefer = {**base, "precedence": {"text_ocr": "prefer"}}
     assert build_pipeline_config(prefer).ocr_prefer is True

--- a/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
@@ -10,11 +10,11 @@ from app.cdm.adapters.custom_pipeline.tools.fitz_tool import FitzTool, _json_saf
 from app.cdm.models import BlockRole
 
 FIXTURES = Path(__file__).parent / "fixtures"
-TE = Capability.TEXT_EXTRACTION
+LA = Capability.LAYOUT_ANALYSIS
 
 
 def _blocks(result):
-    return result.blocks_by_capability[TE]
+    return result.blocks_by_capability[LA]
 
 
 def _make_image_pdf(path: Path) -> None:
@@ -33,11 +33,11 @@ def test_fitz_tool_id():
     assert FitzTool().tool_id == "fitz"
 
 
-def test_fitz_declares_text_extraction_and_emits_under_it():
+def test_fitz_declares_layout_analysis_and_emits_under_it():
     tool = FitzTool()
-    assert tool.provides == frozenset({TE})
-    result = tool.run(FIXTURES / "simple_text.pdf", emit=frozenset({TE}))
-    assert list(result.blocks_by_capability) == [TE]
+    assert tool.provides == frozenset({LA})
+    result = tool.run(FIXTURES / "simple_text.pdf", emit=frozenset({LA}))
+    assert list(result.blocks_by_capability) == [LA]
     assert len(_blocks(result)) >= 1
 
 

--- a/backend/tests/cdm/adapters/custom_pipeline/test_merger.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_merger.py
@@ -4,7 +4,7 @@ from app.cdm.adapters.custom_pipeline.page_flags import PageFlags
 from app.cdm.adapters.custom_pipeline.tools.base import ToolResult
 from app.cdm.models import BBox, Block, BlockRole
 
-TE, TB, OC = Capability.TEXT_EXTRACTION, Capability.TABLE_DETECTION, Capability.TEXT_OCR
+LA, TB, OC = Capability.LAYOUT_ANALYSIS, Capability.TABLE_DETECTION, Capability.TEXT_OCR
 
 
 def _b(bid, x0, y0, x1, y1, role=BlockRole.TEXT):
@@ -34,19 +34,19 @@ def test_overlap_fraction_of_zero_area_loser_is_zero():
 
 
 def test_table_evicts_overlapping_text():
-    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.9, 0.4)])
+    text = _res("fitz", LA, [_b("t1", 0.1, 0.1, 0.9, 0.4)])
     table = _res("fitz_tables", TB, [_b("tb1", 0.0, 0.0, 1.0, 0.5, BlockRole.TABLE)])
     out = merge([text, table], source_document_id="d", page_flags=_flags())
     assert len(out.blocks) == 1
     rec = out.raw_output["evicted"][0]
-    assert rec["capability"] == "text_extraction"
+    assert rec["capability"] == "layout_analysis"
     assert rec["winner_capability"] == "table_detection"
     assert rec["reason"] == "covered_by"
     assert rec["won_by"] == "d:0:0"
 
 
 def test_native_text_evicts_overlapping_ocr_by_default():
-    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 1.0, 0.5)])
+    text = _res("fitz", LA, [_b("t1", 0.0, 0.0, 1.0, 0.5)])
     ocr = _res("tesseract", OC, [_b("o1", 0.1, 0.1, 0.3, 0.2)])
     out = merge([text, ocr], source_document_id="d", page_flags=_flags())
     assert [b.id for b in out.blocks] == ["d:0:0"]
@@ -54,7 +54,7 @@ def test_native_text_evicts_overlapping_ocr_by_default():
 
 
 def test_ocr_survives_where_no_native_text_covers_it():
-    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 1.0, 0.2)])
+    text = _res("fitz", LA, [_b("t1", 0.0, 0.0, 1.0, 0.2)])
     ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.6, 0.5, 0.8)])  # no overlap
     out = merge([text, ocr], source_document_id="d", page_flags=_flags())
     assert len(out.blocks) == 2
@@ -62,32 +62,32 @@ def test_ocr_survives_where_no_native_text_covers_it():
 
 
 def test_cid_corrupt_page_lets_ocr_evict_native_text():
-    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
+    text = _res("fitz", LA, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
     ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.0, 1.0, 0.5)])
     out = merge([text, ocr], source_document_id="d", page_flags=_flags(cid=True))
-    assert out.raw_output["evicted"][0]["capability"] == "text_extraction"
+    assert out.raw_output["evicted"][0]["capability"] == "layout_analysis"
     assert out.raw_output["evicted"][0]["winner_capability"] == "text_ocr"
 
 
 def test_ocr_prefer_flips_precedence_for_the_whole_run():
-    text = _res("fitz", TE, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
+    text = _res("fitz", LA, [_b("t1", 0.1, 0.1, 0.3, 0.2)])
     ocr = _res("tesseract", OC, [_b("o1", 0.0, 0.0, 1.0, 0.5)])
     out = merge([text, ocr], source_document_id="d", page_flags=_flags(), ocr_prefer=True)
-    assert out.raw_output["evicted"][0]["capability"] == "text_extraction"
+    assert out.raw_output["evicted"][0]["capability"] == "layout_analysis"
 
 
 def test_reading_order_is_contiguous_from_zero_per_page():
-    text = _res("fitz", TE, [_b("a", 0.0, 0.5, 0.2, 0.6), _b("b", 0.0, 0.1, 0.2, 0.2)])
+    text = _res("fitz", LA, [_b("a", 0.0, 0.5, 0.2, 0.6), _b("b", 0.0, 0.1, 0.2, 0.2)])
     out = merge([text], source_document_id="d", page_flags=_flags())
     assert [b.reading_order for b in out.blocks] == [0, 1]
     assert [b.id for b in out.blocks] == ["d:0:0", "d:0:1"]
 
 
 def test_audit_trail_is_keyed_by_instance():
-    text = _res("fitz", TE, [_b("t1", 0.0, 0.0, 0.2, 0.2)])
+    text = _res("fitz", LA, [_b("t1", 0.0, 0.0, 0.2, 0.2)])
     out = merge([text], source_document_id="d", page_flags=_flags())
     assert "instances" in out.raw_output and "tools" not in out.raw_output
-    assert out.raw_output["instances"]["fitz"]["capabilities"] == ["text_extraction"]
+    assert out.raw_output["instances"]["fitz"]["capabilities"] == ["layout_analysis"]
     assert "d:0:0" in out.raw_output["instances"]["fitz"]["block_map"]
 
 
@@ -96,7 +96,7 @@ def test_a_figure_block_does_not_evict_ocr_text_inside_it():
     # text. The image must NOT evict the OCR text it contains.
     figure = _b("fig1", 0.0, 0.5, 0.6, 0.75, BlockRole.FIGURE)
     figure = figure.model_copy(update={"text": None})
-    text = _res("fitz", TE, [figure])
+    text = _res("fitz", LA, [figure])
     ocr = _res("tesseract", OC, [_b("o1", 0.1, 0.56, 0.4, 0.68)])
     out = merge([text, ocr], source_document_id="d", page_flags=_flags())
     ids_texts = {(b.native_type) for b in out.blocks}

--- a/backend/tests/cdm/adapters/custom_pipeline/test_ocr_reconciliation.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_ocr_reconciliation.py
@@ -45,7 +45,7 @@ async def test_ocr_keeps_image_text_and_drops_ocr_over_native(tmp_path):
     config = {
         "tools": {"fitz": {"tool": "fitz", "config": {}},
                   "ocr": {"tool": "tesseract", "config": {"pages": "all", "dpi": 200}}},
-        "capabilities": {"text_extraction": "fitz", "text_ocr": "ocr"},
+        "capabilities": {"layout_analysis": "fitz", "text_ocr": "ocr"},
     }
     run, parsed = await run_custom_pipeline(
         source=_source(), file_path=str(_mixed_pdf(tmp_path)),

--- a/backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
@@ -28,7 +28,7 @@ def _source() -> SourceDocument:
 
 @pytest.fixture
 def ruled_table_pdf(tmp_path):
-    """Text plus a ruled grid, so both text_extraction and table_detection fire."""
+    """Text plus a ruled grid, so both layout_analysis and table_detection fire."""
     d = fitz.open()
     page = d.new_page(width=595, height=842)
     page.insert_text(fitz.Point(72, 72), "Quarterly revenue report", fontsize=14)
@@ -53,7 +53,7 @@ async def test_text_only_pipeline_output_is_stable(ruled_table_pdf):
         source=_source(), file_path=str(ruled_table_pdf),
         representation_kind="extract_rich",
         config={"tools": {"fitz": {"tool": "fitz", "config": {}}},
-                "capabilities": {"text_extraction": "fitz"}},
+                "capabilities": {"layout_analysis": "fitz"}},
         client=None,
     )
     assert run.status == ParseRunStatus.SUCCEEDED
@@ -74,7 +74,7 @@ async def test_table_tool_evicts_overlapping_text_exactly_as_before(ruled_table_
     config = {
         "tools": {"fitz": {"tool": "fitz", "config": {}},
                   "tbl": {"tool": "fitz_tables", "config": {}}},
-        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+        "capabilities": {"layout_analysis": "fitz", "table_detection": "tbl"},
     }
     run, parsed = await run_custom_pipeline(
         source=_source(), file_path=str(ruled_table_pdf),
@@ -86,7 +86,7 @@ async def test_table_tool_evicts_overlapping_text_exactly_as_before(ruled_table_
     # The table won over the text it covers — same rule, same 0.5 threshold.
     assert run.raw_payload["evicted"], "expected the table to evict covered text"
     for rec in run.raw_payload["evicted"]:
-        assert rec["capability"] == "text_extraction"
+        assert rec["capability"] == "layout_analysis"
         assert rec["winner_capability"] == "table_detection"
         assert rec["reason"] == "covered_by"
         assert rec["overlap_fraction"] > 0.5
@@ -100,11 +100,11 @@ async def test_table_tool_does_not_change_the_surviving_text(ruled_table_pdf):
     """Adding table_detection must only remove text the table covers — never
     alter the text blocks that survive."""
     base = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
-            "capabilities": {"text_extraction": "fitz"}}
+            "capabilities": {"layout_analysis": "fitz"}}
     with_table = {
         "tools": {"fitz": {"tool": "fitz", "config": {}},
                   "tbl": {"tool": "fitz_tables", "config": {}}},
-        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+        "capabilities": {"layout_analysis": "fitz", "table_detection": "tbl"},
     }
     _, text_only = await run_custom_pipeline(
         source=_source(), file_path=str(ruled_table_pdf),
@@ -117,3 +117,35 @@ async def test_table_tool_does_not_change_the_surviving_text(ruled_table_pdf):
     original = {b.text for b in text_only.blocks if b.role == BlockRole.TEXT}
     assert surviving <= original
     assert "Quarterly revenue report" in " ".join(surviving)
+
+
+# ── Golden snapshot: content-identical to the pre-refactor pipeline ──────────
+
+import json
+from pathlib import Path
+
+from tests.cdm.adapters.custom_pipeline.fixtures.equivalence_fixtures import (
+    EQUIV_CONFIGS, build_for, content_projection,
+)
+
+_GOLDEN_DIR = Path(__file__).parent / "fixtures" / "equivalence"
+
+
+def _relabel(config: dict) -> dict:
+    """Rewrite the captured text_extraction key to layout_analysis."""
+    caps = dict(config["capabilities"])
+    caps["layout_analysis"] = caps.pop("text_extraction")
+    return {**config, "capabilities": caps}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", list(EQUIV_CONFIGS))
+async def test_output_matches_pre_refactor_golden(name, tmp_path):
+    golden = json.loads((_GOLDEN_DIR / f"{name}.json").read_text())
+    pdf = tmp_path / f"{name}.pdf"
+    build_for(name, pdf)
+    _, parsed = await run_custom_pipeline(
+        source=_source(), file_path=str(pdf),
+        representation_kind="extract_rich",
+        config=_relabel(EQUIV_CONFIGS[name]), client=None)
+    assert content_projection(parsed) == golden

--- a/backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
+++ b/backend/tests/cdm/adapters/custom_pipeline/test_tools_base.py
@@ -22,13 +22,13 @@ def test_tool_result_holds_blocks_by_capability_and_native_records():
                   text="hi", page_index=0)
     result = ToolResult(
         tool_id="fitz",
-        blocks_by_capability={Capability.TEXT_EXTRACTION: [block]},
+        blocks_by_capability={Capability.LAYOUT_ANALYSIS: [block]},
         page_meta={0: PageMeta(index=0, width=612.0, height=792.0)},
         raw={"pages": {}},
         native_by_block={"fitz:0:0": {"type": 0}},
     )
     assert result.tool_id == "fitz"
-    assert result.blocks_by_capability[Capability.TEXT_EXTRACTION][0].text == "hi"
+    assert result.blocks_by_capability[Capability.LAYOUT_ANALYSIS][0].text == "hi"
     assert result.native_by_block["fitz:0:0"] == {"type": 0}
     assert result.warnings == []
     assert result.duration_ms == 0
@@ -37,7 +37,7 @@ def test_tool_result_holds_blocks_by_capability_and_native_records():
 def test_pipeline_tool_protocol_is_runtime_checkable():
     class Fake:
         tool_id = "fake"
-        provides = frozenset({Capability.TEXT_EXTRACTION})
+        provides = frozenset({Capability.LAYOUT_ANALYSIS})
 
         def run(self, pdf_path, *, pages=None, page_meta=None, emit=frozenset()):
             return ToolResult(tool_id="fake", blocks_by_capability={}, page_meta={})

--- a/backend/tests/services/parsing/test_custom_pipeline_runner.py
+++ b/backend/tests/services/parsing/test_custom_pipeline_runner.py
@@ -29,7 +29,7 @@ def _source() -> SourceDocument:
 async def test_run_custom_pipeline_fitz_only_succeeds():
     config = {
         "tools": {"fitz": {"tool": "fitz", "config": {}}},
-        "capabilities": {"text_extraction": "fitz"},
+        "capabilities": {"layout_analysis": "fitz"},
         "eviction_overlap_threshold": 0.5,
     }
     run, doc = await run_custom_pipeline(
@@ -66,7 +66,7 @@ async def test_run_custom_pipeline_raw_payload_json_serializable_with_images(tmp
     doc_pdf.close()
 
     config = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
-              "capabilities": {"text_extraction": "fitz"}}
+              "capabilities": {"layout_analysis": "fitz"}}
     run, _ = await run_custom_pipeline(
         source=_source(),
         file_path=str(pdf),
@@ -82,7 +82,7 @@ async def test_run_custom_pipeline_raw_payload_json_serializable_with_images(tmp
 @pytest.mark.asyncio
 async def test_run_custom_pipeline_wraps_failure(tmp_path):
     config = {"tools": {"fitz": {"tool": "fitz", "config": {}}},
-              "capabilities": {"text_extraction": "fitz"}}
+              "capabilities": {"layout_analysis": "fitz"}}
     with pytest.raises(CustomPipelineRunError) as ei:
         await run_custom_pipeline(
             source=_source(),
@@ -123,7 +123,7 @@ async def test_run_custom_pipeline_fitz_tables_emits_table_blocks(tmp_path):
     config = {
         "tools": {"fitz": {"tool": "fitz", "config": {}},
                   "fitz_tables": {"tool": "fitz_tables", "config": {}}},
-        "capabilities": {"text_extraction": "fitz", "table_detection": "fitz_tables"},
+        "capabilities": {"layout_analysis": "fitz", "table_detection": "fitz_tables"},
         "eviction_overlap_threshold": 0.5,
     }
     run, doc_result = await run_custom_pipeline(
@@ -139,12 +139,12 @@ async def test_run_custom_pipeline_fitz_tables_emits_table_blocks(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_run_custom_pipeline_requires_a_text_extraction_slot():
+async def test_run_custom_pipeline_requires_a_layout_analysis_slot():
     """Two table tools are now structurally unrepresentable (the capabilities map
     has a single table_detection key), so the old dual-table guard is gone. What
     remains worth asserting is the required slot."""
     config = {"tools": {}, "capabilities": {}}
-    with pytest.raises(CustomPipelineRunError, match="text_extraction"):
+    with pytest.raises(CustomPipelineRunError, match="layout_analysis"):
         await run_custom_pipeline(
             source=_source(),
             file_path=str(FIXTURES / "simple_text.pdf"),
@@ -194,7 +194,7 @@ async def test_runner_passes_selected_pages_and_ocr_prefer(monkeypatch):
     config = {
         "tools": {"fitz": {"tool": "fitz", "config": {}},
                   "ocr": {"tool": "tesseract", "config": {"pages": "auto"}}},
-        "capabilities": {"text_extraction": "fitz", "text_ocr": "ocr"},
+        "capabilities": {"layout_analysis": "fitz", "text_ocr": "ocr"},
         "precedence": {"text_ocr": "prefer"},
     }
     run, _ = await run_custom_pipeline(

--- a/docs/superpowers/plans/2026-07-11-layout-analysis-capability.md
+++ b/docs/superpowers/plans/2026-07-11-layout-analysis-capability.md
@@ -1,0 +1,1349 @@
+# Layout Analysis — Structure Capability Slot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse `text_extraction` into a single required, block-producing `layout_analysis` (structure) slot, with fitz as the tier-0 tool and docling as the tier-1 authoritative producer, so parsing approaches can be composed and compared on the local→AI ladder.
+
+**Architecture:** Two sequential PRs. **PR A** is a pure, behaviour-preserving refactor: rename the capability, keep fitz's output byte-identical (verified against goldens captured from the current pipeline). **PR B** adds docling as an authoritative structure tool, makes the merger honour a producer's intrinsic reading order (the multi-column L2 fix), offloads tool runs off the event loop, and retires the standalone `ParserKind.DOCLING` method.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic v2, PyMuPDF (`fitz`), pypdf, docling; React 18 + TypeScript + Vite + shadcn/ui; pytest, vitest.
+
+**Spec:** [docs/superpowers/specs/2026-07-11-layout-analysis-capability-design.md](../specs/2026-07-11-layout-analysis-capability-design.md)
+
+## Global Constraints
+
+- **Pre-implementation gate (CLAUDE.md):** before writing code for each PR, create a GitHub issue with acceptance criteria derived from this plan and confirm it with the user. Work on a feature branch. Two PRs → two issues.
+- Backend tests run on SQLite in-memory; run with `cd backend && uv run python -m pytest -o "addopts=" <path>`.
+- All DB/async code uses type hints; services raise, routers catch (not exercised here — this is adapter/runner code).
+- Frontend: shadcn/ui + Tailwind only; `cd frontend && npm run lint && npm run build && npx vitest run` must pass.
+- `datetime.now(timezone.utc)` — never `datetime.utcnow()` (deprecated on 3.12).
+- No DB migration and no legacy-config compat shim: this is a sole-user prototype; stale dev runs are wiped/ignored.
+- Capability name is **`layout_analysis`** (not `structure`); the slot label in the UI is "Layout analysis".
+
+---
+
+# PR A — Unify the capability model (pure refactor)
+
+**Branch:** `feat/layout-analysis-pr-a-unify`
+**Acceptance:** for every fixture and every pipeline expressible today, the new pipeline produces content-identical `ParsedDocument`s (proven against captured goldens); full backend + frontend suites green.
+
+## Task A1: Capture equivalence goldens from the current pipeline
+
+Capture the *current* (pre-refactor) output so the rename can be proven equivalent. This task makes **no production change** — it only adds shared fixture builders and committed golden JSONs.
+
+**Files:**
+- Create: `backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence_fixtures.py`
+- Create: `backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence/` (golden JSONs land here)
+- Create: `backend/scripts/capture_equivalence_golden.py`
+
+**Interfaces:**
+- Produces: `build_text_pdf(path: Path) -> None`, `build_table_pdf(path: Path) -> None`, `EQUIV_CONFIGS: dict[str, dict]` (config keyed by golden name, using the **current** `text_extraction` contract), `content_projection(doc) -> dict`.
+
+- [ ] **Step 1: Write the shared fixture builders + projection helper**
+
+Create `backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence_fixtures.py`:
+
+```python
+"""Shared fixtures for the PR A equivalence gate.
+
+Both the golden-capture script (run once, pre-refactor) and the post-refactor
+comparison test import these, so the two sides can never drift.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import fitz
+
+
+def build_text_pdf(path: Path) -> None:
+    """Two text blocks, no table — exercises plain text_extraction."""
+    d = fitz.open()
+    page = d.new_page(width=595, height=842)
+    page.insert_text(fitz.Point(72, 72), "Quarterly revenue report", fontsize=14)
+    page.insert_text(fitz.Point(72, 110), "Figures are provisional.", fontsize=10)
+    d.save(str(path)); d.close()
+
+
+def build_table_pdf(path: Path) -> None:
+    """Text plus a ruled grid — exercises text + table_detection + eviction."""
+    d = fitz.open()
+    page = d.new_page(width=595, height=842)
+    page.insert_text(fitz.Point(72, 72), "Quarterly revenue report", fontsize=14)
+    col_x, row_y = [72, 236, 400], [200, 250, 300]
+    for x in col_x:
+        page.draw_line(fitz.Point(x, row_y[0]), fitz.Point(x, row_y[-1]), width=1)
+    for y in row_y:
+        page.draw_line(fitz.Point(col_x[0], y), fitz.Point(col_x[-1], y), width=1)
+    page.insert_text(fitz.Point(80, 235), "Name", fontsize=11)
+    page.insert_text(fitz.Point(244, 235), "Value", fontsize=11)
+    page.insert_text(fitz.Point(80, 285), "alpha", fontsize=11)
+    page.insert_text(fitz.Point(244, 285), "1", fontsize=11)
+    d.save(str(path)); d.close()
+
+
+# Config keyed by golden name. NOTE: written in the *current* contract
+# (capabilities.text_extraction). Task A5's comparison test rewrites the key to
+# layout_analysis and asserts the produced content still matches these goldens —
+# proving the rename changed nothing.
+EQUIV_CONFIGS: dict[str, dict] = {
+    "text_only": {
+        "tools": {"fitz": {"tool": "fitz", "config": {}}},
+        "capabilities": {"text_extraction": "fitz"},
+    },
+    "text_plus_table": {
+        "tools": {"fitz": {"tool": "fitz", "config": {}},
+                  "tbl": {"tool": "fitz_tables", "config": {}}},
+        "capabilities": {"text_extraction": "fitz", "table_detection": "tbl"},
+    },
+}
+
+_BUILDERS = {"text_only": build_text_pdf, "text_plus_table": build_table_pdf}
+
+
+def build_for(name: str, path: Path) -> None:
+    _BUILDERS[name](path)
+
+
+def content_projection(doc) -> dict:
+    """Stable, volatile-field-free projection of a ParsedDocument.
+
+    Excludes `id` and `parse_run_id` (random/UUID per run); everything that
+    describes *content* — pages, blocks, text, markdown — is deterministic
+    because block ids derive from the fixed source_document_id.
+    """
+    return doc.model_dump(
+        mode="json",
+        include={"page_count", "pages", "blocks", "full_text", "full_markdown"},
+    )
+```
+
+- [ ] **Step 2: Write the capture script**
+
+Create `backend/scripts/capture_equivalence_golden.py`:
+
+```python
+"""Run ONCE on the pre-refactor branch to snapshot current pipeline output.
+
+    cd backend && uv run python scripts/capture_equivalence_golden.py
+
+Writes tests/.../fixtures/equivalence/<name>.json. Commit the results; Task A5's
+test compares the post-refactor pipeline against them.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.cdm.source import SourceDocument
+from app.services.parsing.custom_pipeline_runner import run_custom_pipeline
+from tests.cdm.adapters.custom_pipeline.fixtures.equivalence_fixtures import (
+    EQUIV_CONFIGS, build_for, content_projection,
+)
+
+GOLDEN_DIR = (Path(__file__).resolve().parents[1]
+              / "tests/cdm/adapters/custom_pipeline/fixtures/equivalence")
+
+
+def _source() -> SourceDocument:
+    return SourceDocument(
+        id="src-1", sha256="b" * 64, filename="equiv.pdf",
+        mime_type="application/pdf", byte_size=1234,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+async def main() -> None:
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    for name, config in EQUIV_CONFIGS.items():
+        pdf = GOLDEN_DIR / f"{name}.pdf"
+        build_for(name, pdf)
+        _, parsed = await run_custom_pipeline(
+            source=_source(), file_path=str(pdf),
+            representation_kind="extract_rich", config=config, client=None)
+        (GOLDEN_DIR / f"{name}.json").write_text(
+            json.dumps(content_projection(parsed), indent=2, sort_keys=True))
+        pdf.unlink(missing_ok=True)
+        print(f"captured {name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 3: Run the capture script**
+
+Run: `cd backend && uv run python scripts/capture_equivalence_golden.py`
+Expected: prints `captured text_only` and `captured text_plus_table`; two `.json` files appear in `fixtures/equivalence/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence_fixtures.py \
+        backend/scripts/capture_equivalence_golden.py \
+        backend/tests/cdm/adapters/custom_pipeline/fixtures/equivalence/
+git commit -m "test: capture pre-refactor equivalence goldens for layout_analysis rename"
+```
+
+## Task A2: Collapse the capability enum
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/capabilities.py`
+- Test: `backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py`
+
+**Interfaces:**
+- Produces: `Capability.LAYOUT_ANALYSIS` is block-producing; `Capability.TEXT_EXTRACTION` no longer exists; `resolve_precedence` ranks `LAYOUT_ANALYSIS` where it ranked `TEXT_EXTRACTION`.
+
+- [ ] **Step 1: Update the failing test first**
+
+Edit `backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py` — replace every `Capability.TEXT_EXTRACTION` with `Capability.LAYOUT_ANALYSIS`, and assert layout is block-producing. Add:
+
+```python
+from app.cdm.adapters.custom_pipeline.capabilities import (
+    BLOCK_PRODUCING, STAGING, Capability, resolve_precedence,
+)
+
+
+def test_layout_analysis_is_block_producing():
+    assert Capability.LAYOUT_ANALYSIS in BLOCK_PRODUCING
+    assert Capability.LAYOUT_ANALYSIS not in STAGING
+
+
+def test_text_extraction_is_gone():
+    assert not hasattr(Capability, "TEXT_EXTRACTION")
+
+
+def test_precedence_ranks_layout_below_tables():
+    ranks = resolve_precedence(cid_corrupt=False, ocr_prefer=False)
+    assert ranks[Capability.TABLE_DETECTION] > ranks[Capability.LAYOUT_ANALYSIS]
+    assert ranks[Capability.LAYOUT_ANALYSIS] > ranks[Capability.TEXT_OCR]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_capabilities.py -v`
+Expected: FAIL — `AttributeError: LAYOUT_ANALYSIS`/`TEXT_EXTRACTION` still referenced.
+
+- [ ] **Step 3: Rewrite `capabilities.py`**
+
+```python
+"""IDP capabilities and their precedence.
+
+One tool fills at most one capability slot. Blocks are tagged with the
+capability that produced them; the merger ranks blocks by that tag.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict
+
+
+class Capability(str, Enum):
+    LAYOUT_ANALYSIS = "layout_analysis"   # required structure slot (fitz tier-0, docling tier-1)
+    TABLE_DETECTION = "table_detection"
+    TEXT_OCR = "text_ocr"
+
+
+#: Capabilities whose blocks compete for page area (governed by precedence).
+BLOCK_PRODUCING = frozenset({
+    Capability.LAYOUT_ANALYSIS,
+    Capability.TABLE_DETECTION,
+    Capability.TEXT_OCR,
+})
+
+#: Capabilities that order/route rather than compete. Empty for now — the
+#: router slice refills this with bbox+label-only layout detectors.
+STAGING: frozenset[Capability] = frozenset()
+
+
+def resolve_precedence(*, cid_corrupt: bool, ocr_prefer: bool) -> Dict[Capability, int]:
+    """Rank block-producing capabilities for one page. Higher wins.
+
+    Structure always beats loose text. The only variable is whether OCR sits
+    above or below the structure text — the CID flip and `prefer` are the same
+    mechanism, applied per-page vs per-run.
+    """
+    ocr_outranks_text = ocr_prefer or cid_corrupt
+    if ocr_outranks_text:
+        return {
+            Capability.TABLE_DETECTION: 3,
+            Capability.TEXT_OCR: 2,
+            Capability.LAYOUT_ANALYSIS: 1,
+        }
+    return {
+        Capability.TABLE_DETECTION: 3,
+        Capability.LAYOUT_ANALYSIS: 2,
+        Capability.TEXT_OCR: 1,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_capabilities.py -v`
+Expected: PASS. (Other modules still reference `TEXT_EXTRACTION` and will fail their own suites until Task A3/A4 — that's expected; do not run the full suite yet.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/capabilities.py \
+        backend/tests/cdm/adapters/custom_pipeline/test_capabilities.py
+git commit -m "refactor: collapse text_extraction into block-producing layout_analysis"
+```
+
+## Task A3: Point config, fitz, and base at `layout_analysis`
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/config.py:120` (required-slot check)
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py:61,72` (`provides`, default `emit`)
+- Modify: `backend/app/cdm/adapters/custom_pipeline/tools/base.py:22-23` (PageMeta docstring)
+- Test: `backend/tests/cdm/adapters/custom_pipeline/test_config.py`, `backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py`
+
+**Interfaces:**
+- Consumes: `Capability.LAYOUT_ANALYSIS` (Task A2).
+- Produces: `build_pipeline_config` requires `layout_analysis`; `FitzTool.provides == {LAYOUT_ANALYSIS}`.
+
+- [ ] **Step 1: Update the failing tests**
+
+In `backend/tests/cdm/adapters/custom_pipeline/test_config.py`: replace every `"text_extraction"` config key with `"layout_analysis"` and every `Capability.TEXT_EXTRACTION` with `Capability.LAYOUT_ANALYSIS`. Update the two tests whose meaning inverts:
+
+```python
+def test_layout_analysis_slot_is_required():
+    with pytest.raises(ValueError, match="layout_analysis"):
+        build_pipeline_config({"tools": {}, "capabilities": {}})
+
+
+def test_layout_analysis_is_fillable_now():
+    # Was test_staging_capability_has_no_tools_yet — layout is block-producing now.
+    cfg = {"tools": {"f": {"tool": "fitz"}},
+           "capabilities": {"layout_analysis": "f"}}
+    p = build_pipeline_config(cfg)
+    assert p.for_capability(Capability.LAYOUT_ANALYSIS).key == "f"
+```
+
+Delete the old `test_staging_capability_has_no_tools_yet`. In `test_fitz_tool.py`, replace `Capability.TEXT_EXTRACTION` with `Capability.LAYOUT_ANALYSIS` throughout.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_config.py tests/cdm/adapters/custom_pipeline/test_fitz_tool.py -v`
+Expected: FAIL — required-slot check still says `text_extraction`; `FitzTool.provides` still `{TEXT_EXTRACTION}`.
+
+- [ ] **Step 3: Edit `config.py`**
+
+Change the required-slot guard (was `config.py:120-121`):
+
+```python
+    if Capability.LAYOUT_ANALYSIS not in slots:
+        raise ValueError("capability 'layout_analysis' is required")
+```
+
+(No other change needed in `config.py` — the staging-rejection guard at the top of the loop now permits `layout_analysis` automatically because it is in `BLOCK_PRODUCING`.)
+
+- [ ] **Step 4: Edit `fitz_tool.py`**
+
+```python
+    tool_id = "fitz"
+    provides = frozenset({Capability.LAYOUT_ANALYSIS})
+```
+
+And the `run` default emit (was `fitz_tool.py:72`) and the returned `blocks_by_capability` key (was `fitz_tool.py:151`):
+
+```python
+        emit: frozenset[Capability] = frozenset({Capability.LAYOUT_ANALYSIS}),
+```
+```python
+            blocks_by_capability={Capability.LAYOUT_ANALYSIS: blocks},
+```
+
+- [ ] **Step 5: Edit `base.py` PageMeta docstring**
+
+```python
+class PageMeta(BaseModel):
+    """Authoritative page geometry, sourced from the structure (layout_analysis) tool."""
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_config.py tests/cdm/adapters/custom_pipeline/test_fitz_tool.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/config.py \
+        backend/app/cdm/adapters/custom_pipeline/tools/fitz_tool.py \
+        backend/app/cdm/adapters/custom_pipeline/tools/base.py \
+        backend/tests/cdm/adapters/custom_pipeline/test_config.py \
+        backend/tests/cdm/adapters/custom_pipeline/test_fitz_tool.py
+git commit -m "refactor: require layout_analysis slot; fitz provides it"
+```
+
+## Task A4: Rename the runner's structure instance
+
+**Files:**
+- Modify: `backend/app/services/parsing/custom_pipeline_runner.py:57-62`
+- Test: `backend/tests/services/parsing/test_custom_pipeline_runner.py`
+
+**Interfaces:**
+- Consumes: `Capability.LAYOUT_ANALYSIS`.
+- Produces: runner resolves the structure instance via `LAYOUT_ANALYSIS`, still runs it first and supplies its `page_meta`.
+
+- [ ] **Step 1: Update the failing test**
+
+In `test_custom_pipeline_runner.py`, replace `"text_extraction"` config keys with `"layout_analysis"` and any `Capability.TEXT_EXTRACTION` with `Capability.LAYOUT_ANALYSIS`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_custom_pipeline_runner.py -v`
+Expected: FAIL — runner still looks up `TEXT_EXTRACTION`.
+
+- [ ] **Step 3: Edit the runner**
+
+Replace `custom_pipeline_runner.py:57-62`:
+
+```python
+        structure_instance = pipeline.for_capability(Capability.LAYOUT_ANALYSIS)
+        # build_pipeline_config guarantees this, but fail loudly if it ever does not.
+        if structure_instance is None:
+            raise ValueError("capability 'layout_analysis' is required")
+
+        structure_result = structure_instance.tool.run(pdf_path, emit=structure_instance.emit)
+        results = [structure_result]
+        warnings = list(structure_result.warnings)
+```
+
+Then in the loop and the adapter call, rename `text_instance` → `structure_instance` and `text_result` → `structure_result` (was `custom_pipeline_runner.py:70,78,112`):
+
+```python
+        for inst in pipeline.instances:
+            if inst is structure_instance:
+                continue
+```
+```python
+            r = inst.tool.run(
+                pdf_path, pages=pages, page_meta=structure_result.page_meta, emit=inst.emit)
+```
+```python
+    doc = adapter.adapt(
+        {"page_meta": structure_result.page_meta, "blocks": merge_result.blocks},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_custom_pipeline_runner.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parsing/custom_pipeline_runner.py \
+        backend/tests/services/parsing/test_custom_pipeline_runner.py
+git commit -m "refactor: runner resolves the structure instance via layout_analysis"
+```
+
+## Task A5: Prove equivalence + green the whole backend
+
+**Files:**
+- Modify: `backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py`
+
+**Interfaces:**
+- Consumes: goldens from Task A1; `content_projection`, `EQUIV_CONFIGS`, `build_for`.
+
+- [ ] **Step 1: Update the existing behavioural equivalence tests**
+
+In `test_refactor_equivalence.py`, replace every `"text_extraction"` config key with `"layout_analysis"` (lines 56, 77, 103, 107). The structural asserts (reading order contiguous, `src-1:0:0` id scheme, table eviction records) are unchanged.
+
+- [ ] **Step 2: Add the golden-snapshot test**
+
+Append to `test_refactor_equivalence.py`:
+
+```python
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.cdm.adapters.custom_pipeline.fixtures.equivalence_fixtures import (
+    EQUIV_CONFIGS, build_for, content_projection,
+)
+
+_GOLDEN_DIR = Path(__file__).parent / "fixtures" / "equivalence"
+
+
+def _relabel(config: dict) -> dict:
+    """Rewrite the captured text_extraction key to layout_analysis."""
+    caps = dict(config["capabilities"])
+    caps["layout_analysis"] = caps.pop("text_extraction")
+    return {**config, "capabilities": caps}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", list(EQUIV_CONFIGS))
+async def test_output_matches_pre_refactor_golden(name, tmp_path):
+    golden = json.loads((_GOLDEN_DIR / f"{name}.json").read_text())
+    pdf = tmp_path / f"{name}.pdf"
+    build_for(name, pdf)
+    _, parsed = await run_custom_pipeline(
+        source=_source(), file_path=str(pdf),
+        representation_kind="extract_rich",
+        config=_relabel(EQUIV_CONFIGS[name]), client=None)
+    assert content_projection(parsed) == golden
+```
+
+- [ ] **Step 3: Run the equivalence suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py -v`
+Expected: PASS — content-identical to the goldens captured in Task A1.
+
+- [ ] **Step 4: Run the full parsing + cdm backend suites**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm tests/services/parsing -q`
+Expected: PASS. (Note: `tests/cdm/adapters/test_docling_adapter.py` still passes — it targets the untouched standalone `DoclingAdapter`, retired in PR B.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py
+git commit -m "test: prove layout_analysis rename is content-equivalent to pre-refactor"
+```
+
+## Task A6: Frontend — relabel the slot as Layout analysis
+
+**Files:**
+- Modify: `frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx` (`:363-368`, `:404-407`, `:483-484`, `:525-540`)
+- Modify: `frontend/src/components/documents/ParseMethodSelector.tsx:51`
+- Test: `frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx`
+
+**Interfaces:**
+- Produces: config emits `capabilities.layout_analysis`; UI slot titled "Layout analysis".
+
+- [ ] **Step 1: Update the failing test**
+
+In `CustomPipelineConfig.test.tsx`, change assertions referencing the "Text extraction" label/slot to "Layout analysis", and any emitted `capabilities.text_extraction` to `capabilities.layout_analysis`. (Open the file and update the specific queries — `getByLabelText('Text extraction')` → `getByLabelText('Layout analysis')`, and config-shape assertions.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/documents/parser-configs/CustomPipelineConfig.test.tsx`
+Expected: FAIL — component still renders "Text extraction" and emits `text_extraction`.
+
+- [ ] **Step 3: Edit `CustomPipelineConfig.tsx`**
+
+`CAPABILITY_BY_TOOL` (`:363`):
+
+```tsx
+const CAPABILITY_BY_TOOL: Record<string, string> = {
+  fitz: 'layout_analysis',
+  pdfplumber: 'layout_analysis',
+  fitz_tables: 'table_detection',
+  camelot: 'table_detection',
+}
+```
+
+The required-slot guarantee in `normalizeCustomPipelineConfig` (`:404-407`):
+
+```tsx
+  // Guarantee the required layout_analysis slot.
+  if (!capabilities.layout_analysis) {
+    if (!tools.fitz) tools.fitz = { tool: 'fitz', config: {} }
+    capabilities.layout_analysis = 'fitz'
+  }
+```
+
+The slot key read (`:483`):
+
+```tsx
+  const textKey = capabilities.layout_analysis ?? 'fitz'
+```
+
+The slot header block (`:525-540`) — label, help text, and `aria-label`:
+
+```tsx
+      {/* Layout analysis — the required structure slot */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div className="space-y-1">
+          <Label htmlFor="layout-tool-select">Layout analysis</Label>
+          <p className="text-xs text-muted-foreground">
+            Turns each page into ordered, labelled regions. Required — every pipeline fills this slot.
+            fitz is fast, local, and text-only (no real layout yet).
+          </p>
+          <Select value={textKey} onValueChange={() => {}} disabled={disabled}>
+            <SelectTrigger id="layout-tool-select" aria-label="Layout analysis">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="fitz">fitz (text + images)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+```
+
+(Leave the fitz `include_images` / `span_detail` checkboxes below it unchanged. The `onValueChange={() => {}}` stays inert in PR A — fitz is still the only option; PR B Task B5 makes it a real selector.)
+
+- [ ] **Step 4: Edit `ParseMethodSelector.tsx`**
+
+The `custom_pipeline` default config's `capabilities` key (`:51`):
+
+```tsx
+      capabilities: { layout_analysis: 'fitz' },
+```
+
+- [ ] **Step 5: Run test, lint, build**
+
+Run: `cd frontend && npx vitest run src/components/documents/parser-configs/CustomPipelineConfig.test.tsx && npm run lint && npm run build`
+Expected: PASS on all three.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx \
+        frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx \
+        frontend/src/components/documents/ParseMethodSelector.tsx
+git commit -m "refactor(ui): rename text extraction slot to Layout analysis"
+```
+
+**PR A is complete.** Open the PR, confirm the equivalence gate is green, and merge before starting PR B.
+
+---
+
+# PR B — Docling as the tier-1 authoritative tool
+
+**Branch:** `feat/layout-analysis-pr-b-docling`
+**Acceptance:** a two-column fixture parses with docling into correct cross-column order; fitz output unchanged (goldens still pass); standalone `ParserKind.DOCLING` removed; suites green.
+
+## Task B1: Merger honours intrinsic reading order
+
+**Files:**
+- Modify: `backend/app/cdm/adapters/custom_pipeline/merger.py:40-43`
+- Test: `backend/tests/cdm/adapters/custom_pipeline/test_merger.py`
+
+**Interfaces:**
+- Produces: within a page, blocks with a non-`None` `reading_order` sort by it; blocks without fall back to `(bbox.y0, bbox.x0)`, ordered after the intrinsic ones.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test_merger.py`:
+
+```python
+from app.cdm.adapters.custom_pipeline.merger import _sort_key
+from app.cdm.models import BBox, Block, BlockRole
+
+
+def _blk(bid, y0, order=None):
+    return Block(id=bid, role=BlockRole.TEXT, native_type="text", text=bid,
+                 page_index=0, bbox=BBox(x0=0.0, y0=y0, x1=1.0, y1=y0 + 0.1),
+                 reading_order=order)
+
+
+def test_sort_key_honours_intrinsic_order_over_geometry():
+    # Higher on the page (smaller y0) but LATER intrinsic order -> sorts later.
+    top_late = _blk("a", y0=0.1, order=5)
+    bottom_early = _blk("b", y0=0.8, order=1)
+    ordered = sorted([top_late, bottom_early], key=_sort_key)
+    assert [b.id for b in ordered] == ["b", "a"]
+
+
+def test_sort_key_falls_back_to_geometry_without_order():
+    top = _blk("a", y0=0.1, order=None)
+    bottom = _blk("b", y0=0.8, order=None)
+    ordered = sorted([bottom, top], key=_sort_key)
+    assert [b.id for b in ordered] == ["a", "b"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_merger.py::test_sort_key_honours_intrinsic_order_over_geometry -v`
+Expected: FAIL — current `_sort_key` ignores `reading_order`.
+
+- [ ] **Step 3: Edit `_sort_key` in `merger.py`**
+
+```python
+def _sort_key(block: Block) -> Tuple[float, float, float]:
+    # A producer that supplies its own reading order (e.g. a layout model that
+    # crosses columns correctly) is honoured; producers that don't (fitz) fall
+    # back to top-to-bottom, left-to-right geometry and sort after.
+    order = float(block.reading_order) if block.reading_order is not None else 1e9
+    if block.bbox is None:
+        return (order, 1e9, 1e9)
+    return (order, block.bbox.y0, block.bbox.x0)
+```
+
+- [ ] **Step 4: Run the merger + ocr + equivalence suites**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/test_merger.py tests/cdm/adapters/custom_pipeline/test_ocr_reconciliation.py tests/cdm/adapters/custom_pipeline/test_refactor_equivalence.py -v`
+Expected: PASS — fitz/OCR blocks carry no `reading_order`, so the fallback preserves existing behaviour and the goldens still match.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/merger.py \
+        backend/tests/cdm/adapters/custom_pipeline/test_merger.py
+git commit -m "feat: merger honours a producer's intrinsic reading order (multi-column fix)"
+```
+
+## Task B2: DoclingTool + DoclingConfig + registry
+
+Reuses the pure helpers already in `app/cdm/adapters/docling.py` (`_to_cdm_bbox`, `_map_role`, `_map_table`) — those stay put; only the `DoclingAdapter` class and the standalone runner are removed later (Task B4).
+
+**Files:**
+- Create: `backend/app/cdm/adapters/custom_pipeline/tools/docling_tool.py`
+- Modify: `backend/app/cdm/adapters/custom_pipeline/config.py:19-57` (add `DoclingConfig`), `:67-82` (register in `_tool_registry`)
+- Test: `backend/tests/cdm/adapters/custom_pipeline/tools/test_docling_tool.py`
+
+**Interfaces:**
+- Consumes: `PipelineTool`, `ToolResult`, `PageMeta`, `Capability.LAYOUT_ANALYSIS`; helpers from `app.cdm.adapters.docling`.
+- Produces: `DoclingTool(config: DoclingConfig)` with `tool_id="docling"`, `provides=frozenset({LAYOUT_ANALYSIS})`, and `run(pdf_path, *, pages=None, page_meta=None, emit) -> ToolResult` whose blocks carry provisional ids `docling:{page}:{order}` and a populated `reading_order`. `DoclingConfig(page_batch_size: int = 20)`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `backend/tests/cdm/adapters/custom_pipeline/tools/test_docling_tool.py` (reuses the fake-doc helpers pattern from `tests/cdm/adapters/test_docling_adapter.py`):
+
+```python
+"""DoclingTool — unit tests using a fake DoclingDocument (no docling binary)."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.config import DoclingConfig
+from app.cdm.models import BlockRole
+
+
+def _fake_bbox(l=50.0, t=750.0, r=545.0, b=700.0):
+    return SimpleNamespace(l=l, t=t, r=r, b=b, coord_origin="BOTTOMLEFT")
+
+
+def _fake_text_item(text, label="text", page_no=1):
+    return SimpleNamespace(
+        label=SimpleNamespace(value=label), text=text,
+        prov=[SimpleNamespace(page_no=page_no, bbox=_fake_bbox())],
+        export_to_markdown=lambda: text)
+
+
+def _fake_doc(items, width=595.0, height=842.0):
+    return SimpleNamespace(
+        pages={1: SimpleNamespace(size=SimpleNamespace(width=width, height=height))},
+        iterate_items=lambda: iter([(it, 0) for it in items]),
+        export_to_markdown=lambda: "\n\n".join(i.text for i in items),
+        model_dump_json=lambda: "{}",
+    )
+
+
+@pytest.fixture
+def tool_result(monkeypatch, tmp_path):
+    from app.cdm.adapters.custom_pipeline.tools import docling_tool
+    items = [_fake_text_item("Annual Report", "title"),
+             _fake_text_item("Body one", "text"),
+             _fake_text_item("Body two", "text")]
+    # Stub the heavy conversion: return one batch's fake document.
+    monkeypatch.setattr(docling_tool, "_convert_batch",
+                        lambda path: _fake_doc(items))
+    pdf = tmp_path / "doc.pdf"; pdf.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    monkeypatch.setattr(docling_tool, "_split_pages",
+                        lambda path, size: [(path, 0)])
+    tool = docling_tool.DoclingTool(config=DoclingConfig())
+    return tool.run(pdf, emit=frozenset({Capability.LAYOUT_ANALYSIS}))
+
+
+def test_emits_layout_analysis_blocks(tool_result):
+    blocks = tool_result.blocks_by_capability[Capability.LAYOUT_ANALYSIS]
+    assert [b.role for b in blocks][0] == BlockRole.TITLE
+    assert len(blocks) == 3
+
+
+def test_blocks_carry_intrinsic_reading_order(tool_result):
+    blocks = tool_result.blocks_by_capability[Capability.LAYOUT_ANALYSIS]
+    assert [b.reading_order for b in blocks] == [0, 1, 2]
+
+
+def test_provisional_ids_and_page_meta(tool_result):
+    blocks = tool_result.blocks_by_capability[Capability.LAYOUT_ANALYSIS]
+    assert blocks[0].id == "docling:0:0"
+    assert tool_result.page_meta[0].width == 595.0
+
+
+def test_bboxes_normalized(tool_result):
+    for b in tool_result.blocks_by_capability[Capability.LAYOUT_ANALYSIS]:
+        assert 0.0 <= b.bbox.x0 <= b.bbox.x1 <= 1.0
+        assert 0.0 <= b.bbox.y0 <= b.bbox.y1 <= 1.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/tools/test_docling_tool.py -v`
+Expected: FAIL — `docling_tool` module does not exist.
+
+- [ ] **Step 3: Create `docling_tool.py`**
+
+```python
+"""DoclingTool — tier-1 authoritative layout analysis for the custom pipeline.
+
+Docling's `iterate_items()` order IS reading order (it crosses columns
+correctly), so blocks are emitted with an intrinsic `reading_order` the merger
+honours. Text, headings, and tables all come out of a single conversion pass;
+this tool fills only the layout_analysis slot for now (table content flows
+through as ordinary BlockRole.TABLE blocks).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.cdm.adapters.custom_pipeline.capabilities import Capability
+from app.cdm.adapters.custom_pipeline.tools.base import PageMeta, ToolResult
+from app.cdm.adapters.docling import _map_role, _map_table, _to_cdm_bbox
+from app.cdm.models import Block, BlockRole
+
+logger = logging.getLogger(__name__)
+
+# Docling is memory-hungry; serialize concurrent conversions. run() executes in
+# a worker thread (the runner offloads it via asyncio.to_thread), so a threading
+# lock is the right primitive. Fixed at 1 for this slice; revisited with the job
+# queue. See design §4.
+_DOCLING_LOCK = threading.Lock()
+
+
+def _split_pages(pdf_path: Path, batch_size: int) -> List[Tuple[Path, int]]:
+    """Split into (batch_path, page_offset). One batch => original file, offset 0."""
+    from pypdf import PdfReader, PdfWriter
+
+    reader = PdfReader(str(pdf_path))
+    total = len(reader.pages)
+    if total <= batch_size:
+        return [(pdf_path, 0)]
+
+    batches: List[Tuple[Path, int]] = []
+    for start in range(0, total, batch_size):
+        writer = PdfWriter()
+        for i in range(start, min(start + batch_size, total)):
+            writer.add_page(reader.pages[i])
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            writer.write(tmp)
+            batches.append((Path(tmp.name), start))
+    return batches
+
+
+def _convert_batch(pdf_path: Path) -> Any:
+    """Heavy docling conversion. Returns a DoclingDocument."""
+    from docling.document_converter import DocumentConverter
+    return DocumentConverter().convert(str(pdf_path)).document
+
+
+class DoclingConfig:
+    """Kept minimal on purpose; add knobs when we learn what matters."""
+    def __init__(self, page_batch_size: int = 20) -> None:
+        self.page_batch_size = page_batch_size
+
+    @classmethod
+    def model_validate(cls, data: Dict[str, Any]) -> "DoclingConfig":
+        return cls(page_batch_size=int((data or {}).get("page_batch_size", 20)))
+
+
+class DoclingTool:
+    tool_id = "docling"
+    provides = frozenset({Capability.LAYOUT_ANALYSIS})
+
+    def __init__(self, config: Optional[DoclingConfig] = None) -> None:
+        self.config = config or DoclingConfig()
+
+    def run(
+        self,
+        pdf_path: Path,
+        *,
+        pages: Optional[List[int]] = None,       # ignored: docling is the source
+        page_meta: Optional[Dict[int, PageMeta]] = None,  # ignored: docling is the source
+        emit: frozenset[Capability] = frozenset({Capability.LAYOUT_ANALYSIS}),
+    ) -> ToolResult:
+        if not emit <= self.provides:
+            raise ValueError(f"{self.tool_id} cannot emit {set(emit - self.provides)}")
+
+        t0 = time.perf_counter()
+        blocks: List[Block] = []
+        page_meta_out: Dict[int, PageMeta] = {}
+        native_by_block: Dict[str, Any] = {}
+        warnings: List[str] = []
+        raw_batches: List[Any] = []
+
+        batches = _split_pages(pdf_path, self.config.page_batch_size)
+        made_temp = len(batches) > 1
+        try:
+            with _DOCLING_LOCK:
+                for batch_path, page_offset in batches:
+                    doc = _convert_batch(batch_path)
+                    raw_batches.append(doc)
+                    self._collect(doc, page_offset, blocks, page_meta_out,
+                                  native_by_block, warnings)
+        finally:
+            if made_temp:
+                for batch_path, _ in batches:
+                    Path(batch_path).unlink(missing_ok=True)
+
+        raw: Any = None
+        try:
+            raw = ([json.loads(d.model_dump_json()) for d in raw_batches]
+                   if len(raw_batches) != 1 else json.loads(raw_batches[0].model_dump_json()))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("docling: raw serialization failed: %s", exc)
+
+        return ToolResult(
+            tool_id=self.tool_id,
+            blocks_by_capability={Capability.LAYOUT_ANALYSIS: blocks},
+            page_meta=page_meta_out,
+            raw=raw,
+            native_by_block=native_by_block,
+            warnings=warnings,
+            duration_ms=int((time.perf_counter() - t0) * 1000),
+        )
+
+    def _collect(self, doc, page_offset, blocks, page_meta_out,
+                 native_by_block, warnings) -> None:
+        page_sizes: Dict[int, Tuple[float, float]] = {}
+        for page_no, page_item in doc.pages.items():
+            size = getattr(page_item, "size", None)
+            w = size.width if size else 595.0
+            h = size.height if size else 842.0
+            idx = (int(page_no) - 1) + page_offset
+            page_sizes[int(page_no)] = (w, h)
+            page_meta_out[idx] = PageMeta(index=idx, width=w, height=h)
+
+        for order, (item, depth) in enumerate(doc.iterate_items()):
+            prov_list = getattr(item, "prov", None) or []
+            if not prov_list:
+                continue
+            prov = prov_list[0]
+            page_no = int(prov.page_no)
+            page_index = (page_no - 1) + page_offset
+            w, h = page_sizes.get(page_no, (595.0, 842.0))
+
+            bbox = None
+            raw_bbox = getattr(prov, "bbox", None)
+            if raw_bbox is not None:
+                try:
+                    bbox = _to_cdm_bbox(raw_bbox, w, h)
+                except Exception:  # noqa: BLE001
+                    pass
+
+            role = _map_role(item.label)
+            table = None
+            if role == BlockRole.TABLE:
+                try:
+                    table = _map_table(item)
+                except Exception:  # noqa: BLE001
+                    pass
+
+            md = None
+            try:
+                md = item.export_to_markdown() or None
+            except Exception:  # noqa: BLE001
+                pass
+            text = getattr(item, "text", "") or (md or "")
+
+            prov_id = f"{self.tool_id}:{page_index}:{order}"
+            blocks.append(Block(
+                id=prov_id, role=role, native_type=item.label.value,
+                text=text, markdown=md, page_index=page_index, bbox=bbox,
+                reading_order=order,
+                depth=depth if role == BlockRole.HEADING else None,
+                table=table,
+                parser_extras={"producer": "docling", "capability": "layout_analysis"},
+            ))
+            native_by_block[prov_id] = {"label": item.label.value, "markdown": md}
+```
+
+- [ ] **Step 4: Register the tool in `config.py`**
+
+Add `DoclingConfig` import isn't needed (it lives in the tool module). In `_tool_registry()` (`config.py:67-82`), add the docling import and entry:
+
+```python
+    from app.cdm.adapters.custom_pipeline.tools.docling_tool import DoclingConfig, DoclingTool
+```
+```python
+        "docling": ToolSpec(DoclingConfig, DoclingTool.provides,
+                            lambda c: DoclingTool(config=c)),
+```
+
+Re-export `DoclingConfig` from `config` for the test import — add at the bottom of `config.py`:
+
+```python
+def _docling_config_cls():
+    from app.cdm.adapters.custom_pipeline.tools.docling_tool import DoclingConfig
+    return DoclingConfig
+```
+
+Actually simpler and consistent with the test: import it at module top of `config.py` is circular (config imports tool, tool imports nothing from config). The tool module does **not** import `config`, so add a direct top-level re-export in `config.py`:
+
+```python
+from app.cdm.adapters.custom_pipeline.tools.docling_tool import DoclingConfig  # re-export
+```
+
+Place this import with the other tool imports is unsafe (they're lazy to avoid heavy deps). Instead, update the test import to `from app.cdm.adapters.custom_pipeline.tools.docling_tool import DoclingConfig` and **remove** the re-export idea. (Fix the Step-1 test import accordingly: it already imports from `...config import DoclingConfig` — change it to import from `...tools.docling_tool`.)
+
+- [ ] **Step 5: Run the DoclingTool unit test**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/custom_pipeline/tools/test_docling_tool.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/cdm/adapters/custom_pipeline/tools/docling_tool.py \
+        backend/app/cdm/adapters/custom_pipeline/config.py \
+        backend/tests/cdm/adapters/custom_pipeline/tools/test_docling_tool.py
+git commit -m "feat: DoclingTool fills the layout_analysis slot (tier-1 authoritative)"
+```
+
+## Task B3: Runner offloads tool runs off the event loop
+
+**Files:**
+- Modify: `backend/app/services/parsing/custom_pipeline_runner.py:62,77`
+- Test: `backend/tests/services/parsing/test_custom_pipeline_runner.py`
+
+**Interfaces:**
+- Produces: every `tool.run(...)` is awaited via `asyncio.to_thread`, so a heavy parse never blocks the event loop (design §4; fixes review §2.1 for the pipeline path).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test_custom_pipeline_runner.py`:
+
+```python
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_tool_run_is_offloaded_to_a_thread(monkeypatch, tmp_path):
+    """The event-loop thread must not be the one executing tool.run."""
+    import app.services.parsing.custom_pipeline_runner as runner_mod
+
+    loop_thread_id = None
+
+    async def _capture():
+        nonlocal loop_thread_id
+        import threading
+        loop_thread_id = threading.get_ident()
+    await _capture()
+
+    seen: dict = {}
+    real_to_thread = asyncio.to_thread
+
+    async def _tracking_to_thread(fn, *a, **k):
+        import threading
+        seen["ran_off_loop"] = threading.get_ident() != loop_thread_id
+        return await real_to_thread(fn, *a, **k)
+
+    monkeypatch.setattr(runner_mod.asyncio, "to_thread", _tracking_to_thread)
+
+    pdf = tmp_path / "x.pdf"
+    import fitz
+    d = fitz.open(); p = d.new_page(); p.insert_text(fitz.Point(72, 72), "hi"); d.save(str(pdf)); d.close()
+
+    from app.cdm.source import SourceDocument
+    from datetime import datetime, timezone
+    src = SourceDocument(id="src-1", sha256="b" * 64, filename="x.pdf",
+                         mime_type="application/pdf", byte_size=1,
+                         created_at=datetime.now(timezone.utc))
+    await runner_mod.run_custom_pipeline(
+        source=src, file_path=str(pdf), representation_kind="extract_rich",
+        config={"tools": {"fitz": {"tool": "fitz", "config": {}}},
+                "capabilities": {"layout_analysis": "fitz"}}, client=None)
+    assert seen.get("ran_off_loop") is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_custom_pipeline_runner.py::test_tool_run_is_offloaded_to_a_thread -v`
+Expected: FAIL — `asyncio.to_thread` is never called (runs are inline).
+
+- [ ] **Step 3: Add `import asyncio` and offload the two run sites**
+
+At the top of `custom_pipeline_runner.py` add `import asyncio`. Replace the structure run (was `:62`):
+
+```python
+        structure_result = await asyncio.to_thread(
+            structure_instance.tool.run, pdf_path, emit=structure_instance.emit)
+```
+
+And the loop run (was `:77-78`):
+
+```python
+            r = await asyncio.to_thread(
+                inst.tool.run, pdf_path, pages=pages,
+                page_meta=structure_result.page_meta, emit=inst.emit)
+```
+
+- [ ] **Step 4: Run the runner suite**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_custom_pipeline_runner.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/parsing/custom_pipeline_runner.py \
+        backend/tests/services/parsing/test_custom_pipeline_runner.py
+git commit -m "perf: offload custom-pipeline tool runs off the event loop"
+```
+
+## Task B4: Retire the standalone docling parse method (D1)
+
+**Files:**
+- Modify: `backend/app/cdm/models.py:20` (remove `DOCLING` from `ParserKind`)
+- Modify: `backend/app/services/parsing/parsing_service.py:23,37` (remove import + `_RUNNERS` entry)
+- Delete: `backend/app/services/parsing/docling_runner.py`
+- Modify: `backend/app/services/parsing/errors.py:25-26` (remove `DoclingRunError`)
+- Modify: `backend/app/cdm/adapters/docling.py` (delete the `DoclingAdapter` class + `_mint_block_id`; keep pure helpers `_ROLE_MAP`, `_map_role`, `_to_cdm_bbox`, `_clamp`, `_map_table`)
+- Delete: `backend/tests/services/parsing/test_docling_runner.py`
+- Modify: `backend/tests/cdm/adapters/test_docling_adapter.py` (drop Task-1 `ParserKind.DOCLING`/`DoclingRunError` tests and the Task-3 `DoclingAdapter.adapt` tests; keep the helper tests for `_to_cdm_bbox`/`_map_role`)
+
+**Interfaces:**
+- Produces: docling is reachable **only** via `custom_pipeline` with `layout_analysis: docling`. The pure helpers remain importable from `app.cdm.adapters.docling` (DoclingTool depends on them).
+
+- [ ] **Step 1: Delete the standalone-docling tests first**
+
+Delete `backend/tests/services/parsing/test_docling_runner.py`.
+
+In `test_docling_adapter.py`, delete: `test_parser_kind_docling_value`, `test_docling_run_error_is_parse_run_error`, `test_docling_run_error_carries_run`, the `from app.services.parsing.errors import DoclingRunError, ParseRunError` line, the entire "Task 3: DoclingAdapter.adapt() tests" section (fixtures `simple_doc`/`adapted` and every test using them), and the `_fake_table_item`/`_make_fake_doc`/`_fake_page_item` helpers if now unused. **Keep**: `_fake_bbox`, `_fake_prov`, `_fake_text_item` (if referenced), and all `test_to_cdm_bbox_*`, `test_map_role_*`, `test_mint_block_id_format` → **remove** `test_mint_block_id_format` (that helper is deleted). Rename the file's module docstring to "Tests for docling helper functions."
+
+- [ ] **Step 2: Run the trimmed helper tests to verify they fail to import**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/test_docling_adapter.py -v`
+Expected: FAIL at collection — still imports `DoclingRunError`, or references removed symbols. (If you removed all such references cleanly, it may instead PASS; proceed either way — the production deletions below are what make it authoritative.)
+
+- [ ] **Step 3: Remove `DOCLING` from `ParserKind`**
+
+In `backend/app/cdm/models.py`, delete line `DOCLING = "docling"` from `class ParserKind`.
+
+- [ ] **Step 4: Remove the runner wiring**
+
+In `parsing_service.py`, delete `from app.services.parsing.docling_runner import run_docling` (`:23`) and the `ParserKind.DOCLING: run_docling,` line in `_RUNNERS` (`:37`).
+
+- [ ] **Step 5: Delete the runner + error**
+
+```bash
+git rm backend/app/services/parsing/docling_runner.py
+```
+
+In `errors.py`, delete the `DoclingRunError` class (`:25-26`).
+
+- [ ] **Step 6: Trim `docling.py` to helpers only**
+
+Delete the `DoclingAdapter` class and `_mint_block_id` from `app/cdm/adapters/docling.py`. Keep the module docstring (reword to "Docling → CDM mapping helpers, shared by DoclingTool."), the imports still used by the kept helpers, and `_ROLE_MAP`, `_map_role`, `_clamp`, `_to_cdm_bbox`, `_map_table`.
+
+- [ ] **Step 7: Run the affected suites**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/cdm/adapters/test_docling_adapter.py tests/cdm/adapters/custom_pipeline tests/services/parsing tests/models -q`
+Expected: PASS. If any test still references `ParserKind.DOCLING` or `DoclingRunError`, fix that reference (search: `grep -rn "DOCLING\|DoclingRunError\|run_docling\|DoclingAdapter" backend/tests backend/app`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A backend/app/cdm/models.py backend/app/services/parsing/parsing_service.py \
+        backend/app/services/parsing/errors.py backend/app/cdm/adapters/docling.py \
+        backend/tests/cdm/adapters/test_docling_adapter.py
+git rm backend/app/services/parsing/docling_runner.py backend/tests/services/parsing/test_docling_runner.py
+git commit -m "refactor: retire standalone ParserKind.DOCLING; docling is a pipeline tool"
+```
+
+## Task B5: Frontend — docling option in the layout slot + eval default
+
+**Files:**
+- Modify: `frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx` (real layout selector + docling panel)
+- Modify: `frontend/src/components/documents/ParseMethodSelector.tsx:36-40` (remove top-level `docling` method)
+- Modify: `frontend/src/components/parser-eval/NewRunDialog.tsx:16` (`DEFAULT_ADAPTER`)
+- Test: `frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx`, `frontend/src/components/parser-eval/NewRunDialog.test.tsx`
+
+**Interfaces:**
+- Produces: the Layout analysis select offers `fitz` and `docling`; choosing docling emits `capabilities.layout_analysis: 'docling'` with a docling instance; eval "Add variant" defaults to a `custom_pipeline` variant.
+
+- [ ] **Step 1: Update the failing tests**
+
+In `CustomPipelineConfig.test.tsx`, add a test that selecting `docling` in the "Layout analysis" combobox emits `capabilities.layout_analysis === 'docling'` and a `tools.docling` instance. In `NewRunDialog.test.tsx`, update the two `docling`/`{}` expectations (`:36,:53`) to the new default adapter `custom_pipeline` and its default config (import `PARSER_REGISTRY` to reference `PARSER_REGISTRY.custom_pipeline.defaultConfig`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/documents/parser-configs/CustomPipelineConfig.test.tsx src/components/parser-eval/NewRunDialog.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Make the layout selector real in `CustomPipelineConfig.tsx`**
+
+Add a `DOCLING_DEFAULTS` const and a handler, and replace the inert select. Near the other defaults:
+
+```tsx
+const DOCLING_DEFAULTS = { page_batch_size: 20 }
+```
+
+Replace the layout `Select` (the `onValueChange={() => {}}` block from Task A6) with a real slot swap and a conditional panel:
+
+```tsx
+          <Select
+            value={textKey}
+            onValueChange={(v) =>
+              onChange(setSlot(cfg, 'layout_analysis', v,
+                v === 'docling' ? { ...DOCLING_DEFAULTS } : {}) as unknown as ParseConfig)
+            }
+            disabled={disabled}
+          >
+            <SelectTrigger id="layout-tool-select" aria-label="Layout analysis">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="fitz">fitz — fast, local, text-only</SelectItem>
+              <SelectItem value="docling">docling — ML layout + reading order + tables</SelectItem>
+            </SelectContent>
+          </Select>
+```
+
+Guard the fitz-only checkboxes so they show only for fitz, and add a docling panel:
+
+```tsx
+        {fitz?.tool === 'fitz' && (
+          <>
+            {/* existing include_images + span_detail checkboxes */}
+          </>
+        )}
+        {fitz?.tool === 'docling' && (
+          <NumField
+            id="docling-batch"
+            label="Page batch size"
+            description="Pages per docling conversion batch"
+            value={(fitz?.config.page_batch_size as number) ?? 20}
+            onChange={(v) => updateTool(textKey, { page_batch_size: Math.round(v) })}
+            disabled={disabled}
+          />
+        )}
+```
+
+- [ ] **Step 4: Remove the top-level docling method + fix eval default**
+
+In `ParseMethodSelector.tsx`, delete the `docling: { … }` entry from `PARSER_REGISTRY` (`:36-40`). **Keep** any `'Docling'` label mapping in `ParserComparisonTable` so historical eval rows still render (verify: `grep -n "Docling" frontend/src/components/parser-eval/ParserComparisonTable.tsx` — leave that map untouched).
+
+In `NewRunDialog.tsx:16`:
+
+```tsx
+const DEFAULT_ADAPTER = 'custom_pipeline'
+```
+
+- [ ] **Step 5: Run tests, lint, build**
+
+Run: `cd frontend && npx vitest run && npm run lint && npm run build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx \
+        frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx \
+        frontend/src/components/documents/ParseMethodSelector.tsx \
+        frontend/src/components/parser-eval/NewRunDialog.tsx \
+        frontend/src/components/parser-eval/NewRunDialog.test.tsx
+git commit -m "feat(ui): docling as a layout_analysis option; eval defaults to custom_pipeline"
+```
+
+## Task B6: Docling integration test (the L2 fix, demonstrated)
+
+**Files:**
+- Create: `backend/tests/services/parsing/test_docling_pipeline_integration.py`
+
+**Interfaces:**
+- Consumes: `run_custom_pipeline` with `layout_analysis: docling`.
+
+- [ ] **Step 1: Write the integration test (guarded)**
+
+```python
+"""End-to-end docling via the custom pipeline. Skipped where docling is absent."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+docling = pytest.importorskip("docling")  # skip whole module if not installed
+
+import fitz
+
+from app.cdm.source import ParseRunStatus, SourceDocument
+from app.services.parsing.custom_pipeline_runner import run_custom_pipeline
+
+
+def _two_column_pdf(path):
+    d = fitz.open()
+    page = d.new_page(width=595, height=842)
+    # Left column then right column — reading order must be L-col then R-col,
+    # which a naive (y0, x0) sort interleaves incorrectly.
+    for i, y in enumerate(range(120, 400, 40)):
+        page.insert_text(fitz.Point(72, y), f"Left line {i}", fontsize=11)
+    for i, y in enumerate(range(120, 400, 40)):
+        page.insert_text(fitz.Point(340, y), f"Right line {i}", fontsize=11)
+    d.save(str(path)); d.close()
+
+
+def _source():
+    return SourceDocument(id="src-1", sha256="b" * 64, filename="cols.pdf",
+                          mime_type="application/pdf", byte_size=1,
+                          created_at=datetime.now(timezone.utc))
+
+
+@pytest.mark.asyncio
+async def test_docling_reading_order_is_column_aware(tmp_path):
+    pdf = tmp_path / "cols.pdf"; _two_column_pdf(pdf)
+    _, parsed = await run_custom_pipeline(
+        source=_source(), file_path=str(pdf), representation_kind="extract_rich",
+        config={"tools": {"docling": {"tool": "docling", "config": {}}},
+                "capabilities": {"layout_analysis": "docling"}}, client=None)
+    text = parsed.full_text
+    # All left-column lines precede all right-column lines in reading order.
+    assert text.index("Left line 0") < text.index("Right line 0")
+    assert text.index("Left line 3") < text.index("Right line 0")
+
+
+@pytest.mark.asyncio
+async def test_docling_run_succeeds_and_populates_blocks(tmp_path):
+    pdf = tmp_path / "cols.pdf"; _two_column_pdf(pdf)
+    run, parsed = await run_custom_pipeline(
+        source=_source(), file_path=str(pdf), representation_kind="extract_rich",
+        config={"tools": {"docling": {"tool": "docling", "config": {}}},
+                "capabilities": {"layout_analysis": "docling"}}, client=None)
+    assert run.status == ParseRunStatus.SUCCEEDED
+    assert len(parsed.blocks) > 0
+    assert all(b.id.startswith("src-1:") for b in parsed.blocks)
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests/services/parsing/test_docling_pipeline_integration.py -v`
+Expected: PASS if docling is installed in the env (it is in the backend image); otherwise SKIPPED. If the column-order assert fails, docling batching/`reading_order` wiring in Task B2 is wrong — debug there, not by weakening the assert.
+
+- [ ] **Step 3: Full backend + frontend green**
+
+Run: `cd backend && uv run python -m pytest -o "addopts=" tests -q`
+Then: `cd frontend && npx vitest run && npm run lint && npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/services/parsing/test_docling_pipeline_integration.py
+git commit -m "test: docling via custom pipeline yields column-aware reading order"
+```
+
+**PR B is complete.** Open the PR; the two-column integration test + unchanged goldens are the acceptance evidence.
+
+---
+
+## Self-Review (completed)
+
+**Spec coverage:** §3 (PR A rename) → A2–A6; the double-duty page-geometry role → A4. §4 (merger reading order) → B1; DoclingTool → B2; threading/semaphore → B2 (`_DOCLING_LOCK`) + B3 (offload); D1 retirement → B4. §5 (config UI) → A6 + B5. §6 (eval follow-throughs) → B5 (DEFAULT_ADAPTER, ParseMethodSelector, ParserComparisonTable label kept). §7 (testing) → A1/A5 goldens, B1 pure-function, B2 tool unit, B6 integration. §8 limitations are accepted (no tasks): composition unwired, STAGING empty, fitz naive, routing out, docling multi-capability deferred.
+
+**Placeholder scan:** no TBDs; every code step carries full code. One deliberately conditional step: B4 Step 2 notes the trimmed test may pass or fail at collection depending on cleanup order — both outcomes are handled.
+
+**Type consistency:** `Capability.LAYOUT_ANALYSIS` used uniformly after A2; `structure_instance`/`structure_result` names consistent across A4/B3; `DoclingConfig`/`DoclingTool` imported from `...tools.docling_tool` in both the registry and the unit test (B2 Step 4 corrects the test import); `_sort_key` returns a 3-tuple used only inside `merge`. `content_projection`/`build_for`/`EQUIV_CONFIGS` names match between A1 (definition) and A5 (use).

--- a/docs/superpowers/specs/2026-07-11-layout-analysis-capability-design.md
+++ b/docs/superpowers/specs/2026-07-11-layout-analysis-capability-design.md
@@ -1,0 +1,258 @@
+# Layout Analysis — the Structure Capability Slot (WS3, slice 1)
+
+**Status:** Design — approved in brainstorming, pending spec review
+**Date:** 2026-07-11
+**Related:** [OCR + capability-slot pipeline](2026-07-10-ocr-capability-pipeline-design.md) ·
+[Custom pipeline overview](2026-06-30-custom-pipeline-design.md) ·
+[Docling parser adapter](2026-06-22-docling-parser-adapter-design.md) ·
+[Backend parse architecture review](../../architecture/2026-07-11-parse-architecture-review-backend.md)
+
+---
+
+## 1. Context & product framing
+
+The custom pipeline is a set of **capability slots**, each filled by at most one named
+tool instance (established in the OCR slice). `layout_analysis` was reserved in the
+`Capability` enum as a *staging* capability with no tools. This slice fills it — and in
+doing so corrects a structural inversion in the model.
+
+**The product.** This is an internal tool for **quick prototyping and evaluation** of
+parsing approaches. Its job is to let a user compose a config and compare it against
+another, to answer a specific question for a specific document population: *"is local,
+fast, cheap layout analysis (fitz/pdfplumber) good enough for these documents, or do we
+need an ML layout model (docling), or a cloud VLM?"* We are **not** chasing the best
+layout analysis, OCR, or table detection. We are making capabilities **independently
+swappable and comparable** so the local→AI ladder can be walked empirically, with
+justification. The config *is* the ladder.
+
+**The inversion this slice fixes.** A mature IDP pipeline is a **DAG with layout at the
+root**: layout analysis finds regions + reading order, and text/OCR/table are recognition
+backends that *fill* those regions. The current pipeline instead models capabilities as
+**peers reconciled by spatial eviction** — `fitz(text)`, `camelot(tables)`,
+`tesseract(ocr)` deduplicated by bbox overlap. That was a reasonable bootstrap, but it is
+upside-down: `fitz.get_text("blocks")` + a `(y0,x0)` sort **is already a crude layout
+analysis** — it was simply never named one. The OCR slice's own limitations L1 (peers, not
+a DAG) and L2 (`(y0,x0)` breaks on multi-column pages) are symptoms of having no layout
+root.
+
+**Consequence — `text_extraction` is not a real capability.** It was presented as mandatory
+and load-bearing, but text extraction is a **non-differentiator** (every tool pulls clean
+text off a digital PDF) and, in industry terms, is *recognition within regions*, subordinate
+to layout. `text_extraction` and `layout_analysis` are therefore **the same capability at
+different tiers**, not two capabilities:
+
+| Tier | Tool | Character |
+|------|------|-----------|
+| 0 | `fitz` (today), `pdfplumber` (later) | geometric, no ML, fast, CPU, text-only |
+| 1 | `docling` (this slice) | ML layout + reading-order + table structure, local, slower |
+| 2 | LlamaParse / vision-LLM (exists as other adapters) | cloud, priciest |
+
+They all fill **one required slot** — "turn a page into ordered, labelled regions with
+text." This slice collapses `text_extraction` into `layout_analysis` and adds docling as
+the first tier-1 tool.
+
+## 2. Decisions (locked in brainstorming)
+
+- **Slice scope = regions + reading order → CDM.** Routing (region-level OCR selection) is
+  **out of scope**.
+- **Model A — the layout tool is authoritative.** When a `layout_analysis` tool is chosen it
+  produces the CDM (regions + reading order + text). It is *not* a pure ordering overlay on
+  separate text/OCR tools (that was "model B", rejected for this slice — its main added value
+  beyond reordering is routing, which is out of scope). `layout_analysis` is reclassified from
+  *staging* to *block-producing*; "staging" was a brainstorming artifact, not a product
+  decision.
+- **Unify now, not later.** Greenfield, undeployed, sole user, no data migration concerns.
+  The only cost of the collapse is engineering effort, and deferring it would mean building
+  the merger + config UI twice. So `text_extraction` is retired *now*, not in a follow-up.
+- **fitz stays a text-producing `layout_analysis` tool** — a deliberately naive tier-0
+  placeholder (text blocks only, order via the merger's `(y0,x0)` sort). Iterating fitz/
+  pdfplumber into a *real* geometric layout analyzer happens after docling shows what's worth
+  reaching for.
+- **Delivery = two PRs**, seam chosen so PR A is a pure refactor (no behaviour change),
+  verified by equivalence, and PR B adds docling on top of the proven contract. Same seam the
+  OCR slice used.
+- **Composition deferred.** docling-alone is the tested path this slice; wiring docling
+  alongside external camelot/tesseract is the composition/routing problem, deferred.
+- **Standalone `ParserKind.DOCLING` is retired (D1).** Docling is reachable only via
+  `custom_pipeline` with `layout_analysis: docling`. The parser-eval engine is
+  adapter-agnostic (forwards the adapter string), so eval *logic* is unaffected; the
+  follow-throughs are UI-level (§6) plus the accepted consequence that stored `docling` eval
+  variants can no longer be *re-run* (their captured results still display).
+
+## 3. PR A — unify the capability model (pure refactor)
+
+**One line:** delete `TEXT_EXTRACTION`; make `LAYOUT_ANALYSIS` the single required,
+block-producing structure slot; fitz becomes its tier-0 tool. No new ML, no behaviour change.
+
+### Backend
+
+- **`capabilities.py`**
+  - Remove `Capability.TEXT_EXTRACTION`.
+  - Move `LAYOUT_ANALYSIS` out of `STAGING` into `BLOCK_PRODUCING`. `STAGING` becomes an empty
+    frozenset (kept, with a comment: routing will refill it — see §8).
+  - `resolve_precedence` uses `LAYOUT_ANALYSIS` everywhere it used `TEXT_EXTRACTION`.
+    Ranks are **identical** (structure at the bottom, below tables; OCR flips above/below it
+    via `cid_corrupt` / `ocr_prefer` exactly as before).
+- **`config.py`**
+  - Required-slot check: `LAYOUT_ANALYSIS` instead of `TEXT_EXTRACTION` (was `config.py:120`).
+  - The guard rejecting a non-block-producing capability (was `config.py:116`) now permits
+    `LAYOUT_ANALYSIS` automatically, since it moved into `BLOCK_PRODUCING`.
+- **`fitz_tool.py`** — `provides = {LAYOUT_ANALYSIS}`. Behaviour untouched; it remains the
+  naive tier-0 analyzer.
+- **`custom_pipeline_runner.py`** — `structure_instance =
+  pipeline.for_capability(LAYOUT_ANALYSIS)`; it still runs first and supplies `page_meta` to
+  every other tool and to the adapter (this is the second, load-bearing role the structure
+  slot inherits: authoritative page geometry).
+- **`base.py`** — `PageMeta` docstring: "sourced from the structure (layout_analysis) tool."
+- **The merger is NOT touched in PR A.** fitz sets no intrinsic `reading_order`, so the
+  existing `(y0,x0)` sort still runs — this is what makes equivalence hold.
+
+### Frontend
+
+- `CustomPipelineConfig.tsx` — the "Text extraction" slot becomes the "Layout analysis" slot.
+  `CAPABILITY_BY_TOOL` maps `fitz`/`pdfplumber` → `layout_analysis`; the required-slot
+  guarantee in `normalizeCustomPipelineConfig` targets `layout_analysis`. fitz stays the only
+  option in PR A (docling arrives in PR B). Help text introduces the tier framing.
+- `CustomPipelineConfig.test.tsx` — slot relabel.
+- **No compat shim / no DB migration** (sole user, prototyping): stale dev runs with
+  `capabilities.text_extraction` are wiped/ignored, not coerced.
+
+### Acceptance property
+
+For every fixture document and every pipeline expressible under the old config, the new
+pipeline produces a **byte-identical `ParsedDocument`** (same block ids, roles,
+`reading_order`, `raw_output`). PR A is proven by equivalence, not just unit tests.
+
+## 4. PR B — docling as the tier-1 authoritative tool
+
+### The one merger change
+
+docling's `iterate_items()` **is** reading order — it crosses columns correctly. If the
+merger re-sorts docling's blocks by `(y0,x0)` it destroys that order and reintroduces L2. So:
+
+> **Within-page ordering honors a block's intrinsic `reading_order` when present, falling
+> back to `(y0,x0)` when absent.**
+
+That is the whole change. It preserves PR A's equivalence *even in PR B*: fitz blocks carry
+no `reading_order`, so they still get `(y0,x0)`; only a tool that supplies its own order
+(docling) opts into being honored. `Block.reading_order` already exists (`models.py:109`) —
+nothing new in the CDM.
+
+### DoclingTool (`tools/docling_tool.py`, implements `PipelineTool`)
+
+- `provides = {LAYOUT_ANALYSIS}` for this slice. docling still emits table content as
+  `BlockRole.TABLE` blocks (they flow through as ordinary blocks); claiming
+  `TABLE_DETECTION`/`TEXT_OCR` for eviction/composition is a later refinement.
+- `run(pdf_path, *, pages, page_meta, emit) -> ToolResult` with
+  `blocks_by_capability={LAYOUT_ANALYSIS: blocks}`, `page_meta` (docling knows page sizes),
+  `raw`, `native_by_block`, `warnings`, `duration_ms`.
+- **Reuses `docling.py`'s adapter logic**: "iterate items → Blocks with roles + normalized
+  bboxes + `reading_order` from `enumerate`" and "page sizes → `page_meta`" move into the
+  tool. **Dropped**: the `ParsedDocument` assembly and final-id minting — the merger mints
+  final ids and `CustomPipelineAdapter` assembles the doc. Blocks come out with provisional
+  ids + intrinsic `reading_order`.
+- **Batching / semaphore / offload** move in from `docling_runner.py`: page-range batching
+  (`page_batch_size`, default 20) with `page_offset`; a module-level `asyncio.Semaphore(1)`
+  (docling is memory-hungry — carried over verbatim, **fixed** for this slice, revisited with
+  the job-queue work); the runner **offloads each `tool.run` via `asyncio.to_thread`** so a
+  parse never runs on the event loop (fixes review §2.1 for docling; incidentally helps
+  tesseract/camelot too — not an expansion of scope).
+- Errors: a per-page docling failure degrades to `warnings` + `failed_pages`; the run
+  completes. A missing/failed docling install is surfaced clearly, not as a mid-parse crash.
+
+### Retire standalone docling (D1)
+
+- Delete `ParserKind.DOCLING`, `_RUNNERS[DOCLING]` (`parsing_service.py:37`),
+  `docling_runner.py`, `DoclingRunError` (`errors.py`). Repurpose `docling.py`'s logic into
+  `DoclingTool`.
+- Tests: delete `test_docling_runner.py`; retarget `test_docling_adapter.py` at the tool.
+
+### Composition stance
+
+docling-alone is the recommended and tested config. The machinery permits adding external
+camelot/tesseract alongside docling, but interleaving external blocks into docling's intrinsic
+sequence is **out of slice-1 scope** and recorded as a limitation (§8).
+
+### Acceptance
+
+- A two-column fixture parses with docling into **correct cross-column reading order** (L2
+  fix, demonstrated).
+- fitz on the same fixture still produces its `(y0,x0)` order unchanged (equivalence holds).
+- A one-page docling failure → `warnings` + `failed_pages`, run completes.
+
+## 5. Config UI (`CustomPipelineConfig.tsx`)
+
+| Slot | Control |
+|------|---------|
+| **Layout analysis** *(required)* | Select: `fitz` (PR A) → `+ docling` (PR B). Help text: *"fitz — fast, local, text-only (no real layout yet). docling — local ML layout + reading order + tables; slower."* |
+| Table detection | Unchanged — `none / fitz_tables / camelot`. |
+| Text OCR | Unchanged — `none / tesseract` + precedence. |
+| Eviction thresholds | Unchanged. |
+
+- `CAPABILITY_BY_TOOL`: `fitz`/`pdfplumber`/`docling` → `layout_analysis`.
+- The current "Text extraction" `Select` is inert (`onValueChange={() => {}}`) because fitz
+  was the only option; PR B makes it a real selector (fitz ↔ docling) via the existing
+  `setSlot` helper (handles slot swap + config defaults). docling arriving is a genuine slot
+  swap, not a redesign.
+- When docling is selected, fitz-specific checkboxes (`include_images`, `span_detail`) hide
+  and a minimal docling panel shows — slice-1 config is just `page_batch_size` (default 20).
+  Add knobs when we learn what matters.
+
+## 6. Parser-eval follow-throughs (D1)
+
+The eval engine is adapter-agnostic (`engine.py:36` forwards `variant["adapter"]` →
+`parsing_service.parse_and_persist(parser=adapter)`), so eval logic is unaffected. UI-level
+changes only:
+
+1. **`NewRunDialog.tsx:16`** — `DEFAULT_ADAPTER = 'docling'` → `custom_pipeline` seeded with a
+   `layout_analysis: docling` config (the real functional break, since a bare `docling`
+   adapter would no longer resolve).
+2. **`ParseMethodSelector.tsx:36`** — remove the top-level `docling` parse method.
+3. **`ParserComparisonTable`** — keep the cosmetic `'Docling'` label so historical eval rows
+   with `adapter: "docling"` still render a friendly name.
+
+**Accepted consequence:** stored `docling` eval variants can no longer be *re-run*
+(re-running would call `ParserKind("docling")` → error); their captured results still display.
+Re-expressing docling as `custom_pipeline` + `layout_analysis: docling` is the intended path.
+
+## 7. Testing
+
+**PR A**
+- **Equivalence harness (load-bearing):** fixture PDFs (clean digital, multi-column, tables,
+  image+OCR) → assert `ParsedDocument` byte-identical to a golden captured on `main`.
+- Unit: `build_pipeline_config` requires `layout_analysis`; rejects a config missing it;
+  `resolve_precedence` truth table unchanged under the renamed capability.
+- Frontend: slot relabel; `normalizeCustomPipelineConfig` guarantees `layout_analysis`.
+
+**PR B**
+- **Pure functions, no docling binary:** blocks *with* intrinsic `reading_order` → merger
+  honors it; *without* → `(y0,x0)` fallback. The merger change is tested without invoking
+  docling.
+- **Tool logic (retargeted `test_docling_adapter.py`):** captured `DoclingDocument` fixture →
+  `DoclingTool.run` yields blocks with roles, normalized bboxes, populated `reading_order`,
+  and `page_meta`.
+- **Integration (`skipif` no docling):** two-column fixture → correct cross-column order (L2);
+  fitz unchanged (equivalence); one-page failure → `warnings` + `failed_pages`, run completes.
+- **Threading:** `tool.run` is offloaded (not on the event loop); the docling `Semaphore(1)`
+  serializes concurrent runs.
+- Frontend: docling appears as a `layout_analysis` option; `NewRunDialog` default variant is
+  `custom_pipeline`+docling and round-trips.
+
+## 8. Known limitations & deferred (accepted deliberately)
+
+| # | Item |
+|---|------|
+| 1 | **Composition unwired.** docling-alone is the tested path; interleaving external camelot/tesseract into docling's intrinsic order is deferred (the composition/routing problem). |
+| 2 | **`STAGING` is now empty.** Pure bbox+label layout detectors (needing a separate recognition pass — e.g. LayoutParser/PubLayNet, a bare Surya detector) are deferred to the **router slice**. The `PipelineTool` contract must **not** assume "layout always carries text," so such a detector can slot in later. |
+| 3 | **fitz stays naive.** tier-0 remains text-only with `(y0,x0)` order; making fitz/pdfplumber a real geometric layout analyzer (column detection / XY-cut) is the post-docling iteration. |
+| 4 | **Routing out of scope.** Region-level OCR selection (mitigating OCR-slice L3) is not addressed here; it is the motivating workload for the router slice and for the parked execution-location axis. |
+| 5 | **docling multi-capability deferred.** docling emits only `layout_analysis` this slice; having it also claim `table_detection`/`text_ocr` (one run, multiple slots via `emit` masking) is a later refinement. |
+
+## 9. Sequencing
+
+1. **PR A** — capability-model unification (equivalence-gated, no ML). Merges first.
+2. **PR B** — docling tool + the merger reading-order change + D1 retirement, on top of the
+   proven contract.
+
+Each PR is a single GitHub issue + PR per the project workflow. Per the pre-implementation
+gate, an issue with acceptance criteria is created and confirmed before implementation begins.

--- a/frontend/src/components/documents/ParseMethodSelector.test.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.test.tsx
@@ -79,7 +79,7 @@ describe('ParseMethodSelector', () => {
         parserType="custom_pipeline"
         config={{
           tools: { fitz: { tool: 'fitz', config: {} } },
-          capabilities: { text_extraction: 'fitz' },
+          capabilities: { layout_analysis: 'fitz' },
           eviction_overlap_threshold: 0.5,
         }}
       />

--- a/frontend/src/components/documents/ParseMethodSelector.tsx
+++ b/frontend/src/components/documents/ParseMethodSelector.tsx
@@ -48,7 +48,7 @@ export const PARSER_REGISTRY: Record<string, ParserMeta> = {
           config: { min_chars_threshold: 10, include_images: true, span_detail: false },
         },
       },
-      capabilities: { text_extraction: 'fitz' },
+      capabilities: { layout_analysis: 'fitz' },
       eviction_overlap_threshold: 0.5,
     },
   },

--- a/frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx
+++ b/frontend/src/components/documents/parser-configs/CustomPipelineConfig.test.tsx
@@ -10,7 +10,7 @@ const fitzOnly = {
       config: { include_images: true, span_detail: false, min_chars_threshold: 10 },
     },
   },
-  capabilities: { text_extraction: 'fitz' },
+  capabilities: { layout_analysis: 'fitz' },
   eviction_overlap_threshold: 0.5,
 }
 
@@ -23,7 +23,7 @@ const withFitzTables = {
       config: { vertical_strategy: 'lines_strict', horizontal_strategy: 'lines_strict' },
     },
   },
-  capabilities: { text_extraction: 'fitz', table_detection: 'fitz_tables' },
+  capabilities: { layout_analysis: 'fitz', table_detection: 'fitz_tables' },
 }
 
 const withCamelot = {
@@ -32,13 +32,13 @@ const withCamelot = {
     ...fitzOnly.tools,
     camelot: { tool: 'camelot', config: { flavor: 'lattice', edge_tol: 50, row_tol: 2 } },
   },
-  capabilities: { text_extraction: 'fitz', table_detection: 'camelot' },
+  capabilities: { layout_analysis: 'fitz', table_detection: 'camelot' },
 }
 
 describe('CustomPipelineConfig', () => {
-  it('renders text extraction as a slot, not an always-on label', () => {
+  it('renders layout analysis as a slot, not an always-on label', () => {
     render(<CustomPipelineConfig config={fitzOnly} onChange={vi.fn()} />)
-    expect(screen.getByRole('combobox', { name: /text extraction/i })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: /layout analysis/i })).toBeInTheDocument()
     expect(screen.getByRole('combobox', { name: /table extraction/i })).toBeInTheDocument()
     expect(screen.queryByText(/always on/i)).not.toBeInTheDocument()
   })
@@ -49,7 +49,7 @@ describe('CustomPipelineConfig', () => {
     await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
     await userEvent.click(screen.getByText(/fitz_tables/i))
     const next = onChange.mock.calls[0][0]
-    expect(next.capabilities.text_extraction).toBe('fitz')
+    expect(next.capabilities.layout_analysis).toBe('fitz')
     expect(next.capabilities.table_detection).toBe('fitz_tables')
     expect(next.tools.fitz_tables.tool).toBe('fitz_tables')
     expect(next.tools.camelot).toBeUndefined()
@@ -112,7 +112,7 @@ describe('CustomPipelineConfig', () => {
         ...fitzOnly.tools,
         camelot: { tool: 'camelot', config: { flavor: 'stream', edge_tol: 50, row_tol: 2 } },
       },
-      capabilities: { text_extraction: 'fitz', table_detection: 'camelot' },
+      capabilities: { layout_analysis: 'fitz', table_detection: 'camelot' },
     }
     render(<CustomPipelineConfig config={withStream} onChange={vi.fn()} />)
     expect(screen.getByText('edge_tol')).toBeInTheDocument()
@@ -135,7 +135,7 @@ describe('normalizeCustomPipelineConfig', () => {
     expect(n.tools['0']).toBeUndefined()          // no array-index key
     expect(n.tools.fitz.tool).toBe('fitz')
     expect(n.tools.fitz.config.include_images).toBe(true)
-    expect(n.capabilities.text_extraction).toBe('fitz')
+    expect(n.capabilities.layout_analysis).toBe('fitz')
   })
 
   it('infers table_detection from an old array with a table tool', () => {
@@ -145,17 +145,17 @@ describe('normalizeCustomPipelineConfig', () => {
         { tool_id: 'camelot', config: { flavor: 'stream' } },
       ],
     })
-    expect(n.capabilities.text_extraction).toBe('fitz')
+    expect(n.capabilities.layout_analysis).toBe('fitz')
     expect(n.capabilities.table_detection).toBe('camelot')
     expect(n.tools.camelot.config.flavor).toBe('stream')
   })
 
-  it('guarantees a text_extraction slot even if the input lacks one', () => {
+  it('guarantees a layout_analysis slot even if the input lacks one', () => {
     const n = normalizeCustomPipelineConfig({
       tools: { fitz_tables: { tool: 'fitz_tables', config: {} } },
       capabilities: { table_detection: 'fitz_tables' },
     })
-    expect(n.capabilities.text_extraction).toBe('fitz')
+    expect(n.capabilities.layout_analysis).toBe('fitz')
     expect(n.tools.fitz.tool).toBe('fitz')
   })
 
@@ -177,19 +177,19 @@ describe('CustomPipelineConfig with a legacy config', () => {
     render(<CustomPipelineConfig config={OLD_ARRAY} onChange={onChange} />)
     expect(onChange).toHaveBeenCalled()
     const next = onChange.mock.calls[0][0]
-    expect(next.capabilities.text_extraction).toBe('fitz')
+    expect(next.capabilities.layout_analysis).toBe('fitz')
     expect(next.tools['0']).toBeUndefined()
     expect(Array.isArray(next.tools)).toBe(false)
   })
 
-  it('never produces a config missing text_extraction after editing the table slot', async () => {
+  it('never produces a config missing layout_analysis after editing the table slot', async () => {
     const onChange = vi.fn()
     render(<CustomPipelineConfig config={OLD_ARRAY} onChange={onChange} />)
     await userEvent.click(screen.getByRole('combobox', { name: /table extraction/i }))
     await userEvent.click(screen.getByText(/fitz_tables/i))
     const calls = onChange.mock.calls
     const next = calls[calls.length - 1][0]
-    expect(next.capabilities.text_extraction).toBe('fitz')
+    expect(next.capabilities.layout_analysis).toBe('fitz')
     expect(next.capabilities.table_detection).toBe('fitz_tables')
     expect(next.tools['0']).toBeUndefined()
   })
@@ -200,7 +200,7 @@ const TESSERACT_DEFAULTS_KEYS = ['pages', 'lang', 'psm', 'dpi', 'min_confidence'
 describe('OCR slot', () => {
   const base = {
     tools: { fitz: { tool: 'fitz', config: {} } },
-    capabilities: { text_extraction: 'fitz' },
+    capabilities: { layout_analysis: 'fitz' },
   }
 
   it('selecting tesseract adds a text_ocr slot with defaults', async () => {
@@ -221,7 +221,7 @@ describe('OCR slot', () => {
     const withOcr = {
       tools: { fitz: { tool: 'fitz', config: {} },
                tesseract: { tool: 'tesseract', config: { pages: 'auto' } } },
-      capabilities: { text_extraction: 'fitz', text_ocr: 'tesseract' },
+      capabilities: { layout_analysis: 'fitz', text_ocr: 'tesseract' },
     }
     const { rerender } = render(<CustomPipelineConfig config={base} onChange={vi.fn()} />)
     expect(screen.queryByText(/native text wins/i)).not.toBeInTheDocument()

--- a/frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx
+++ b/frontend/src/components/documents/parser-configs/CustomPipelineConfig.tsx
@@ -361,18 +361,18 @@ function FitzTablesConfigPanel({
 }
 
 const CAPABILITY_BY_TOOL: Record<string, string> = {
-  fitz: 'text_extraction',
-  pdfplumber: 'text_extraction',
+  fitz: 'layout_analysis',
+  pdfplumber: 'layout_analysis',
   fitz_tables: 'table_detection',
   camelot: 'table_detection',
 }
 
 /** Coerce any accepted config shape into the capability-slot shape, and
- * guarantee the required `text_extraction` slot.
+ * guarantee the required `layout_analysis` slot.
  *
  * Handles the pre-refactor array shape (`tools: [{tool_id, config}]`, no
  * `capabilities`) so re-parsing an old run — or any stale seed — cannot emit a
- * config the backend will reject with "text_extraction is required".
+ * config the backend will reject with "layout_analysis is required".
  * Idempotent: normalizing an already-normal config returns an equal object.
  */
 export function normalizeCustomPipelineConfig(raw: unknown): PipelineConfig {
@@ -400,10 +400,10 @@ export function normalizeCustomPipelineConfig(raw: unknown): PipelineConfig {
     }
   }
 
-  // Guarantee the required text_extraction slot.
-  if (!capabilities.text_extraction) {
+  // Guarantee the required layout_analysis slot.
+  if (!capabilities.layout_analysis) {
     if (!tools.fitz) tools.fitz = { tool: 'fitz', config: {} }
-    capabilities.text_extraction = 'fitz'
+    capabilities.layout_analysis = 'fitz'
   }
 
   const out: PipelineConfig = { tools, capabilities }
@@ -480,7 +480,7 @@ export function CustomPipelineConfig({
   const capabilities = cfg.capabilities
   const threshold = cfg.eviction_overlap_threshold ?? 0.5
 
-  const textKey = capabilities.text_extraction ?? 'fitz'
+  const textKey = capabilities.layout_analysis ?? 'fitz'
   const fitz = tools[textKey]
 
   const tableKey = capabilities.table_detection
@@ -522,15 +522,16 @@ export function CustomPipelineConfig({
 
   return (
     <div className="space-y-4">
-      {/* Text extraction — a capability slot (required) */}
+      {/* Layout analysis — the required structure slot */}
       <div className="space-y-2 rounded-md border p-3">
         <div className="space-y-1">
-          <Label htmlFor="text-tool-select">Text extraction</Label>
+          <Label htmlFor="layout-tool-select">Layout analysis</Label>
           <p className="text-xs text-muted-foreground">
-            The base text extractor. Required — every pipeline fills this slot.
+            Turns each page into ordered, labelled regions. Required — every pipeline fills this
+            slot. fitz is fast, local, and text-only (no real layout yet).
           </p>
           <Select value={textKey} onValueChange={() => {}} disabled={disabled}>
-            <SelectTrigger id="text-tool-select" aria-label="Text extraction">
+            <SelectTrigger id="layout-tool-select" aria-label="Layout analysis">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
Closes #165. First of two PRs implementing layout analysis as the custom pipeline's structure slot. **PR A is a pure, behaviour-preserving refactor** — no new ML, no behaviour change. PR B (docling) follows on top of this.

## What
Retires the `text_extraction` capability and makes `layout_analysis` the single **required, block-producing** structure slot. fitz becomes its tier-0 tool. This corrects the model's inversion (peer capabilities → layout-rooted) and encodes the local→AI ladder as "which tool fills the structure slot."

See [spec](docs/superpowers/specs/2026-07-11-layout-analysis-capability-design.md) · [plan](docs/superpowers/plans/2026-07-11-layout-analysis-capability.md).

## Changes
- **`capabilities.py`** — remove `TEXT_EXTRACTION`; `LAYOUT_ANALYSIS` moves into `BLOCK_PRODUCING`; `STAGING` now empty (reserved for the router slice); `resolve_precedence` ranks layout where text sat.
- **`config.py`** — required slot is now `layout_analysis`.
- **`fitz_tool.py`** — `provides = {LAYOUT_ANALYSIS}` (behaviour untouched).
- **`custom_pipeline_runner.py`** — resolves the structure instance via `LAYOUT_ANALYSIS`; still runs it first and supplies authoritative `page_meta`.
- **Frontend** — slot relabeled "Layout analysis"; config emits `capabilities.layout_analysis`.

## Verification
- **Equivalence gate:** goldens captured from the pre-refactor pipeline; a snapshot test asserts **content-identical** `ParsedDocument`s after the rename.
- `tests/cdm` + `tests/services/parsing` green (282); frontend vitest (368) + lint + build green.
- Note: `test_project_repository.py::test_list_all_sorted_by_created_at` fails on `main` too (pre-existing timestamp-tie flake, unrelated); tracked separately.

## Out of scope (PR B)
Docling tool, the merger intrinsic-reading-order change, event-loop offload, retiring standalone `ParserKind.DOCLING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)