### PR TITLE
Put rag-admin behind the shared edge Caddy reverse proxy

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,115 +1,67 @@
-# Replace 'yourdomain.com' with your actual domain
-ragadmin.adilitech.com {
-    # Enable automatic HTTPS with Let's Encrypt
-    # Caddy will automatically obtain and renew SSL certificates
-
-    # Security headers
-    header {
-        # Enable HSTS
-        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-
-        # Prevent MIME type sniffing
-        X-Content-Type-Options "nosniff"
-
-        # Prevent clickjacking
-        X-Frame-Options "SAMEORIGIN"
-
-        # Enable XSS protection
-        X-XSS-Protection "1; mode=block"
-
-        # Referrer policy
-        Referrer-Policy "strict-origin-when-cross-origin"
-
-        # Permissions policy
-        Permissions-Policy "geolocation=(), microphone=(), camera=()"
-
-        # Remove server header
-        -Server
-    }
-
-    # Enable compression
-    encode gzip zstd
-
-    # API routes - proxy to backend
-    handle /api/* {
-        reverse_proxy backend:8000 {
-            # Health check
-            health_uri /health
-            health_interval 30s
-            health_timeout 5s
-
-            # Connection settings
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto {scheme}
-
-            # ─────────────────────────────────────────────────────────────
-            # Trace Context Propagation (W3C standard)
-            # ─────────────────────────────────────────────────────────────
-            # These headers enable distributed tracing across services.
-            # When present in the incoming request, they're forwarded to
-            # the backend so all services share the same trace context.
-            #
-            # traceparent: Contains trace_id + span_id + flags
-            #   Format: 00-{trace_id}-{span_id}-{flags}
-            #   Example: 00-abc123...-def456...-01
-            #
-            # tracestate: Vendor-specific trace data (optional)
-            #   Format: vendor1=value1,vendor2=value2
-            #
-            # This enables end-to-end tracing: Browser → Caddy → Backend
-            # All spans will share the same trace_id in SigNoz.
-            # ─────────────────────────────────────────────────────────────
-            header_up traceparent {header.traceparent}
-            header_up tracestate {header.tracestate}
-        }
-    }
-
-    # Frontend - serve React SPA static files
-    handle /* {
-        root * /srv
-
-        # Try to serve the requested file, fallback to index.html for SPA routing
-        try_files {path} /index.html
-
-        # Serve files
-        file_server
-
-        # Cache static assets (js, css, images, fonts)
-        @static {
-            path *.js *.css *.png *.jpg *.jpeg *.gif *.ico *.svg *.woff *.woff2 *.ttf *.eot
-        }
-        header @static Cache-Control "public, max-age=31536000, immutable"
-
-        # Don't cache index.html
-        @html {
-            path *.html
-        }
-        header @html Cache-Control "no-cache, no-store, must-revalidate"
-    }
-
-    # Access logs
-    log {
-        output file /var/log/caddy/access.log {
-            roll_size 100mb
-            roll_keep 5
-            roll_keep_for 720h
-        }
-        format json
-    }
-
-    # Error logs
-    log {
-        level ERROR
-        output file /var/log/caddy/error.log {
-            roll_size 10mb
-            roll_keep 3
-        }
-    }
+# RAG Admin — INTERNAL web server.
+#
+# This Caddy no longer faces the internet or handles TLS. The standalone "edge"
+# Caddy (see /opt/edge) terminates TLS for ragadmin.adilitech.com and forwards
+# the request here over the shared `edge` Docker network. This instance's only
+# jobs are: serve the React SPA and proxy /api/* to the backend.
+{
+	# Trust X-Forwarded-* headers from the edge proxy. Docker networks use
+	# private IP ranges, so this lets the real client scheme/IP (set by the
+	# edge) flow through to the backend instead of being overwritten with the
+	# edge's own address.
+	servers {
+		trusted_proxies static private_ranges
+	}
+	# No public HTTPS here, and don't try to fetch certs.
+	auto_https off
 }
 
-# Redirect www to non-www (optional - uncomment if needed)
-# www.yourdomain.com {
-#     redir https://yourdomain.com{uri} permanent
-# }
+:80 {
+	encode gzip zstd
+
+	# API routes — proxy to backend
+	handle /api/* {
+		reverse_proxy backend:8000 {
+			health_uri /health
+			health_interval 30s
+			health_timeout 5s
+
+			# Preserve original Host and propagate W3C trace context so the
+			# whole chain (Browser → edge → here → backend) shares one trace.
+			header_up Host {host}
+			header_up traceparent {header.traceparent}
+			header_up tracestate {header.tracestate}
+		}
+	}
+
+	# Frontend — serve React SPA static files
+	handle /* {
+		root * /srv
+
+		# Serve the requested file, fall back to index.html for SPA routing
+		try_files {path} /index.html
+		file_server
+
+		# Cache fingerprinted static assets aggressively
+		@static {
+			path *.js *.css *.png *.jpg *.jpeg *.gif *.ico *.svg *.woff *.woff2 *.ttf *.eot
+		}
+		header @static Cache-Control "public, max-age=31536000, immutable"
+
+		# Never cache index.html
+		@html {
+			path *.html
+		}
+		header @html Cache-Control "no-cache, no-store, must-revalidate"
+	}
+
+	# Access logs
+	log {
+		output file /var/log/caddy/access.log {
+			roll_size 100mb
+			roll_keep 5
+			roll_keep_for 720h
+		}
+		format json
+	}
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,27 +50,23 @@ services:
       retries: 3
       start_period: 15s
 
-  # Caddy Reverse Proxy (automatic HTTPS) + Static File Server
-  caddy:
+  # Internal web server: serves the React SPA and proxies /api to the backend.
+  # TLS and public ports are owned by the standalone edge Caddy (see /opt/edge);
+  # this container is reached only over the shared `edge` network by container name.
+  web:
     image: caddy:2-alpine
-    container_name: rag-admin-caddy
+    container_name: rag-admin-web
     restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"  # HTTP/3
     volumes:
-      # Caddy configuration
+      # Caddy configuration (HTTP-only :80, no TLS)
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       # Frontend static files (built locally, copied to VPS)
       - ./frontend/dist:/srv:ro
-      # Persistent storage for certificates
-      - caddy_data:/data
-      - caddy_config:/config
       # Logs
       - caddy_logs:/var/log/caddy
     networks:
-      - app-network
+      - app-network   # reach the backend
+      - edge          # receive traffic from the edge Caddy
     depends_on:
       - backend
 
@@ -83,6 +79,12 @@ networks:
     external: true
     name: signoz-net
 
+  # Shared reverse-proxy network created by the standalone edge stack (/opt/edge).
+  # Bring the edge stack up first so this network exists.
+  edge:
+    external: true
+    name: edge
+
 volumes:
   # PostgreSQL data persistence
   postgres_data:
@@ -92,14 +94,6 @@ volumes:
   document_storage:
     driver: local
 
-  # Caddy data (SSL certificates, etc.)
-  caddy_data:
-    driver: local
-
-  # Caddy configuration
-  caddy_config:
-    driver: local
-
-  # Caddy logs
+  # Web server logs (cert/config volumes moved to the edge stack)
   caddy_logs:
     driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,7 +42,6 @@ services:
         condition: service_healthy
     networks:
       - app-network
-      - signoz-net  # Connect to SigNoz network for observability
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 10s
@@ -73,11 +72,6 @@ services:
 networks:
   app-network:
     driver: bridge
-
-  # External network managed by official SigNoz deployment
-  signoz-net:
-    external: true
-    name: signoz-net
 
   # Shared reverse-proxy network created by the standalone edge stack (/opt/edge).
   # Bring the edge stack up first so this network exists.


### PR DESCRIPTION
## Summary
Restructures the prod stack to sit behind the standalone **edge** reverse proxy (repo `asanyaga/edge`, already deployed and serving `adilitech.com`) instead of owning ports 80/443 and TLS itself.

## Changes
- **`docker-compose.prod.yml`** — the Caddy service becomes an internal web server (`rag-admin-web`): no published ports, no cert volumes; joins the external `edge` network so the edge proxies to it by container name.
- **`caddy/Caddyfile`** — demoted to HTTP-only `:80` (`auto_https off`, `trusted_proxies`); TLS + security headers now owned by the edge. Keeps SPA serving, `/api` proxy, and W3C trace propagation.
- Local dev stack (`docker-compose.local.yml` / `Caddyfile.local`) untouched.

## Deploy note
Requires the edge stack running (it is) and its `conf.d/rag-admin.caddy` re-enabled. Fresh deploy — no existing prod data to preserve.

## Prerequisite flagged
The prod compose still declares `signoz-net` as an external network, so SigNoz must be running on the VPS **or** that dependency dropped before `docker compose up`.

Closes #178