### PR TITLE
Fix POSTGRES_PASSWORD interpolation in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,9 @@ services:
       - .env.prod
     environment:
       POSTGRES_USER: ragadmin
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      # POSTGRES_PASSWORD is injected from .env.prod via env_file above.
+      # (Do NOT set it here via ${POSTGRES_PASSWORD} — that interpolation reads
+      # the shell env / a literal .env file, not env_file, and would blank it.)
       POSTGRES_DB: ragadmin
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:


### PR DESCRIPTION
## Summary
Drops the `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}` interpolation in `docker-compose.prod.yml` and relies on the existing `env_file: .env.prod` to inject the password into the postgres container.

## Why
Compose resolves `${...}` from the shell env or a literal `.env` file — **not** from `env_file`. A fresh deploy with the password only in `.env.prod` therefore initialized postgres with a blank password unless the operator remembered `--env-file .env.prod` (which bit us during the edge cutover). This removes the footgun.

## Verification
`docker compose -f docker-compose.prod.yml config` (no `--env-file`, no shell var) now renders `POSTGRES_PASSWORD` from `env_file` with **no interpolation warnings**. Plain `docker compose -f docker-compose.prod.yml up -d` works with no flag.

Closes #180